### PR TITLE
Fixed workspace variable resolver. Can start debug session multiple times from the toolbar.

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -143,6 +143,8 @@ import { ArchiveSketch } from './contributions/archive-sketch';
 import { OutputToolbarContribution as TheiaOutputToolbarContribution } from '@theia/output/lib/browser/output-toolbar-contribution';
 import { OutputToolbarContribution } from './theia/output/output-toolbar-contribution';
 import { AddZipLibrary } from './contributions/add-zip-library';
+import { WorkspaceVariableContribution as TheiaWorkspaceVariableContribution } from '@theia/workspace/lib/browser/workspace-variable-contribution';
+import { WorkspaceVariableContribution } from './theia/workspace/workspace-variable-contribution';
 
 const ElementQueries = require('css-element-queries/src/ElementQueries');
 
@@ -257,6 +259,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
     bind(WorkspaceService).toSelf().inSingletonScope();
     rebind(TheiaWorkspaceService).toService(WorkspaceService);
+    bind(WorkspaceVariableContribution).toSelf().inSingletonScope();
+    rebind(TheiaWorkspaceVariableContribution).toService(WorkspaceVariableContribution);
 
     // Customizing default Theia layout based on the editor mode: `pro-mode` or `classic`.
     bind(EditorMode).toSelf().inSingletonScope();

--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-variable-contribution.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-variable-contribution.ts
@@ -1,0 +1,29 @@
+import { inject, injectable, postConstruct } from 'inversify';
+import URI from '@theia/core/lib/common/uri';
+import { WorkspaceVariableContribution as TheiaWorkspaceVariableContribution } from '@theia/workspace/lib/browser/workspace-variable-contribution';
+import { Sketch } from '../../../common/protocol';
+import { SketchesServiceClientImpl } from '../../../common/protocol/sketches-service-client-impl';
+
+@injectable()
+export class WorkspaceVariableContribution extends TheiaWorkspaceVariableContribution {
+
+    @inject(SketchesServiceClientImpl)
+    protected readonly sketchesServiceClient: SketchesServiceClientImpl;
+
+    protected currentSketch?: Sketch;
+
+    @postConstruct()
+    protected init(): void {
+        this.sketchesServiceClient.currentSketch().then().then(sketch => this.currentSketch = sketch);
+    }
+
+    getResourceUri(): URI | undefined {
+        const resourceUri = super.getResourceUri();
+        // https://github.com/arduino/arduino-ide/issues/46
+        // `currentWidget` can be an editor representing a file outside of the workspace. The current sketch should be a fallback.
+        if (!resourceUri && this.currentSketch?.uri) {
+            return new URI(this.currentSketch.uri);
+        }
+        return resourceUri;
+    }
+}


### PR DESCRIPTION
Fall back to the current sketch, if `currentWidget` points to a file
outside of the workspace.

Closes: arduino/arduino-ide#46
Signed-off-by: Akos Kitta <kittaakos@typefox.io>

How to test:
 - You should be able to start/stop as many consecutive debug sessions from the toolbar as you pleased.