### PR TITLE
Update ARM Linux link in download table

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Linux ARM | [🚧 Work in progress...] | [🚧 Work in progress...]             
 Windows   |                          | [Nightly Windows 64 bit installer]<br />[Nightly Windows 64 bit MSI]<br />[Nightly Windows 64 bit ZIP] |
 macOS     |                          | [Nightly macOS 64 bit]                                                                                 |
 
-[🚧 Work in progress...]: https://github.com/arduino/arduino-ide/issues/287
+[🚧 Work in progress...]: https://github.com/arduino/arduino-ide/issues/107
 [Nightly Linux 64 bit]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Linux_64bit.zip
 [Nightly Windows 64 bit installer]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Windows_64bit.exe
 [Nightly Windows 64 bit MSI]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Windows_64bit.msi


### PR DESCRIPTION
The issue numbers changed when they were transferred from the `arduino/arduino-pro-ide` to `arduino/arduino-ide` repositories.

Previous issue:
https://github.com/arduino/arduino-pro-ide/issues/287
Now redirects to:
https://github.com/arduino/arduino-ide/issues/107

---
Supercedes https://github.com/arduino/arduino-ide/pull/146