### PR TITLE
Correct typo in gRPC client creation error message

### DIFF
--- a/arduino-ide-extension/src/node/grpc-client-provider.ts
+++ b/arduino-ide-extension/src/node/grpc-client-provider.ts
@@ -59,7 +59,7 @@ export abstract class GrpcClientProvider<C> {
                 const client = await this.createClient(this._port);
                 this._client = client;
             } catch (error) {
-                this.logger.error('Could create client for gRPC.', error)
+                this.logger.error('Could not create client for gRPC.', error)
             }
         }
     }


### PR DESCRIPTION
Previously, when gRPC client creation failed, the incorrect error message was shown:
```
root ERROR Could create client for gRPC.
```
When the message is intended to have the opposite meaning.

---
Reference: https://forum.arduino.cc/index.php?topic=730720.msg4917491#msg4917491