### PR TITLE
[Toolbar] Hover style and Toggle State [ATL-1107][ATL-1045]

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -76,6 +76,11 @@ export class UploadSketch extends SketchContribution {
 
     async uploadSketch(usingProgrammer: boolean = false): Promise<void> {
         
+        // even with buttons disabled, better to double check if an upload is already in progress
+        if (this.uploadInProgress) {
+            return;
+        }
+
         // toggle the toolbar button and menu item state.
         // uploadInProgress will be set to false whether the upload fails or not
         this.uploadInProgress = true;

--- a/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
@@ -18,6 +18,8 @@ export class VerifySketch extends SketchContribution {
     @inject(BoardsServiceProvider)
     protected readonly boardsServiceClientImpl: BoardsServiceProvider;
 
+    verifyInProgress = false;
+
     registerCommands(registry: CommandRegistry): void {
         registry.registerCommand(VerifySketch.Commands.VERIFY_SKETCH, {
             execute: () => this.verifySketch()
@@ -27,6 +29,7 @@ export class VerifySketch extends SketchContribution {
         });
         registry.registerCommand(VerifySketch.Commands.VERIFY_SKETCH_TOOLBAR, {
             isVisible: widget => ArduinoToolbar.is(widget) && widget.side === 'left',
+            isToggled: () => this.verifyInProgress,
             execute: () => registry.executeCommand(VerifySketch.Commands.VERIFY_SKETCH.id)
         });
     }
@@ -65,7 +68,11 @@ export class VerifySketch extends SketchContribution {
     }
 
     async verifySketch(exportBinaries?: boolean): Promise<void> {
+
+        this.verifyInProgress = true;
         const sketch = await this.sketchServiceClient.currentSketch();
+        this.verifyInProgress = false;
+
         if (!sketch) {
             return;
         }

--- a/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
@@ -22,13 +22,16 @@ export class VerifySketch extends SketchContribution {
 
     registerCommands(registry: CommandRegistry): void {
         registry.registerCommand(VerifySketch.Commands.VERIFY_SKETCH, {
-            execute: () => this.verifySketch()
+            execute: () => this.verifySketch(),
+            isEnabled: () => !this.verifyInProgress,
         });
         registry.registerCommand(VerifySketch.Commands.EXPORT_BINARIES, {
-            execute: () => this.verifySketch(true)
+            execute: () => this.verifySketch(true),
+            isEnabled: () => !this.verifyInProgress,
         });
         registry.registerCommand(VerifySketch.Commands.VERIFY_SKETCH_TOOLBAR, {
             isVisible: widget => ArduinoToolbar.is(widget) && widget.side === 'left',
+            isEnabled: () => !this.verifyInProgress,
             isToggled: () => this.verifyInProgress,
             execute: () => registry.executeCommand(VerifySketch.Commands.VERIFY_SKETCH.id)
         });
@@ -69,10 +72,11 @@ export class VerifySketch extends SketchContribution {
 
     async verifySketch(exportBinaries?: boolean): Promise<void> {
 
+        // toggle the toolbar button and menu item state.
+        // verifyInProgress will be set to false whether the compilation fails or not
         this.verifyInProgress = true;
         const sketch = await this.sketchServiceClient.currentSketch();
-        this.verifyInProgress = false;
-
+        
         if (!sketch) {
             return;
         }
@@ -97,6 +101,8 @@ export class VerifySketch extends SketchContribution {
             this.messageService.info('Done compiling.', { timeout: 1000 });
         } catch (e) {
             this.messageService.error(e.toString());
+        } finally {
+            this.verifyInProgress = false;
         }
     }
 

--- a/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
@@ -72,6 +72,11 @@ export class VerifySketch extends SketchContribution {
 
     async verifySketch(exportBinaries?: boolean): Promise<void> {
 
+        // even with buttons disabled, better to double check if a verify is already in progress
+        if (this.verifyInProgress) {
+            return;
+        }
+
         // toggle the toolbar button and menu item state.
         // verifyInProgress will be set to false whether the compilation fails or not
         this.verifyInProgress = true;

--- a/arduino-ide-extension/src/browser/style/main.css
+++ b/arduino-ide-extension/src/browser/style/main.css
@@ -26,6 +26,7 @@
 
 .item.arduino-tool-item.toggled {
   background-color: unset;
+  opacity: 1;
 }
 
 .item.arduino-tool-item.toggled .arduino-verify-sketch--toolbar {

--- a/arduino-ide-extension/src/browser/style/main.css
+++ b/arduino-ide-extension/src/browser/style/main.css
@@ -24,6 +24,14 @@
     border-radius: 12px;
 }
 
+.item.arduino-tool-item.toggled {
+  background-color: unset;
+}
+
+.item.arduino-tool-item.toggled .arduino-verify-sketch--toolbar {
+  background-color: rgb(255,204,0) !important;
+}
+
 .arduino-tool-icon {
     height: 24px;
     width: 24px;

--- a/arduino-ide-extension/src/browser/style/main.css
+++ b/arduino-ide-extension/src/browser/style/main.css
@@ -15,8 +15,8 @@
     background: var(--theia-arduino-toolbar-background);
 }
 
-.p-TabBar-toolbar .item.arduino-tool-item > div:hover {
-    background: (--theia-arduino-toolbar-hoverBackground);
+.p-TabBar-toolbar .item.arduino-tool-item:hover > div {
+    background: white;
 }
 
 .arduino-verify-sketch--toolbar,

--- a/arduino-ide-extension/src/browser/toolbar/arduino-toolbar.tsx
+++ b/arduino-ide-extension/src/browser/toolbar/arduino-toolbar.tsx
@@ -13,6 +13,7 @@ export namespace ArduinoToolbarComponent {
         commands: CommandRegistry,
         labelParser: LabelParser,
         commandIsEnabled: (id: string) => boolean,
+        commandIsToggled: (id: string) => boolean,
         executeCommand: (e: React.MouseEvent<HTMLElement>) => void
     }
     export interface State {
@@ -39,7 +40,7 @@ export class ArduinoToolbarComponent extends React.Component<ArduinoToolbarCompo
             }
         }
         const command = this.props.commands.getCommand(item.command);
-        const cls = `${ARDUINO_TOOLBAR_ITEM_CLASS} ${TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM} ${command && this.props.commandIsEnabled(command.id) ? 'enabled' : ''}`
+        const cls = `${ARDUINO_TOOLBAR_ITEM_CLASS} ${TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM} ${command && this.props.commandIsEnabled(command.id) ? 'enabled' : ''} ${command && this.props.commandIsToggled(command.id) ? 'toggled' : ''}`
         return <div key={item.id} className={cls} >
             <div className={item.id}>
                 <div
@@ -112,6 +113,10 @@ export class ArduinoToolbar extends ReactWidget {
     protected commandIsEnabled(command: string): boolean {
         return this.commands.isEnabled(command, this);
     }
+    protected readonly doCommandIsToggled = (id: string) => this.commandIsToggled(id);
+    protected commandIsToggled(command: string): boolean {
+      return this.commands.isToggled(command, this);
+  }
 
     protected render(): React.ReactNode {
         return <ArduinoToolbarComponent
@@ -121,6 +126,7 @@ export class ArduinoToolbar extends ReactWidget {
             items={[...this.items.values()]}
             commands={this.commands}
             commandIsEnabled={this.doCommandIsEnabled}
+            commandIsToggled={this.doCommandIsToggled}
             executeCommand={this.executeCommand}
         />
     }


### PR DESCRIPTION
## Why
- We are missing hover and pressed state on the buttons, which can be confusing to users switching from Java IDE.
- The Java IDE has the buttons remain “activated” until an operation is carried out.
- We want the "Verify" and "Upload" buttons (and menu items) to be disabled while the corresponding operation is in progress.

## How
- added "hover" behavior to all toolbar items, via CSS rule
- added "toggle" state to arduino toolbar buttons, by adding a prop, binded to the relative registry command. The `isToggled` function of the registry command was previously not called by Toolbar Items. I adopted the same mechanism used for `isEnabled`.
- set isToggled/isEnabled using an internal state updated by the verify and upload functions

## Other
[Jira Task (cosmetics)](https://arduino.atlassian.net/browse/ATL-1107)
[Jira Task (disable while in progress)](https://arduino.atlassian.net/browse/ATL-1045)
Fixes #173 