### PR TITLE
ATL-653: Added error handling for core/lib install

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/component-list/list-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/list-widget.tsx
@@ -5,6 +5,8 @@ import { Deferred } from '@theia/core/lib/common/promise-util';
 import { Emitter } from '@theia/core/lib/common/event';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { CommandService } from '@theia/core/lib/common/command';
+import { MessageService } from '@theia/core/lib/common/message-service';
 import { Installable } from '../../../common/protocol/installable';
 import { Searchable } from '../../../common/protocol/searchable';
 import { ArduinoComponent } from '../../../common/protocol/arduino-component';
@@ -14,6 +16,12 @@ import { NotificationCenter } from '../../notification-center';
 
 @injectable()
 export abstract class ListWidget<T extends ArduinoComponent> extends ReactWidget {
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
 
     @inject(NotificationCenter)
     protected readonly notificationCenter: NotificationCenter;
@@ -87,7 +95,9 @@ export abstract class ListWidget<T extends ArduinoComponent> extends ReactWidget
             uninstall={this.uninstall.bind(this)}
             itemLabel={this.options.itemLabel}
             itemRenderer={this.options.itemRenderer}
-            filterTextChangeEvent={this.filterTextChangeEmitter.event} />;
+            filterTextChangeEvent={this.filterTextChangeEmitter.event}
+            messageService={this.messageService}
+            commandService={this.commandService} />;
     }
 
     /**

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -254,7 +254,11 @@ export class BoardsServiceImpl extends CoreClientAware implements BoardsService 
         });
         await new Promise<void>((resolve, reject) => {
             resp.on('end', resolve);
-            resp.on('error', reject);
+            resp.on('error', error => {
+                this.outputService.append({ chunk: `Failed to install platform: ${item.id}.\n` });
+                this.outputService.append({ chunk: error.toString() });
+                reject(error);
+            });
         });
 
         const items = await this.search({});

--- a/arduino-ide-extension/src/node/library-service-server-impl.ts
+++ b/arduino-ide-extension/src/node/library-service-server-impl.ts
@@ -183,7 +183,11 @@ export class LibraryServiceImpl extends CoreClientAware implements LibraryServic
         });
         await new Promise<void>((resolve, reject) => {
             resp.on('end', resolve);
-            resp.on('error', reject);
+            resp.on('error', error => {
+                this.outputService.append({ chunk: `Failed to install library: ${item.name}${version ? `:${version}` : ''}.\n` });
+                this.outputService.append({ chunk: error.toString() });
+                reject(error);
+            });
         });
 
         const items = await this.search({});


### PR DESCRIPTION
From now on, we toast an error message and update the _Arduino_ output channel if the platform/lib installation has failed for whatever reason. 

I tested the changeset with the following 3rd party cores:
 - https://github.com/watterott/Arduino-Boards/raw/master/package_watterott_index.json (checksum issue)
 - https://raw.githubusercontent.com/eddieespinal/atmegazero/master/package_atmegazero_index.json (no unique root dir in archive)
 - https://raw.githubusercontent.com/tenbaht/sduino/master/package_sduino_stm8_index.json (no unique root dir in archive)
 - https://udooboard.github.io/arduino-board-package/package_udoo_index.json (no unique root dir in archive)

In-action:

https://user-images.githubusercontent.com/1405703/110629391-67248b80-81a4-11eb-8d18-cd6ec91b1539.mp4

Before this change: there was no indication of the installation failure.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>