### PR TITLE
ATL-1064: Support for nested sketchbook structure

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/sketchbook.ts
+++ b/arduino-ide-extension/src/browser/contributions/sketchbook.ts
@@ -1,13 +1,13 @@
 import { inject, injectable } from 'inversify';
-import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
-import { SketchContribution, CommandRegistry, MenuModelRegistry, Sketch } from './contribution';
+import { CommandRegistry, MenuModelRegistry } from './contribution';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { MainMenuManager } from '../../common/main-menu-manager';
 import { NotificationCenter } from '../notification-center';
-import { OpenSketch } from './open-sketch';
+import { Examples } from './examples';
+import { SketchContainer } from '../../common/protocol';
 
 @injectable()
-export class Sketchbook extends SketchContribution {
+export class Sketchbook extends Examples {
 
     @inject(CommandRegistry)
     protected readonly commandRegistry: CommandRegistry;
@@ -21,17 +21,16 @@ export class Sketchbook extends SketchContribution {
     @inject(NotificationCenter)
     protected readonly notificationCenter: NotificationCenter;
 
-    protected toDisposePerSketch = new Map<string, DisposableCollection>();
-
     onStart(): void {
-        this.sketchService.getSketches().then(sketches => {
-            this.register(sketches);
+        this.sketchService.getSketches({}).then(container => {
+            this.register(container);
             this.mainMenuManager.update();
         });
-        this.sketchServiceClient.onSketchbookDidChange(({ created, removed }) => {
-            this.unregister(removed);
-            this.register(created);
-            this.mainMenuManager.update();
+        this.sketchServiceClient.onSketchbookDidChange(() => {
+            this.sketchService.getSketches({}).then(container => {
+                this.register(container);
+                this.mainMenuManager.update();
+            });
         });
     }
 
@@ -39,31 +38,9 @@ export class Sketchbook extends SketchContribution {
         registry.registerSubmenu(ArduinoMenus.FILE__SKETCHBOOK_SUBMENU, 'Sketchbook', { order: '3' });
     }
 
-    protected register(sketches: Sketch[]): void {
-        for (const sketch of sketches) {
-            const { uri } = sketch;
-            const toDispose = this.toDisposePerSketch.get(uri);
-            if (toDispose) {
-                toDispose.dispose();
-            }
-            const command = { id: `arduino-sketchbook-open--${uri}` };
-            const handler = { execute: () => this.commandRegistry.executeCommand(OpenSketch.Commands.OPEN_SKETCH.id, sketch) };
-            this.commandRegistry.registerCommand(command, handler);
-            this.menuRegistry.registerMenuAction(ArduinoMenus.FILE__SKETCHBOOK_SUBMENU, { commandId: command.id, label: sketch.name });
-            this.toDisposePerSketch.set(sketch.uri, new DisposableCollection(
-                Disposable.create(() => this.commandRegistry.unregisterCommand(command)),
-                Disposable.create(() => this.menuRegistry.unregisterMenuAction(command))
-            ));
-        }
-    }
-
-    protected unregister(sketches: Sketch[]): void {
-        for (const { uri } of sketches) {
-            const toDispose = this.toDisposePerSketch.get(uri);
-            if (toDispose) {
-                toDispose.dispose();
-            }
-        }
+    protected register(container: SketchContainer): void {
+        this.toDispose.dispose();
+        this.registerRecursively([...container.children, ...container.sketches], ArduinoMenus.FILE__SKETCHBOOK_SUBMENU, this.toDispose);
     }
 
 }

--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-service.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-service.ts
@@ -8,7 +8,7 @@ import { FrontendApplication } from '@theia/core/lib/browser/frontend-applicatio
 import { FocusTracker, Widget } from '@theia/core/lib/browser';
 import { WorkspaceService as TheiaWorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { ConfigService } from '../../../common/protocol/config-service';
-import { SketchesService, Sketch } from '../../../common/protocol/sketches-service';
+import { SketchesService, Sketch, SketchContainer } from '../../../common/protocol/sketches-service';
 import { ArduinoWorkspaceRootResolver } from '../../arduino-workspace-resolver';
 
 @injectable()
@@ -50,7 +50,7 @@ export class WorkspaceService extends TheiaWorkspaceService {
                 const hash = window.location.hash;
                 const [recentWorkspaces, recentSketches] = await Promise.all([
                     this.server.getRecentWorkspaces(),
-                    this.sketchService.getSketches().then(sketches => sketches.map(s => s.uri))
+                    this.sketchService.getSketches({}).then(container => SketchContainer.toArray(container).map(s => s.uri))
                 ]);
                 const toOpen = await new ArduinoWorkspaceRootResolver({
                     isValid: this.isValid.bind(this)

--- a/arduino-ide-extension/src/common/protocol/examples-service.ts
+++ b/arduino-ide-extension/src/common/protocol/examples-service.ts
@@ -1,14 +1,10 @@
-import { Sketch } from './sketches-service';
+import { SketchContainer } from './sketches-service';
 
 export const ExamplesServicePath = '/services/example-service';
 export const ExamplesService = Symbol('ExamplesService');
 export interface ExamplesService {
-    builtIns(): Promise<ExampleContainer[]>;
-    installed(options: { fqbn: string }): Promise<{ user: ExampleContainer[], current: ExampleContainer[], any: ExampleContainer[] }>;
+    builtIns(): Promise<SketchContainer[]>;
+    installed(options: { fqbn: string }): Promise<{ user: SketchContainer[], current: SketchContainer[], any: SketchContainer[] }>;
 }
 
-export interface ExampleContainer {
-    readonly label: string;
-    readonly children: ExampleContainer[];
-    readonly sketches: Sketch[];
-}
+

--- a/arduino-ide-extension/src/common/protocol/sketches-service-client-impl.ts
+++ b/arduino-ide-extension/src/common/protocol/sketches-service-client-impl.ts
@@ -9,6 +9,7 @@ import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { ConfigService } from './config-service';
 import { DisposableCollection, Emitter } from '@theia/core';
 import { FileChangeType } from '@theia/filesystem/lib/browser';
+import { SketchContainer } from './sketches-service';
 
 @injectable()
 export class SketchesServiceClientImpl implements FrontendApplicationContribution {
@@ -35,9 +36,9 @@ export class SketchesServiceClientImpl implements FrontendApplicationContributio
 
     onStart(): void {
         this.configService.getConfiguration().then(({ sketchDirUri }) => {
-            this.sketchService.getSketches(sketchDirUri).then(sketches => {
+            this.sketchService.getSketches({ uri: sketchDirUri }).then(container => {
                 const sketchbookUri = new URI(sketchDirUri);
-                for (const sketch of sketches) {
+                for (const sketch of SketchContainer.toArray(container)) {
                     this.sketches.set(sketch.uri, sketch);
                 }
                 this.toDispose.push(this.fileService.watch(new URI(sketchDirUri), { recursive: true, excludes: [] }));


### PR DESCRIPTION
This PR adds support for sketchbook subfolders.

FS State:

![Screen Shot 2021-03-10 at 17 28 23](https://user-images.githubusercontent.com/1405703/110663290-92b86d80-81c6-11eb-9d52-ed5ea6265b48.jpg)

`Sketchbook` menu:
![Screen Shot 2021-03-10 at 17 27 39](https://user-images.githubusercontent.com/1405703/110663351-9f3cc600-81c6-11eb-8263-692b2631447d.jpg)

`Open` context menu. `libraries` are there, just like in the Java IDE.
![Screen Shot 2021-03-10 at 17 27 50](https://user-images.githubusercontent.com/1405703/110663441-baa7d100-81c6-11eb-9d2b-4633a1aaf4f1.jpg)

Note: This PR does not expand the `examples` node from the `libraries`.
Java IDE:
![Screen Shot 2021-03-10 at 17 34 15](https://user-images.githubusercontent.com/1405703/110663585-ddd28080-81c6-11eb-866c-4a1795c2e6c0.jpg)

IDE 2:
![Screen Shot 2021-03-10 at 17 35 01](https://user-images.githubusercontent.com/1405703/110663677-f3e04100-81c6-11eb-815a-47b99cda1fc1.jpg)


Signed-off-by: Akos Kitta <kittaakos@typefox.io>