### PR TITLE
[ATL-959] Remove settings icon from sidebar

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -222,6 +222,7 @@ export class ArduinoFrontendContribution implements FrontendApplicationContribut
                 webContents.setZoomLevel(event.newValue || 0);
             }
         });
+        app.shell.leftPanelHandler.removeMenu('settings-menu');
     }
 
     protected languageServerFqbn?: string;


### PR DESCRIPTION
A gear icon is shown prominently in the side bar

This PR removes the gear icon from the sidebar

[Jira Task](https://arduino.atlassian.net/browse/ATL-959)
Github Issue: fixes #15 