### PR TITLE
ATL-1119 Disable code signing when workflows run from forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
 jobs:
 
   build:
+    if: github.repository == 'arduino/arduino-ide'
     strategy:
       matrix:
         config:
@@ -50,21 +51,26 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           IS_NIGHTLY: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') }}
           IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork == true }}
         run: |
             # See: https://www.electron.build/code-signing
-            if [ "${{ runner.OS }}" = "macOS" ]; then
-              export CSC_LINK="${{ runner.temp }}/signing_certificate.p12"
-              # APPLE_SIGNING_CERTIFICATE_P12 secret was produced by following the procedure from:
-              # https://www.kencochrane.com/2020/08/01/build-and-sign-golang-binaries-for-macos-with-github-actions/#exporting-the-developer-certificate
-              echo "${{ secrets.APPLE_SIGNING_CERTIFICATE_P12 }}" | base64 --decode > "$CSC_LINK"
+            if [ $IS_FORK = true ]; then
+              echo "Skipping the app signing: building from a fork."
+            else
+              if [ "${{ runner.OS }}" = "macOS" ]; then
+                export CSC_LINK="${{ runner.temp }}/signing_certificate.p12"
+                # APPLE_SIGNING_CERTIFICATE_P12 secret was produced by following the procedure from:
+                # https://www.kencochrane.com/2020/08/01/build-and-sign-golang-binaries-for-macos-with-github-actions/#exporting-the-developer-certificate
+                echo "${{ secrets.APPLE_SIGNING_CERTIFICATE_P12 }}" | base64 --decode > "$CSC_LINK"
 
-              export CSC_KEY_PASSWORD="${{ secrets.KEYCHAIN_PASSWORD }}"
+                export CSC_KEY_PASSWORD="${{ secrets.KEYCHAIN_PASSWORD }}"
 
-            elif [ "${{ runner.OS }}" = "Windows" ]; then
-              export CSC_LINK="${{ runner.temp }}/signing_certificate.pfx"
-              echo "${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PFX }}" | base64 --decode > "$CSC_LINK"
+              elif [ "${{ runner.OS }}" = "Windows" ]; then
+                export CSC_LINK="${{ runner.temp }}/signing_certificate.pfx"
+                echo "${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PFX }}" | base64 --decode > "$CSC_LINK"
 
-              export CSC_KEY_PASSWORD="${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}"
+                export CSC_KEY_PASSWORD="${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}"
+              fi
             fi
 
             yarn --cwd ./electron/packager/
@@ -120,7 +126,7 @@ jobs:
 
   publish:
     needs: changelog
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
+    if: github.repository == 'arduino/arduino-ide' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'))
     runs-on: ubuntu-latest
     steps:
       - name: Download [GitHub Actions]
@@ -141,7 +147,7 @@ jobs:
 
   release:
     needs: changelog
-    if: startsWith(github.ref, 'refs/tags/')
+    if: github.repository == 'arduino/arduino-ide' && startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     steps:
       - name: Download [GitHub Actions]

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -15,6 +15,11 @@ env:
 
 jobs:
   check-certificates:
+    # Only run when the workflow will have access to the certificate secrets.
+    if: >
+      (github.event_name != 'pull_request' && github.repository == 'arduino/arduino-ide') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'arduino/arduino-ide')
+    
     runs-on: ubuntu-latest
 
     strategy:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -73,6 +73,22 @@ This project is built on [GitHub Actions](https://github.com/arduino/arduino-ide
     git push origin 1.2.3
    ```
 
+## Notes for macOS contributors
+Beginning in macOS 10.14.5, the software [must be notarized to run](https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution). The signing and notarization processes for the Arduino IDE are managed by our Continuous Integration (CI) workflows, implemented with GitHub Actions. On every push and pull request, the Arduino IDE is built and saved to a workflow artifact. These artifacts can be used by contributors and beta testers who don't want to set up a build system locally.
+For security reasons, signing and notarization are disabled for workflow runs for pull requests from forks of this repository. This means that macOS will block you from running those artifacts.
+Due to this limitation, Mac users have two options for testing contributions from forks:
+
+### The Safe approach (recommended)
+
+Follow [the instructions above](#build-from-source) to create the build environment locally, then build the code you want to test.
+
+### The Risky approach
+
+*Please note that this approach is risky as you are lowering the security on your system, therefore we strongly discourage you from following it.*
+1. Use [this guide](https://help.apple.com/xcode/mac/10.2/index.html?localePath=en.lproj#/dev9b7736b0e), in order to disable Gatekeeper (at your own risk!).
+1. Download the unsigned artifact provided by the CI workflow run related to the Pull Request at each push.
+1. Re-enable Gatekeeper after tests are done, following the guide linked above.
+
 ### Creating a release
 
 You will not need to create a new release yourself as the Arduino team takes care of this on a regular basis, but we are documenting the process here. Let's assume the current version is `0.1.3` and you want to release `0.2.0`.

--- a/electron/build/scripts/notarize.js
+++ b/electron/build/scripts/notarize.js
@@ -6,6 +6,10 @@ exports.default = async function notarizing(context) {
         console.log('Skipping notarization: not on CI.');
         return;
     }
+    if (process.env.IS_FORK === 'true') {
+        console.log('Skipping the app notarization: building from a fork.');
+        return;
+    }
     const { electronPlatformName, appOutDir } = context;
     if (electronPlatformName !== 'darwin') {
         return;


### PR DESCRIPTION
This PR supersedes https://github.com/arduino/arduino-ide/pull/208 and comes from a fork of this repo in order to test the workflow update it contains.

The purpose of this PR is to refactor the CI workflows to be more "fork friendly".
If workflows are run on a PR generated by a fork, where secrets are not available, the CI will run skipping the signing steps, providing unsigned artifacts.

What this PR does:

- Skip Mac/Win code signing and Apple notarization only if PR comes from a fork
- Disable workflows entirely if the user enabled Github Actions in
their fork repo
- Add steps to help Mac users to test their forked code in BUILDING.md