### PR TITLE
[ATL-960] Disable editor quick suggestion

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -93,7 +93,7 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
         if (!AttachedBoardsChangeEvent.isEmpty(event)) {
             this.logger.info('Attached boards and available ports changed:');
             this.logger.info(AttachedBoardsChangeEvent.toString(event));
-            this.logger.info(`------------------------------------------`);
+            this.logger.info('------------------------------------------');
         }
         this._attachedBoards = event.newState.boards;
         this._availablePorts = event.newState.ports;

--- a/arduino-ide-extension/src/browser/contributions/add-zip-library.ts
+++ b/arduino-ide-extension/src/browser/contributions/add-zip-library.ts
@@ -82,7 +82,7 @@ export class AddZipLibrary extends SketchContribution {
                     if (name) {
                         throw new AlreadyInstalledError(`A library folder named ${name} already exists. Do you want to overwrite it?`, name);
                     } else {
-                        throw new AlreadyInstalledError(`A library already exists. Do you want to overwrite it?`);
+                        throw new AlreadyInstalledError('A library already exists. Do you want to overwrite it?');
                     }
                 }
             }

--- a/arduino-ide-extension/src/browser/output-service-impl.ts
+++ b/arduino-ide-extension/src/browser/output-service-impl.ts
@@ -14,7 +14,7 @@ export class OutputServiceImpl implements OutputService {
 
     append(message: OutputMessage): void {
         const { chunk } = message;
-        const channel = this.outputChannelManager.getChannel(`Arduino`);
+        const channel = this.outputChannelManager.getChannel('Arduino');
         channel.show({ preserveFocus: true });
         channel.append(chunk);
     }

--- a/arduino-ide-extension/src/browser/settings.tsx
+++ b/arduino-ide-extension/src/browser/settings.tsx
@@ -24,6 +24,7 @@ export interface Settings extends Index {
     editorFontSize: number; // `editor.fontSize`
     themeId: string; // `workbench.colorTheme`
     autoSave: 'on' | 'off'; // `editor.autoSave`
+    quickSuggestions: Record<'other'|'comments'|'strings', boolean>; // `editor.quickSuggestions`
 
     autoScaleInterface: boolean; // `arduino.window.autoScale`
     interfaceScale: number; // `arduino.window.zoomLevel` https://github.com/eclipse-theia/theia/issues/8751
@@ -84,6 +85,7 @@ export class SettingsService {
             editorFontSize,
             themeId,
             autoSave,
+            quickSuggestions,
             autoScaleInterface,
             interfaceScale,
             // checkForUpdates,
@@ -97,6 +99,11 @@ export class SettingsService {
             this.preferenceService.get<number>('editor.fontSize', 12),
             this.preferenceService.get<string>('workbench.colorTheme', 'arduino-theme'),
             this.preferenceService.get<'on' | 'off'>('editor.autoSave', 'on'),
+            this.preferenceService.get<object>('editor.quickSuggestion', {
+              'other': false,
+              'comments': false,
+              'strings': false
+            }),
             this.preferenceService.get<boolean>('arduino.window.autoScale', true),
             this.preferenceService.get<number>('arduino.window.zoomLevel', 0),
             // this.preferenceService.get<string>('arduino.ide.autoUpdate', true),
@@ -113,6 +120,7 @@ export class SettingsService {
             editorFontSize,
             themeId,
             autoSave,
+            quickSuggestions,
             autoScaleInterface,
             interfaceScale,
             // checkForUpdates,
@@ -155,10 +163,10 @@ export class SettingsService {
                 return `Invalid sketchbook location: ${sketchbookPath}`;
             }
             if (editorFontSize <= 0) {
-                return `Invalid editor font size. It must be a positive integer.`;
+                return 'Invalid editor font size. It must be a positive integer.';
             }
             if (!ThemeService.get().getThemes().find(({ id }) => id === themeId)) {
-                return `Invalid theme.`;
+                return 'Invalid theme.';
             }
             return true;
         } catch (err) {
@@ -175,6 +183,7 @@ export class SettingsService {
             editorFontSize,
             themeId,
             autoSave,
+            quickSuggestions,
             autoScaleInterface,
             interfaceScale,
             // checkForUpdates,
@@ -199,6 +208,7 @@ export class SettingsService {
             this.preferenceService.set('editor.fontSize', editorFontSize, PreferenceScope.User),
             this.preferenceService.set('workbench.colorTheme', themeId, PreferenceScope.User),
             this.preferenceService.set('editor.autoSave', autoSave, PreferenceScope.User),
+            this.preferenceService.set('editor.quickSuggestions', quickSuggestions, PreferenceScope.User),
             this.preferenceService.set('arduino.window.autoScale', autoScaleInterface, PreferenceScope.User),
             this.preferenceService.set('arduino.window.zoomLevel', interfaceScale, PreferenceScope.User),
             // this.preferenceService.set('arduino.ide.autoUpdate', checkForUpdates, PreferenceScope.User),
@@ -359,6 +369,13 @@ export class SettingsComponent extends React.Component<SettingsComponent.Props, 
                     checked={this.state.autoSave === 'on'}
                     onChange={this.autoSaveDidChange} />
                 Auto save
+            </label>
+            <label className='flex-line'>
+                <input
+                    type='checkbox'
+                    checked={this.state.quickSuggestions.other === true}
+                    onChange={this.quickSuggestionsOtherDidChange} />
+                Editor Quick Suggestions
             </label>
             <label className='flex-line'>
                 <input
@@ -549,6 +566,21 @@ export class SettingsComponent extends React.Component<SettingsComponent.Props, 
 
     protected autoSaveDidChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         this.setState({ autoSave: event.target.checked ? 'on' : 'off' });
+    };
+
+    protected quickSuggestionsOtherDidChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      
+      // need to persist react events through lifecycle https://reactjs.org/docs/events.html#event-pooling
+      const newVal = event.target.checked ? true : false
+      
+      this.setState(prevState => {
+        return {
+          quickSuggestions: {
+            ...prevState.quickSuggestions,
+            other: newVal
+          }
+        }
+      });
     };
 
     protected themeDidChange = (event: React.ChangeEvent<HTMLSelectElement>) => {

--- a/arduino-ide-extension/src/browser/style/settings-dialog.css
+++ b/arduino-ide-extension/src/browser/style/settings-dialog.css
@@ -4,7 +4,7 @@
 
 .arduino-settings-dialog .content {
     padding: 5px;
-    height: 270px;
+    height: 300px;
 }
 
 .arduino-settings-dialog .flex-line {

--- a/arduino-ide-extension/src/browser/toolbar/arduino-toolbar-contribution.ts
+++ b/arduino-ide-extension/src/browser/toolbar/arduino-toolbar-contribution.ts
@@ -1,9 +1,9 @@
-import { FrontendApplicationContribution, FrontendApplication, Widget, Message } from "@theia/core/lib/browser";
-import { injectable, inject } from "inversify";
-import { ArduinoToolbar } from "./arduino-toolbar";
-import { TabBarToolbarRegistry } from "@theia/core/lib/browser/shell/tab-bar-toolbar";
-import { CommandRegistry } from "@theia/core";
-import { LabelParser } from "@theia/core/lib/browser/label-parser";
+import { FrontendApplicationContribution, FrontendApplication, Widget, Message } from '@theia/core/lib/browser';
+import { injectable, inject } from 'inversify';
+import { ArduinoToolbar } from './arduino-toolbar';
+import { TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { CommandRegistry } from '@theia/core';
+import { LabelParser } from '@theia/core/lib/browser/label-parser';
 
 export class ArduinoToolbarContainer extends Widget {
 

--- a/arduino-ide-extension/src/electron-main/splash/splash-screen.ts
+++ b/arduino-ide-extension/src/electron-main/splash/splash-screen.ts
@@ -28,7 +28,7 @@ SOFTWARE.
  */
 
 import { Event } from '@theia/core/lib/common/event';
-import { BrowserWindow } from "electron";
+import { BrowserWindow } from 'electron';
 
 /**
  * When splashscreen was shown.
@@ -126,11 +126,11 @@ export const initSplashScreen = (config: Config, onCloseRequested?: Event<void>)
     const window = new BrowserWindow(xConfig.windowOpts);
     splashScreen = new BrowserWindow(xConfig.splashScreenOpts);
     splashScreen.loadURL(`file://${xConfig.templateUrl}`);
-    xConfig.closeWindow && splashScreen.on("close", () => {
+    xConfig.closeWindow && splashScreen.on('close', () => {
         done || window.close();
     });
     // Splashscreen is fully loaded and ready to view.
-    splashScreen.webContents.on("did-finish-load", () => {
+    splashScreen.webContents.on('did-finish-load', () => {
         splashScreenReady = true;
         showSplash();
     });

--- a/arduino-ide-extension/src/node/core-client-provider.ts
+++ b/arduino-ide-extension/src/node/core-client-provider.ts
@@ -54,7 +54,7 @@ export class CoreClientProvider extends GrpcClientProvider<CoreClientProvider.Cl
 
         const instance = initResp.getInstance();
         if (!instance) {
-            throw new Error(`Could not retrieve instance from the initialize response.`);
+            throw new Error('Could not retrieve instance from the initialize response.');
         }
 
         // No `await`. The index update event comes later. This way we do not block app startup with index update when invalid proxy is given.

--- a/arduino-ide-extension/src/node/monitor/monitor-service-impl.ts
+++ b/arduino-ide-extension/src/node/monitor/monitor-service-impl.ts
@@ -122,9 +122,9 @@ export class MonitorServiceImpl implements MonitorService {
             if (!this.connection && reason && reason.code === MonitorError.ErrorCodes.CLIENT_CANCEL) {
                 return Status.OK;
             }
-            this.logger.info(`>>> Disposing monitor connection...`);
+            this.logger.info('>>> Disposing monitor connection...');
             if (!this.connection) {
-                this.logger.warn(`<<< Not connected. Nothing to dispose.`);
+                this.logger.warn('<<< Not connected. Nothing to dispose.');
                 return Status.NOT_CONNECTED;
             }
             const { duplex, config } = this.connection;

--- a/arduino-ide-extension/src/node/notification-service-server.ts
+++ b/arduino-ide-extension/src/node/notification-service-server.ts
@@ -53,7 +53,7 @@ export class NotificationServiceServerImpl implements NotificationServiceServer 
     disposeClient(client: NotificationServiceClient): void {
         const index = this.clients.indexOf(client);
         if (index === -1) {
-            console.warn(`Could not dispose notification service client. It was not registered.`);
+            console.warn('Could not dispose notification service client. It was not registered.');
             return;
         }
         this.clients.splice(index, 1);

--- a/arduino-ide-extension/tslint.json
+++ b/arduino-ide-extension/tslint.json
@@ -15,6 +15,7 @@
       "check-else",
       "check-whitespace"
     ],
+    "quotemark": [true, "single", "jsx-single", "avoid-escape", "avoid-template"],
     "radix": true,
     "trailing-comma": [false],
     "triple-equals": [true, "allow-null-check"],

--- a/browser-app/package.json
+++ b/browser-app/package.json
@@ -37,7 +37,12 @@
           "editor.autoSave": "on",
           "editor.minimap.enabled": false,
           "editor.tabSize": 2,
-          "editor.scrollBeyondLastLine": false
+          "editor.scrollBeyondLastLine": false,
+          "editor.quickSuggestions": {
+            "other": false,
+            "comments": false,
+            "strings": false
+          }
         }
       }
     },

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -40,7 +40,12 @@
           "editor.autoSave": "on",
           "editor.minimap.enabled": false,
           "editor.tabSize": 2,
-          "editor.scrollBeyondLastLine": false
+          "editor.scrollBeyondLastLine": false,
+          "editor.quickSuggestions": {
+            "other": false,
+            "comments": false,
+            "strings": false
+          }
         }
       }
     },


### PR DESCRIPTION
While the auto complete functionality will be extremely useful to advanced users, the low level code it exposes constantly while typing will be confusing and distracting to beginners.

This PR disables by default the editor quick suggestion, adding a checkbox in the arduino preference panel to enable it.

[Jira Task](https://arduino.atlassian.net/browse/ATL-960)
Github Issue: fixes #17 