### PR TITLE
Create separate tester artifacts for each build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ on:
   schedule:
     - cron: '0 3 * * *' # run every day at 3AM (https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
 
+env:
+  JOB_TRANSFER_ARTIFACT: build-artifacts
+
 jobs:
 
   build:
@@ -79,7 +82,7 @@ jobs:
       - name: Upload [GitHub Actions]
         uses: actions/upload-artifact@v2
         with:
-          name: build-artifacts
+          name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: electron/build/dist/build-artifacts/
 
   changelog:
@@ -121,7 +124,7 @@ jobs:
         if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
         uses: actions/upload-artifact@v2
         with:
-          name: build-artifacts
+          name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: CHANGELOG.txt
 
   publish:
@@ -132,14 +135,14 @@ jobs:
       - name: Download [GitHub Actions]
         uses: actions/download-artifact@v2
         with:
-          name: build-artifacts
-          path: build-artifacts
+          name: ${{ env.JOB_TRANSFER_ARTIFACT }}
+          path: ${{ env.JOB_TRANSFER_ARTIFACT }}
 
       - name: Publish Nightly [S3]
         uses: docker://plugins/s3
         env:
-          PLUGIN_SOURCE: "build-artifacts/*"
-          PLUGIN_STRIP_PREFIX: "build-artifacts/"
+          PLUGIN_SOURCE: "${{ env.JOB_TRANSFER_ARTIFACT }}/*"
+          PLUGIN_STRIP_PREFIX: "${{ env.JOB_TRANSFER_ARTIFACT }}/"
           PLUGIN_TARGET: "/arduino-ide/nightly"
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -153,8 +156,8 @@ jobs:
       - name: Download [GitHub Actions]
         uses: actions/download-artifact@v2
         with:
-          name: build-artifacts
-          path: build-artifacts
+          name: ${{ env.JOB_TRANSFER_ARTIFACT }}
+          path: ${{ env.JOB_TRANSFER_ARTIFACT }}
 
       - name: Get Tag
         id: tag_name
@@ -166,7 +169,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           release_name: ${{ steps.tag_name.outputs.TAG_NAME }}
-          file: build-artifacts/*
+          file: ${{ env.JOB_TRANSFER_ARTIFACT }}/*
           tag: ${{ github.ref }}
           file_glob: true
           body: ${{ needs.changelog.outputs.BODY }}
@@ -174,8 +177,8 @@ jobs:
       - name: Publish Release [S3]
         uses: docker://plugins/s3
         env:
-          PLUGIN_SOURCE: "build-artifacts/*"
-          PLUGIN_STRIP_PREFIX: "build-artifacts/"
+          PLUGIN_SOURCE: "${{ env.JOB_TRANSFER_ARTIFACT }}/*"
+          PLUGIN_STRIP_PREFIX: "${{ env.JOB_TRANSFER_ARTIFACT }}/"
           PLUGIN_TARGET: "/arduino-ide"
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,3 +183,36 @@ jobs:
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  artifacts:
+    name: ${{ matrix.artifact.name }} artifact
+    needs: build
+    if: always() && needs.build.result != 'skipped'
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        artifact:
+          - path: "*Linux_64bit.zip"
+            name: Linux_X86-64
+          - path: "*macOS_64bit.dmg"
+            name: macOS
+          - path: "*Windows_64bit.exe"
+            name: Windows_X86-64_interactive_installer
+          - path: "*Windows_64bit.msi"
+            name: Windows_X86-64_MSI
+          - path: "*Windows_64bit.zip"
+            name: Windows_X86-64_zip
+
+    steps:
+      - name: Download job transfer artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.JOB_TRANSFER_ARTIFACT }}
+          path: ${{ env.JOB_TRANSFER_ARTIFACT }}
+      
+      - name: Upload tester build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.artifact.name }}
+          path: ${{ env.JOB_TRANSFER_ARTIFACT }}/${{ matrix.artifact.path }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,6 +85,39 @@ jobs:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: electron/build/dist/build-artifacts/
 
+  artifacts:
+    name: ${{ matrix.artifact.name }} artifact
+    needs: build
+    if: always() && needs.build.result != 'skipped'
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        artifact:
+          - path: "*Linux_64bit.zip"
+            name: Linux_X86-64
+          - path: "*macOS_64bit.dmg"
+            name: macOS
+          - path: "*Windows_64bit.exe"
+            name: Windows_X86-64_interactive_installer
+          - path: "*Windows_64bit.msi"
+            name: Windows_X86-64_MSI
+          - path: "*Windows_64bit.zip"
+            name: Windows_X86-64_zip
+
+    steps:
+      - name: Download job transfer artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: ${{ env.JOB_TRANSFER_ARTIFACT }}
+          path: ${{ env.JOB_TRANSFER_ARTIFACT }}
+      
+      - name: Upload tester build artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.artifact.name }}
+          path: ${{ env.JOB_TRANSFER_ARTIFACT }}/${{ matrix.artifact.path }}
+
   changelog:
     needs: build
     runs-on: ubuntu-latest
@@ -184,35 +217,18 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
-  artifacts:
-    name: ${{ matrix.artifact.name }} artifact
-    needs: build
+  clean:
+    # This job must run after all jobs that use the transfer artifact.
+    needs:
+      - build
+      - publish
+      - release
+      - artifacts
     if: always() && needs.build.result != 'skipped'
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        artifact:
-          - path: "*Linux_64bit.zip"
-            name: Linux_X86-64
-          - path: "*macOS_64bit.dmg"
-            name: macOS
-          - path: "*Windows_64bit.exe"
-            name: Windows_X86-64_interactive_installer
-          - path: "*Windows_64bit.msi"
-            name: Windows_X86-64_MSI
-          - path: "*Windows_64bit.zip"
-            name: Windows_X86-64_zip
-
     steps:
-      - name: Download job transfer artifact
-        uses: actions/download-artifact@v2
+      - name: Remove unneeded job transfer artifact
+        uses: geekyeggo/delete-artifact@v1
         with:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
-          path: ${{ env.JOB_TRANSFER_ARTIFACT }}
-      
-      - name: Upload tester build artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ matrix.artifact.name }}
-          path: ${{ env.JOB_TRANSFER_ARTIFACT }}/${{ matrix.artifact.path }}


### PR DESCRIPTION
Previously, a single workflow artifact was created by the "Arduino IDE" GitHub Actions workflow. This artifact contained
the builds for each operating system, including all three versions of the Windows build. This resulted in beta testers
needing to do a >1 GB download for every build, even though they likely needed only ~200 MB of what they downloaded.

Producing separate workflow artifacts makes it easier for beta testers to participate in the development and is less wasteful of
resources.