### PR TITLE
ATL-1128: make the new tab button easier to click

### DIFF
--- a/arduino-ide-extension/src/browser/style/main.css
+++ b/arduino-ide-extension/src/browser/style/main.css
@@ -175,7 +175,6 @@
 
 #arduino-open-sketch-control--toolbar--container {
     background-color: var(--theia-arduino-toolbar-background);
-    padding: 8px 8px 8px 8px; /* based on pure heuristics */
 }
 
 #arduino-open-sketch-control--toolbar {
@@ -183,6 +182,7 @@
     width: unset;
     line-height: unset;
     color: var(--theia-titleBar-activeBackground);
+    padding: 5px 8px; /* based on pure heuristics */
 }
 
 /* Output */


### PR DESCRIPTION
The active area for the new tab button is very small.
<img width="35" alt="image" src="https://user-images.githubusercontent.com/1636933/112112911-6af9da00-8bb6-11eb-9315-6eae6bbafa42.png">

This PR expands the active area by moving the padding from the container of the button to the button itself.

Padding changed because of the actual size of the chevron icon in the button.
___

Fixes #97 
[Jira Task](https://arduino.atlassian.net/browse/ATL-1128)