### PR TITLE
ATL-970: notification to last longer

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/burn-bootloader.ts
+++ b/arduino-ide-extension/src/browser/contributions/burn-bootloader.ts
@@ -61,7 +61,7 @@ export class BurnBootloader extends SketchContribution {
                 verify,
                 verbose
             });
-            this.messageService.info('Done burning bootloader.', { timeout: 1000 });
+            this.messageService.info('Done burning bootloader.', { timeout: 3000 });
         } catch (e) {
             this.messageService.error(e.toString());
         } finally {

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -148,7 +148,7 @@ export class UploadSketch extends SketchContribution {
             } else {
                 await this.coreService.upload(options);
             }
-            this.messageService.info('Done uploading.', { timeout: 1000 });
+            this.messageService.info('Done uploading.', { timeout: 3000 });
         } catch (e) {
             this.messageService.error(e.toString());
         } finally {

--- a/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
@@ -109,7 +109,7 @@ export class VerifySketch extends SketchContribution {
                 sourceOverride,
                 compilerWarnings
             });
-            this.messageService.info('Done compiling.', { timeout: 1000 });
+            this.messageService.info('Done compiling.', { timeout: 3000 });
         } catch (e) {
             this.messageService.error(e.toString());
         } finally {


### PR DESCRIPTION
With this PR I set the timeout of the following notification to 3 seconds (like other notifications in the IDE)
- burn bootloader
- verify sketch
- upload sketch