### PR TITLE
ATL-1136: Add .adoc and .md file support

### DIFF
--- a/arduino-ide-extension/src/common/protocol/sketches-service.ts
+++ b/arduino-ide-extension/src/common/protocol/sketches-service.ts
@@ -87,7 +87,7 @@ export namespace Sketch {
     export namespace Extensions {
         export const MAIN = ['.ino', '.pde'];
         export const SOURCE = ['.c', '.cpp', '.s'];
-        export const ADDITIONAL = ['.h', '.c', '.hpp', '.hh', '.cpp', '.s', '.json'];
+        export const ADDITIONAL = ['.h', '.c', '.hpp', '.hh', '.cpp', '.S', '.json', '.md', '.adoc'];
         export const ALL = Array.from(new Set([...MAIN, ...SOURCE, ...ADDITIONAL]));
     }
     export function isInSketch(uri: string | URI, sketch: Sketch): boolean {


### PR DESCRIPTION
This PR  add support to create and view `.md` and `.adoc` files in IDE2. It also fix .S file extension (see #218 )

> Note: this PR alone do not solve the fact the IDE2 do not open automatically .md and .adoc files belonging to a sketch. That will be handled in a separate PR addressing [ATL-1152](https://arduino.atlassian.net/browse/ATL-1152)

## How to test
- open IDE2
- create a new tab using the top right button
- give it a name and and extension `.md` or `.adoc`

## Demo
![doc-file-support](https://user-images.githubusercontent.com/1636933/112299350-00b96600-8c98-11eb-8b40-5ff308c54c06.gif)

## Tasks
[ATL-1136](https://arduino.atlassian.net/browse/ATL-1136)
fixes #218 