### PR TITLE
GH-259: Use Ubuntu `18.04` for the build job.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         config:
           - os: windows-latest
-          - os: ubuntu-latest
+          - os: ubuntu-18.04 # https://github.com/arduino/arduino-ide/issues/259
           - os: macos-latest
     runs-on: ${{ matrix.config.os }}
     timeout-minutes: 90


### PR DESCRIPTION
Closes #259

Signed-off-by: Akos Kitta <kittaakos@typefox.io>