### PR TITLE
ATL-1151: settings panel to reflect actual state

### DIFF
--- a/arduino-ide-extension/src/browser/settings.tsx
+++ b/arduino-ide-extension/src/browser/settings.tsx
@@ -777,6 +777,11 @@ export class SettingsDialog extends AbstractDialog<Promise<Settings>> {
 
     protected onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
+
+        // calling settingsService.reset() in order to reload the settings from the preferenceService
+        // and update the UI including changes triggerd from the command palette
+        this.settingsService.reset();
+
         this.widget.activate();
     }
 


### PR DESCRIPTION
### Motivation
We want the settings preference panel to reflect the actual state of the application. Even if command palette commands change the status bypassing the preference panel UI.

### Change description
- reload the preference before opening the preference panel dialog


### Additional Notes
[Jira task](https://arduino.atlassian.net/browse/ATL-1151)

Demo:

https://user-images.githubusercontent.com/1636933/112849916-d1489600-90a9-11eb-9148-017c1c17d131.mov

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] History is clean, commit messages are meaningful.