### PR TITLE
ATL-372: .ino file associations

### DIFF
--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -23,7 +23,38 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
         // See: https://github.com/electron-userland/electron-builder/issues/2468
         // Regression in Theia: https://github.com/eclipse-theia/theia/issues/8701
         app.on('ready', () => app.setName(config.applicationName));
+
+        // Add file associations to the app
+        this.attachFileAssociations();
+
         return super.start(config);
+    }
+
+    attachFileAssociations() {
+
+        // OSX: register open-file event
+        if (process.platform === 'darwin') {
+            app.on('open-file', (event, uri) => {
+                event.preventDefault();
+                // TODO: check if the URI is a .ino file
+                // should I call openSketchFiles(uri) ?
+            });
+        }
+
+        // WIN: read file(s) uri from executable args
+        if (process.platform === 'win32') {
+            if (app.isPackaged) {
+                // workaround for missing executable argument when app is packaged
+                process.argv.unshift('packaged');
+            }
+            // parameters is an array containing any files/folders that your OS will pass to your application
+            const uri = process.argv.slice(2) || null;
+            if (uri) {
+                // TODO: filter out only the first .ino file in the array
+                // should I call openSketchFiles(uri) ?
+            }
+        }
+
     }
 
     /**

--- a/electron/build/template-package.json
+++ b/electron/build/template-package.json
@@ -53,6 +53,12 @@
     "directories": {
       "buildResources": "resources"
     },
+    "fileAssociations": [
+      {
+          "ext": ["ino"],
+          "role": "Editor"
+      }
+    ],
     "files": [
       "src-gen",
       "lib",


### PR DESCRIPTION
### Motivation
We want to add 2 functionalities to the ide
- associate a file type (namely, `.ino` files)
- allow the drag and drop of a file over the icon (macOS only) and open the relevant files

### Change description
DRAFT: the following changes are just a proposal;
- file association is done via electronBuilder + `template-package.json` configuration
- files to be opened are handled in `electron-main-applicatoin.ts`

### Additional Notes
See comments in the attached [Jira Task](https://arduino.atlassian.net/browse/ATL-372)

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] History is clean, commit messages are meaningful.