### PR TITLE
ATL-1145: Suppress error if Git is not on `$PATH`.

### DIFF
--- a/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
+++ b/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
@@ -34,6 +34,8 @@ import { NotificationServiceServerImpl } from './notification-service-server';
 import { NotificationServiceServer, NotificationServiceClient, NotificationServicePath } from '../common/protocol';
 import { BackendApplication } from './theia/core/backend-application';
 import { BoardDiscovery } from './board-discovery';
+import { DefaultGitInit } from './theia/git/git-init';
+import { GitInit } from '@theia/git/lib/node/init/git-init';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(BackendApplication).toSelf().inSingletonScope();
@@ -163,5 +165,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         const parentLogger = ctx.container.get<ILogger>(ILogger);
         return parentLogger.child('monitor-service');
     }).inSingletonScope().whenTargetNamed('monitor-service');
+
+    bind(DefaultGitInit).toSelf();
+    rebind(GitInit).toService(DefaultGitInit);
 
 });

--- a/arduino-ide-extension/src/node/theia/git/git-init.ts
+++ b/arduino-ide-extension/src/node/theia/git/git-init.ts
@@ -1,0 +1,44 @@
+import { injectable } from 'inversify';
+import findGit from 'find-git-exec';
+import { dirname } from 'path';
+import { pathExists } from 'fs-extra';
+import { GitInit } from '@theia/git/lib/node/init/git-init';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+
+@injectable()
+export class DefaultGitInit implements GitInit {
+
+    protected readonly toDispose = new DisposableCollection();
+
+    async init(): Promise<void> {
+        const { env } = process;
+        try {
+            const { execPath, path, version } = await findGit();
+            if (!!execPath && !!path && !!version) {
+                const dir = dirname(dirname(path));
+                const [execPathOk, pathOk, dirOk] = await Promise.all([pathExists(execPath), pathExists(path), pathExists(dir)]);
+                if (execPathOk && pathOk && dirOk) {
+                    if (typeof env.LOCAL_GIT_DIRECTORY !== 'undefined' && env.LOCAL_GIT_DIRECTORY !== dir) {
+                        console.error(`Misconfigured env.LOCAL_GIT_DIRECTORY: ${env.LOCAL_GIT_DIRECTORY}. dir was: ${dir}`);
+                        return;
+                    }
+                    if (typeof env.GIT_EXEC_PATH !== 'undefined' && env.GIT_EXEC_PATH !== execPath) {
+                        console.error(`Misconfigured env.GIT_EXEC_PATH: ${env.GIT_EXEC_PATH}. execPath was: ${execPath}`);
+                        return;
+                    }
+                    process.env.LOCAL_GIT_DIRECTORY = dir;
+                    process.env.GIT_EXEC_PATH = execPath;
+                    console.info(`Using Git [${version}] from the PATH. (${path})`);
+                    return;
+                }
+            }
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+}


### PR DESCRIPTION
This PR does one thing: it suppresses the error message when the Git executable is not on the `$PATH`.

How to verify: this is an interesting part, I did the straightforward way and renamed all my Git executables to something else so that `git version` fails from a terminal. I renamed the followings:
 - `C:\Program Files\Git\cmd\git.exe`,
 - `C:\Users\my_name\scopes\shims\git.EXE`, and
 - made sure `/mingw64/bin/git` (for Git Bash) also not accessible.

Once you have a setup without git on the `$PATH`, start the app. You should not see any errors.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>