### PR TITLE
Correct sketchbook folder selection button text

### DIFF
--- a/arduino-ide-extension/src/browser/settings.tsx
+++ b/arduino-ide-extension/src/browser/settings.tsx
@@ -507,7 +507,7 @@ export class SettingsComponent extends React.Component<SettingsComponent.Props, 
     protected browseSketchbookDidClick = async () => {
         const uri = await this.props.fileDialogService.showOpenDialog({
             title: 'Select new sketchbook location',
-            openLabel: 'Chose',
+            openLabel: 'Choose',
             canSelectFiles: false,
             canSelectMany: false,
             canSelectFolders: true


### PR DESCRIPTION
The previous text used past tense, which is not appropriate for a button.

Credit to Arduino Forum user "arduinoshop":
https://forum.arduino.cc/t/ide-2-0-beta-4-ubuntu-21-04-first-time-install/847777/10