### PR TITLE
[ATL-1222] fix editor colors

### DIFF
--- a/arduino-ide-extension/src/browser/data/arduino.color-theme.json
+++ b/arduino-ide-extension/src/browser/data/arduino.color-theme.json
@@ -28,7 +28,8 @@
       "scope": [
         "meta.function.c",
         "entity.name.function",
-        "meta.function-call.c"
+        "meta.function-call.c",
+        "variable.other"
       ],
       "settings": {
         "foreground": "#D35400"
@@ -42,16 +43,19 @@
         "meta.block.c",
         "meta.function.c",
         "entity.name.function.preprocessor.c",
-        "meta.preprocessor.macro.c"
+        "meta.preprocessor.macro.c",
+        "variable",
+        "variable.name"
       ],
       "settings": {
         "foreground": "#434f54"
       }
     },
     {
-      "name": "strings",
+      "name": "constants",
       "scope": [
-        "string.quoted.double"
+        "string.quoted.double",
+        "constant"
       ],
       "settings": {
         "foreground": "#005C5F"


### PR DESCRIPTION
This PR fixes the following colors:
- constant and double quoted strings (as they are constants) have the same color (dark teal color)
- function / methods (orange)

Tasks: 
Fixes [ATL-1222](https://arduino.atlassian.net/browse/ATL-1222)
Fixes #291 