### PR TITLE
[ATL-1247] Language Server now requires an additional cliConfigPath

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -288,10 +288,11 @@ export class ArduinoFrontendContribution implements FrontendApplicationContribut
                 }
             }
             const { clangdUri, cliUri, lsUri } = await this.executableService.list();
-            const [clangdPath, cliPath, lsPath] = await Promise.all([
+            const [clangdPath, cliPath, lsPath, cliConfigPath] = await Promise.all([
                 this.fileService.fsPath(new URI(clangdUri)),
                 this.fileService.fsPath(new URI(cliUri)),
                 this.fileService.fsPath(new URI(lsUri)),
+                this.fileService.fsPath(new URI(await this.configService.getCliConfigFileUri()))
             ]);
             this.languageServerFqbn = await Promise.race([
                 new Promise<undefined>((_, reject) => setTimeout(() => reject(new Error(`Timeout after ${20_000} ms.`)), 20_000)),
@@ -300,6 +301,7 @@ export class ArduinoFrontendContribution implements FrontendApplicationContribut
                     cliPath,
                     clangdPath,
                     log: currentSketchPath ? currentSketchPath : log,
+                    cliConfigPath,
                     board: {
                         fqbn,
                         name: name ? `"${name}"` : undefined

--- a/arduino-ide-extension/src/common/protocol/config-service.ts
+++ b/arduino-ide-extension/src/common/protocol/config-service.ts
@@ -2,6 +2,7 @@ export const ConfigServicePath = '/services/config-service';
 export const ConfigService = Symbol('ConfigService');
 export interface ConfigService {
     getVersion(): Promise<Readonly<{ version: string, commit: string, status?: string }>>;
+    getCliConfigFileUri(): Promise<string>;
     getConfiguration(): Promise<Config>;
     setConfiguration(config: Config): Promise<void>;
     isInDataDir(uri: string): Promise<boolean>;


### PR DESCRIPTION
### Motivation
Language server: pass a flag to set arduino-cli config file

### Change description
- get the cli config path
- pass it to the language server

### How To Test

**In order to test this PR you have to manually install the updated `vscode-arduino-tools` plugin (recommended) or wait for it to be built in the nightly** 

#### Manual Test
So you are bold enough to try with the manual test, aren't you?
-> Unzip the following file in the `.plugins` directory of arduino-ide, replacing the existing `vscode-arduino-tools` dir (see screenshot)
[vscode-arduino-tools.zip](https://github.com/arduino/arduino-ide/files/6426153/vscode-arduino-tools.zip)

<img width="523" alt="image" src="https://user-images.githubusercontent.com/1636933/117122760-826fd980-ad96-11eb-960a-ac21ae3cc29d.png">

### Additional Notes
- Task [ATL-1247](https://arduino.atlassian.net/browse/ATL-1247)
- vscode-arduino-tools [PR](https://github.com/arduino/vscode-arduino-tools/pull/25)

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] History is clean, commit messages are meaningful.