### PR TITLE
Use latest release of built-in examples

### DIFF
--- a/arduino-ide-extension/scripts/download-examples.js
+++ b/arduino-ide-extension/scripts/download-examples.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // The version to use.
-const version = '1.9.0';
+const version = '1.9.1';
 
 (async () => {
 


### PR DESCRIPTION
A new release is available for the example sketches provided via the IDE's **File > Examples > Built-in examples** menu.

### References

- https://github.com/arduino/arduino-examples/releases/tag/1.9.1
- https://github.com/arduino/Arduino/pull/11519