### PR TITLE
Footer min-height for library and board manager

### DIFF
--- a/arduino-ide-extension/src/browser/style/list-widget.css
+++ b/arduino-ide-extension/src/browser/style/list-widget.css
@@ -113,7 +113,7 @@ https://github.com/arduino/arduino-pro-ide/issues/82 */
 
 .component-list-item[min-width~="170px"] .footer {
     padding: 5px 5px 0px 0px;
-    min-height: 26px; /* 21 + 5 from the footer margin top */
+    min-height: 30px;
     display: flex;
     flex-direction: row-reverse;
 }


### PR DESCRIPTION
On Windows 10 (and possibly others), rolling over the items in the Library Manager and Boards Manager causes an unpleasant jump, as seen here:

![ezgif com-gif-maker](https://user-images.githubusercontent.com/190127/119831440-2f042d80-bef5-11eb-954a-8f4b1e7af144.gif)

This PR increases the `min-height` of the footer for the list items from 26px to 30px, which is the minimum value required to prevent this from occurring, and improves the UX in doing so, without changing the spacing excessively:

![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/190127/119831839-902c0100-bef5-11eb-954d-eb413920f544.gif)
