### PR TITLE
eslint to fix unused imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,4 @@
 module.exports = {
-    ignorePatterns: [
-        'node_modules/*',
-        '/*',
-        '!arduino-ide-extension',
-        'arduino-ide-extension/*',
-        '!arduino-ide-extension/src',
-        'arduino-ide-extension/src/node/cli-protocol',
-    ],
     parser: '@typescript-eslint/parser', // Specifies the ESLint parser
     parserOptions: {
         ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
@@ -15,6 +7,16 @@ module.exports = {
             jsx: true, // Allows for the parsing of JSX
         },
     },
+    ignorePatterns: [
+        'node_modules/*',
+        '.node_modules/*',
+        '.browser_modules/*',
+        'electron/*',
+        'electron-app/*',
+        'browser-app/*',
+        'plugins-app/*',
+        'arduino-ide-extension/src/node/cli-protocol',
+    ],
     settings: {
         react: {
             version: 'detect', // Tells eslint-plugin-react to automatically detect the version of React to use
@@ -27,14 +29,24 @@ module.exports = {
         'plugin:prettier/recommended',
         'prettier', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
     ],
-    plugins: ['prettier'],
-    root: true,
+    plugins: ['prettier', 'unused-imports'],
     rules: {
         '@typescript-eslint/no-unused-expressions': 'off',
         '@typescript-eslint/no-namespace': 'off',
         '@typescript-eslint/no-var-requires': 'off',
         '@typescript-eslint/no-empty-function': 'warn',
         '@typescript-eslint/no-empty-interface': 'warn',
+        'no-unused-vars': 'off',
+        'unused-imports/no-unused-imports': 'error',
+        'unused-imports/no-unused-vars': [
+            'warn',
+            {
+                vars: 'all',
+                varsIgnorePattern: '^_',
+                args: 'after-used',
+                argsIgnorePattern: '^_',
+            },
+        ],
         'react/display-name': 'warn',
         eqeqeq: ['error', 'smart'],
         'guard-for-in': 'off',

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
+    "eslint-plugin-unused-imports": "^1.1.1",
     "husky": "^6.0.0",
     "lerna": "^3.20.2",
     "lint-staged": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7343,6 +7343,18 @@ eslint-plugin-react@^7.24.0:
     resolve "^2.0.0-next.3"
     string.prototype.matchall "^4.0.5"
 
+eslint-plugin-unused-imports@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-1.1.1.tgz#a5433f8b394461201129a246d8d92d9613e69597"
+  integrity sha512-EApvRx9Q3XQI96Tg7xPPqY6OuOy95wWMXAtc8RrwdIRk9bv8vkJKwOVoE4HeWJOQhHeHcI8lUbOqmup/PxjfOw==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
### Why
tsc complains about unused imports, stopping the builds in the CI. We want to catch unused imports asap.
Eslint supports unused-vars rule, but this appears to be too strict for our usecase. We need to catch imports *only*, and possibly auto-fix those before committing.

### How
[eslint-plugin-unused-imports](https://www.npmjs.com/package/eslint-plugin-unused-imports) integrates with eslint, detecting unused imports and removing them from the codebase. This automaically integrates with husky/lint staged that are already in place