### PR TITLE
Improve local sketchbook tree

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/component-list/filterable-list-container.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/filterable-list-container.tsx
@@ -94,7 +94,6 @@ export class FilterableListContainer<
   }
 
   protected sort(items: T[]): T[] {
-    // debugger;
     const { itemLabel, itemDeprecated } = this.props;
     return items.sort((left, right) => {
       // always put deprecated items at the bottom of the list

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
@@ -48,21 +48,9 @@ export class SketchbookTreeWidget extends FileTreeWidget {
   @postConstruct()
   protected async init(): Promise<void> {
     super.init();
-    this.toDispose.push(
-      this.arduinoPreferences.onPreferenceChanged(({ preferenceName }) => {
-        if (preferenceName === 'arduino.sketchbook.showAllFiles') {
-          this.updateModel();
-        }
-      })
-    );
-    this.updateModel();
     // cache the current open sketch uri
     const currentSketch = await this.sketchServiceClient.currentSketch();
     this.currentSketchUri = (currentSketch && currentSketch.uri) || '';
-  }
-
-  async updateModel(): Promise<void> {
-    return this.model.updateRoot();
   }
 
   protected createNodeClassNames(node: TreeNode, props: NodeProps): string[] {

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget.tsx
@@ -38,6 +38,10 @@ export class SketchbookWidget extends BaseWidget {
     );
   }
 
+  getTreeWidget(): SketchbookTreeWidget {
+    return this.localSketchbookTreeWidget;
+  }
+
   protected onActivateRequest(message: Message): void {
     super.onActivateRequest(message);
 


### PR DESCRIPTION
## Why
Need to improve the user experience when working on local files.
- As a user, I expect the current file I'm working on in the Editor to be highlighted in the sketchbook explorer
- As a user, I expect the local sketchbook explorer to reflect changes happening in the file system. Eg: I expect to immediately see freshly added/renamed/deleted files in the sketchbook explorer tree

## How
- Refactored the sketchbook tree to use a single root node which contains a child for every directory in the `Arduino` user directory
- Re-create the node tree when changes in either Monaco/FileSystem happens. This let us update the sketchbook treen when files are added-removed to directories as well as selecting the current focused file in the Monaco editor
- Removed useless re-renders of the sketchbook explorer during IDE startup

## Notes
Jira Tasks:
- [[Sketchbook] Selecting tab in Monaco doesn't select tab in explorer](https://arduino.atlassian.net/browse/ATL-1433)
- [[Sketchbook] When file system change happens files in the tree are not updated](https://arduino.atlassian.net/browse/ATL-1434)