### PR TITLE
Fix url to open sketch in cloud editor

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-contributions.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-contributions.ts
@@ -176,7 +176,7 @@ export class CloudSketchbookContribution extends Contribution {
     registry.registerCommand(CloudSketchbookCommands.OPEN_IN_CLOUD_EDITOR, {
       execute: (arg) => {
         this.windowService.openNewWindow(
-          `https://create.arduino.cc/editor/${arg.node.sketchId}`,
+          `https://create.arduino.cc/editor/${arg.username}/${arg.node.sketchId}`,
           { external: true }
         );
       },

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-widget.tsx
@@ -94,7 +94,9 @@ export class CloudSketchbookTreeWidget extends SketchbookTreeWidget {
         this.currentSketchUri === node.uri.toString())
     ) {
       return Array.from(new Set(node.commands)).map((command) =>
-        this.renderInlineCommand(command.id, node)
+        this.renderInlineCommand(command.id, node, {
+          username: this.authenticationService.session?.account?.label,
+        })
       );
     }
     return undefined;

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
@@ -125,11 +125,12 @@ export class SketchbookTreeWidget extends FileTreeWidget {
 
   protected renderInlineCommand(
     commandId: string,
-    node: SketchbookTree.SketchDirNode
+    node: SketchbookTree.SketchDirNode,
+    options?: any
   ): React.ReactNode {
     const command = this.commandRegistry.getCommand(commandId);
     const icon = command?.iconClass;
-    const args = { model: this.model, node: node };
+    const args = { model: this.model, node: node, ...options };
     if (
       command &&
       icon &&


### PR DESCRIPTION
## WHY
When opening a sketch in the Cloud editor through the contextual menu in the Remote Sketchbook, the user is redirected to the wrong URL.

It should link to: “create.arduino.cc/[USERNAME]/[SKETCH_ID]”

But right now it links to: “create.arduino.cc/[SKETCH_ID]”  

Which results in the editor opening the first sketch in the list

## HOW
Pass the username as an argument when executing the command to open the contextual menu.