### PR TITLE
Improve remote sketchbook tree

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -236,6 +236,7 @@ import { CloudSketchbookCompositeWidget } from './widgets/cloud-sketchbook/cloud
 import { SketchbookWidget } from './widgets/sketchbook/sketchbook-widget';
 import { SketchbookTreeWidget } from './widgets/sketchbook/sketchbook-tree-widget';
 import { createSketchbookTreeWidget } from './widgets/sketchbook/sketchbook-tree-container';
+import { SketchCache } from './widgets/cloud-sketchbook/cloud-sketch-cache';
 
 const ElementQueries = require('css-element-queries/src/ElementQueries');
 
@@ -686,6 +687,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     createCloudSketchbookTreeWidget(container)
   );
   bind(CreateApi).toSelf().inSingletonScope();
+  bind(SketchCache).toSelf().inSingletonScope();
+
   bind(ShareSketchDialog).toSelf().inSingletonScope();
   bind(AuthenticationClientService).toSelf().inSingletonScope();
   bind(CommandContribution).toService(AuthenticationClientService);

--- a/arduino-ide-extension/src/browser/create/create-api.ts
+++ b/arduino-ide-extension/src/browser/create/create-api.ts
@@ -1,8 +1,9 @@
-import { injectable } from 'inversify';
+import { injectable, inject } from 'inversify';
 import * as createPaths from './create-paths';
-import { posix, splitSketchPath } from './create-paths';
+import { posix } from './create-paths';
 import { AuthenticationClientService } from '../auth/authentication-client-service';
 import { ArduinoPreferences } from '../arduino-preferences';
+import { SketchCache } from '../widgets/cloud-sketchbook/cloud-sketch-cache';
 
 export interface ResponseResultProvider {
   (response: Response): Promise<any>;
@@ -15,10 +16,11 @@ export namespace ResponseResultProvider {
 
 type ResourceType = 'f' | 'd';
 
-export let sketchCache: Create.Sketch[] = [];
-
 @injectable()
 export class CreateApi {
+  @inject(SketchCache)
+  protected readonly sketchCache: SketchCache;
+
   protected authenticationService: AuthenticationClientService;
   protected arduinoPreferences: ArduinoPreferences;
 
@@ -32,48 +34,24 @@ export class CreateApi {
     return this;
   }
 
-  public sketchCompareByPath = (param: string) => {
-    return (sketch: Create.Sketch) => {
-      const [, spath] = splitSketchPath(sketch.path);
-      return param === spath;
-    };
-  };
-
-  async findSketchInCache(
-    compareFn: (sketch: Create.Sketch) => boolean,
-    trustCache = true
-  ): Promise<Create.Sketch | undefined> {
-    const sketch = sketchCache.find((sketch) => compareFn(sketch));
-    if (trustCache) {
-      return Promise.resolve(sketch);
-    }
-    return await this.sketch({ id: sketch?.id });
+  public wipeCache(): void {
+    this.sketchCache.init();
   }
 
   getSketchSecretStat(sketch: Create.Sketch): Create.Resource {
     return {
       href: `${sketch.href}${posix.sep}${Create.arduino_secrets_file}`,
       modified_at: sketch.modified_at,
+      created_at: sketch.created_at,
       name: `${Create.arduino_secrets_file}`,
       path: `${sketch.path}${posix.sep}${Create.arduino_secrets_file}`,
       mimetype: 'text/x-c++src; charset=utf-8',
       type: 'file',
-      sketchId: sketch.id,
     };
   }
 
-  async sketch(opt: {
-    id?: string;
-    path?: string;
-  }): Promise<Create.Sketch | undefined> {
-    let url;
-    if (opt.id) {
-      url = new URL(`${this.domain()}/sketches/byID/${opt.id}`);
-    } else if (opt.path) {
-      url = new URL(`${this.domain()}/sketches/byPath${opt.path}`);
-    } else {
-      return;
-    }
+  async sketch(id: string): Promise<Create.Sketch | undefined> {
+    const url = new URL(`${this.domain()}/sketches/byID/${id}`);
 
     url.searchParams.set('user_id', 'me');
     const headers = await this.headers();
@@ -92,7 +70,7 @@ export class CreateApi {
       method: 'GET',
       headers,
     });
-    sketchCache = result.sketches;
+    result.sketches.forEach((sketch) => this.sketchCache.addSketch(sketch));
     return result.sketches;
   }
 
@@ -118,7 +96,7 @@ export class CreateApi {
 
   async readDirectory(
     posixPath: string,
-    options: { recursive?: boolean; match?: string; secrets?: boolean } = {}
+    options: { recursive?: boolean; match?: string } = {}
   ): Promise<Create.Resource[]> {
     const url = new URL(
       `${this.domain()}/files/d/$HOME/sketches_v2${posixPath}`
@@ -131,58 +109,21 @@ export class CreateApi {
     }
     const headers = await this.headers();
 
-    const sketchProm = options.secrets
-      ? this.sketches()
-      : Promise.resolve(sketchCache);
+    return this.run<Create.RawResource[]>(url, {
+      method: 'GET',
+      headers,
+    })
+      .then(async (result) => {
+        // add arduino_secrets.h to the results, when reading a sketch main folder
+        if (posixPath.length && posixPath !== posix.sep) {
+          const sketch = this.sketchCache.getSketch(posixPath);
 
-    return Promise.all([
-      this.run<Create.RawResource[]>(url, {
-        method: 'GET',
-        headers,
-      }),
-      sketchProm,
-    ])
-      .then(async ([result, sketches]) => {
-        if (options.secrets) {
-          // for every sketch with secrets, create a fake arduino_secrets.h
-          result.forEach(async (res) => {
-            if (res.type !== 'sketch') {
-              return;
-            }
-
-            const [, spath] = createPaths.splitSketchPath(res.path);
-            const sketch = await this.findSketchInCache(
-              this.sketchCompareByPath(spath)
-            );
-            if (sketch && sketch.secrets && sketch.secrets.length > 0) {
-              result.push(this.getSketchSecretStat(sketch));
-            }
-          });
-
-          if (posixPath !== posix.sep) {
-            const sketch = await this.findSketchInCache(
-              this.sketchCompareByPath(posixPath)
-            );
-            if (sketch && sketch.secrets && sketch.secrets.length > 0) {
-              result.push(this.getSketchSecretStat(sketch));
-            }
+          if (sketch && sketch.secrets && sketch.secrets.length > 0) {
+            result.push(this.getSketchSecretStat(sketch));
           }
         }
-        const sketchesMap: Record<string, Create.Sketch> = sketches.reduce(
-          (prev, curr) => {
-            return { ...prev, [curr.path]: curr };
-          },
-          {}
-        );
 
-        // add the sketch id and isPublic to the resource
-        return result.map((resource) => {
-          return {
-            ...resource,
-            sketchId: sketchesMap[resource.path]?.id || '',
-            isPublic: sketchesMap[resource.path]?.is_public || false,
-          };
-        });
+        return result;
       })
       .catch((reason) => {
         if (reason?.status === 404) return [] as Create.Resource[];
@@ -214,18 +155,16 @@ export class CreateApi {
 
     let resources;
     if (basename === Create.arduino_secrets_file) {
-      const sketch = await this.findSketchInCache(
-        this.sketchCompareByPath(parentPosixPath)
-      );
+      const sketch = this.sketchCache.getSketch(parentPosixPath);
       resources = sketch ? [this.getSketchSecretStat(sketch)] : [];
     } else {
       resources = await this.readDirectory(parentPosixPath, {
         match: basename,
       });
     }
-
-    resources.sort((left, right) => left.path.length - right.path.length);
-    const resource = resources.find(({ name }) => name === basename);
+    const resource = resources.find(
+      ({ path }) => createPaths.splitSketchPath(path)[1] === posixPath
+    );
     if (!resource) {
       throw new CreateError(`Not found: ${posixPath}.`, 404);
     }
@@ -248,10 +187,7 @@ export class CreateApi {
         return data;
       }
 
-      const sketch = await this.findSketchInCache((sketch) => {
-        const [, spath] = splitSketchPath(sketch.path);
-        return spath === createPaths.parentPosix(path);
-      }, true);
+      const sketch = this.sketchCache.getSketch(createPaths.parentPosix(path));
 
       if (
         sketch &&
@@ -273,14 +209,25 @@ export class CreateApi {
 
     if (basename === Create.arduino_secrets_file) {
       const parentPosixPath = createPaths.parentPosix(posixPath);
-      const sketch = await this.findSketchInCache(
-        this.sketchCompareByPath(parentPosixPath),
-        false
-      );
+
+      //retrieve the sketch id from the cache
+      const cacheSketch = this.sketchCache.getSketch(parentPosixPath);
+      if (!cacheSketch) {
+        throw new Error(`Unable to find sketch ${parentPosixPath} in cache`);
+      }
+
+      // get a fresh copy of the sketch in order to guarantee fresh secrets
+      const sketch = await this.sketch(cacheSketch.id);
+      if (!sketch) {
+        throw new Error(
+          `Unable to get a fresh copy of the sketch ${cacheSketch.id}`
+        );
+      }
+      this.sketchCache.addSketch(sketch);
 
       let file = '';
       if (sketch && sketch.secrets) {
-        for (const item of sketch?.secrets) {
+        for (const item of sketch.secrets) {
           file += `#define ${item.name} "${item.value}"\r\n`;
         }
       }
@@ -310,9 +257,9 @@ export class CreateApi {
 
     if (basename === Create.arduino_secrets_file) {
       const parentPosixPath = createPaths.parentPosix(posixPath);
-      const sketch = await this.findSketchInCache(
-        this.sketchCompareByPath(parentPosixPath)
-      );
+
+      const sketch = this.sketchCache.getSketch(parentPosixPath);
+
       if (sketch) {
         const url = new URL(`${this.domain()}/sketches/${sketch.id}`);
         const headers = await this.headers();
@@ -357,8 +304,7 @@ export class CreateApi {
         };
 
         // replace the sketch in the cache, so other calls will not overwrite each other
-        sketchCache = sketchCache.filter((skt) => skt.id !== sketch.id);
-        sketchCache.push({ ...sketch, secrets });
+        this.sketchCache.addSketch(sketch);
 
         const init = {
           method: 'POST',
@@ -543,8 +489,9 @@ export namespace Create {
      */
     readonly path: string;
     readonly type: ResourceType;
-    readonly sketchId: string;
+    readonly sketchId?: string;
     readonly modified_at: string; // As an ISO-8601 formatted string: `YYYY-MM-DDTHH:mm:ss.sssZ`
+    readonly created_at: string; // As an ISO-8601 formatted string: `YYYY-MM-DDTHH:mm:ss.sssZ`
     readonly children?: number; // For 'sketch' and 'folder' types.
     readonly size?: number; // For 'sketch' type only.
     readonly isPublic?: boolean; // For 'sketch' type only.

--- a/arduino-ide-extension/src/browser/create/create-fs-provider.ts
+++ b/arduino-ide-extension/src/browser/create/create-fs-provider.ts
@@ -24,10 +24,11 @@ import {
   FileServiceContribution,
 } from '@theia/filesystem/lib/browser/file-service';
 import { AuthenticationClientService } from '../auth/authentication-client-service';
-import { Create, CreateApi } from './create-api';
+import { CreateApi } from './create-api';
 import { CreateUri } from './create-uri';
 import { SketchesService } from '../../common/protocol';
 import { ArduinoPreferences } from '../arduino-preferences';
+import { Create } from './typings';
 
 export const REMOTE_ONLY_FILES = ['sketch.json'];
 

--- a/arduino-ide-extension/src/browser/create/create-fs-provider.ts
+++ b/arduino-ide-extension/src/browser/create/create-fs-provider.ts
@@ -106,10 +106,7 @@ export class CreateFsProvider
 
   async readdir(uri: URI): Promise<[string, FileType][]> {
     const resources = await this.getCreateApi.readDirectory(
-      uri.path.toString(),
-      {
-        secrets: true,
-      }
+      uri.path.toString()
     );
     return resources
       .filter((res) => !REMOTE_ONLY_FILES.includes(res.name))

--- a/arduino-ide-extension/src/browser/create/create-uri.ts
+++ b/arduino-ide-extension/src/browser/create/create-uri.ts
@@ -1,7 +1,7 @@
 import { URI as Uri } from 'vscode-uri';
 import URI from '@theia/core/lib/common/uri';
-import { Create } from './create-api';
 import { toPosixPath, parentPosix, posix } from './create-paths';
+import { Create } from './typings';
 
 export namespace CreateUri {
   export const scheme = 'arduino-create';

--- a/arduino-ide-extension/src/browser/create/typings.ts
+++ b/arduino-ide-extension/src/browser/create/typings.ts
@@ -1,0 +1,73 @@
+export namespace Create {
+  export interface Sketch {
+    readonly name: string;
+    readonly path: string;
+    readonly modified_at: string;
+    readonly created_at: string;
+
+    readonly secrets?: { name: string; value: string }[];
+
+    readonly id: string;
+    readonly is_public: boolean;
+    readonly board_fqbn: '';
+    readonly board_name: '';
+    readonly board_type: 'serial' | 'network' | 'cloud' | '';
+    readonly href?: string;
+    readonly libraries: string[];
+    readonly tutorials: string[] | null;
+    readonly types: string[] | null;
+    readonly user_id: string;
+  }
+
+  export type ResourceType = 'sketch' | 'folder' | 'file';
+  export const arduino_secrets_file = 'arduino_secrets.h';
+  export const do_not_sync_files = ['.theia'];
+  export interface Resource {
+    readonly name: string;
+    /**
+     * Note: this path is **not** the POSIX path we use. It has the leading segments with the `user_id`.
+     */
+    readonly path: string;
+    readonly type: ResourceType;
+    readonly sketchId?: string;
+    readonly modified_at: string; // As an ISO-8601 formatted string: `YYYY-MM-DDTHH:mm:ss.sssZ`
+    readonly created_at: string; // As an ISO-8601 formatted string: `YYYY-MM-DDTHH:mm:ss.sssZ`
+    readonly children?: number; // For 'sketch' and 'folder' types.
+    readonly size?: number; // For 'sketch' type only.
+    readonly isPublic?: boolean; // For 'sketch' type only.
+
+    readonly mimetype?: string; // For 'file' type.
+    readonly href?: string;
+  }
+  export namespace Resource {
+    export function is(arg: any): arg is Resource {
+      return (
+        !!arg &&
+        'name' in arg &&
+        typeof arg['name'] === 'string' &&
+        'path' in arg &&
+        typeof arg['path'] === 'string' &&
+        'type' in arg &&
+        typeof arg['type'] === 'string' &&
+        'modified_at' in arg &&
+        typeof arg['modified_at'] === 'string' &&
+        (arg['type'] === 'sketch' ||
+          arg['type'] === 'folder' ||
+          arg['type'] === 'file')
+      );
+    }
+  }
+
+  export type RawResource = Omit<Resource, 'sketchId' | 'isPublic'>;
+}
+
+export class CreateError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly details?: string
+  ) {
+    super(message);
+    Object.setPrototypeOf(this, CreateError.prototype);
+  }
+}

--- a/arduino-ide-extension/src/browser/local-cache/local-cache-fs-provider.ts
+++ b/arduino-ide-extension/src/browser/local-cache/local-cache-fs-provider.ts
@@ -103,7 +103,7 @@ export class LocalCacheFsProvider
     });
   }
 
-  private get currentUserUri(): URI {
+  public get currentUserUri(): URI {
     const { session } = this.authenticationService;
     if (!session) {
       throw new FileSystemProviderError(

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketch-cache.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketch-cache.ts
@@ -1,0 +1,34 @@
+import { FileStat } from '@theia/filesystem/lib/common/files';
+import { injectable } from 'inversify';
+import { Create } from '../../create/create-api';
+import { toPosixPath } from '../../create/create-paths';
+
+@injectable()
+export class SketchCache {
+  sketches: Record<string, Create.Sketch> = {};
+  filestats: Record<string, FileStat> = {};
+
+  init(): void {
+    // reset the data
+    this.sketches = {};
+    this.filestats = {};
+  }
+
+  addItem(item: FileStat): void {
+    this.filestats[item.resource.path.toString()] = item;
+  }
+
+  getItem(path: string): FileStat | null {
+    return this.filestats[path] || null;
+  }
+
+  addSketch(sketch: Create.Sketch): void {
+    const { path } = sketch;
+    const posixPath = toPosixPath(path);
+    this.sketches[posixPath] = sketch;
+  }
+
+  getSketch(path: string): Create.Sketch | null {
+    return this.sketches[path] || null;
+  }
+}

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketch-cache.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketch-cache.ts
@@ -1,25 +1,25 @@
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { injectable } from 'inversify';
-import { Create } from '../../create/create-api';
 import { toPosixPath } from '../../create/create-paths';
+import { Create } from '../../create/typings';
 
 @injectable()
 export class SketchCache {
   sketches: Record<string, Create.Sketch> = {};
-  filestats: Record<string, FileStat> = {};
+  fileStats: Record<string, FileStat> = {};
 
   init(): void {
     // reset the data
     this.sketches = {};
-    this.filestats = {};
+    this.fileStats = {};
   }
 
   addItem(item: FileStat): void {
-    this.filestats[item.resource.path.toString()] = item;
+    this.fileStats[item.resource.path.toString()] = item;
   }
 
   getItem(path: string): FileStat | null {
-    return this.filestats[path] || null;
+    return this.fileStats[path] || null;
   }
 
   addSketch(sketch: Create.Sketch): void {

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-composite-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-composite-widget.tsx
@@ -35,6 +35,10 @@ export class CloudSketchbookCompositeWidget extends BaseWidget {
     this.id = 'cloud-sketchbook-composite-widget';
   }
 
+  public getTreeWidget(): CloudSketchbookTreeWidget {
+    return this.cloudSketchbookTreeWidget;
+  }
+
   protected onAfterAttach(message: Message): void {
     super.onAfterAttach(message);
     Widget.attach(this.cloudSketchbookTreeWidget, this.compositeNode);

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-contributions.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-contributions.ts
@@ -166,11 +166,11 @@ export class CloudSketchbookContribution extends Contribution {
       isEnabled: (arg) =>
         CloudSketchbookCommands.Arg.is(arg) &&
         CloudSketchbookTree.CloudSketchDirNode.is(arg.node) &&
-        !!arg.node.synced,
+        CloudSketchbookTree.CloudSketchTreeNode.isSynced(arg.node),
       isVisible: (arg) =>
         CloudSketchbookCommands.Arg.is(arg) &&
         CloudSketchbookTree.CloudSketchDirNode.is(arg.node) &&
-        !!arg.node.synced,
+        CloudSketchbookTree.CloudSketchTreeNode.isSynced(arg.node),
     });
 
     registry.registerCommand(CloudSketchbookCommands.OPEN_IN_CLOUD_EDITOR, {
@@ -257,18 +257,10 @@ export class CloudSketchbookContribution extends Contribution {
 
           const currentSketch = await this.sketchServiceClient.currentSketch();
 
-          const localUri = await arg.model.cloudSketchbookTree.localUri(
-            arg.node
-          );
-          let underlying = null;
-          if (arg.node && localUri) {
-            underlying = await this.fileService.toUnderlyingResource(localUri);
-          }
-
           // disable the "open sketch" command for the current sketch and for those not in sync
           if (
-            !underlying ||
-            (currentSketch && currentSketch.uri === underlying.toString())
+            !CloudSketchbookTree.CloudSketchTreeNode.isSynced(arg.node) ||
+            (currentSketch && currentSketch.uri === arg.node.uri.toString())
           ) {
             const placeholder = new PlaceholderMenuNode(
               SKETCHBOOKSYNC__CONTEXT__MAIN_GROUP,
@@ -284,7 +276,6 @@ export class CloudSketchbookContribution extends Contribution {
               )
             );
           } else {
-            arg.node.uri = localUri;
             this.menuRegistry.registerMenuAction(
               SKETCHBOOKSYNC__CONTEXT__MAIN_GROUP,
               {

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-model.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-model.ts
@@ -1,66 +1,59 @@
 import { inject, injectable, postConstruct } from 'inversify';
 import { TreeNode } from '@theia/core/lib/browser/tree';
-import { toPosixPath, posixSegments, posix } from '../../create/create-paths';
+import { posixSegments, splitSketchPath } from '../../create/create-paths';
 import { CreateApi, Create } from '../../create/create-api';
 import { CloudSketchbookTree } from './cloud-sketchbook-tree';
 import { AuthenticationClientService } from '../../auth/authentication-client-service';
-import {
-  LocalCacheFsProvider,
-  LocalCacheUri,
-} from '../../local-cache/local-cache-fs-provider';
-import { CommandRegistry } from '@theia/core/lib/common/command';
 import { SketchbookTreeModel } from '../sketchbook/sketchbook-tree-model';
 import { ArduinoPreferences } from '../../arduino-preferences';
-import { ConfigService } from '../../../common/protocol';
+import { WorkspaceNode } from '@theia/navigator/lib/browser/navigator-tree';
+import { CreateUri } from '../../create/create-uri';
+import { FileStat } from '@theia/filesystem/lib/common/files';
+import { LocalCacheFsProvider } from '../../local-cache/local-cache-fs-provider';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import URI from '@theia/core/lib/common/uri';
 
-export type CreateCache = Record<string, Create.Resource>;
-export namespace CreateCache {
-  export function build(resources: Create.Resource[]): CreateCache {
-    const treeData: CreateCache = {};
-    treeData[posix.sep] = CloudSketchbookTree.rootResource;
-    for (const resource of resources) {
-      const { path } = resource;
-      const posixPath = toPosixPath(path);
-      if (treeData[posixPath] !== undefined) {
-        throw new Error(
-          `Already visited resource for path: ${posixPath}.\nData: ${JSON.stringify(
-            treeData,
-            null,
-            2
-          )}`
-        );
-      }
-      treeData[posixPath] = resource;
-    }
-    return treeData;
+export function sketchBaseDir(sketch: Create.Sketch): FileStat {
+  // extract the sketch path
+  const [, path] = splitSketchPath(sketch.path);
+  const dirs = posixSegments(path);
+
+  const mtime = Date.parse(sketch.modified_at);
+  const ctime = Date.parse(sketch.created_at);
+  const createPath = CreateUri.toUri(dirs[0]);
+  const baseDir: FileStat = {
+    name: dirs[0],
+    isDirectory: true,
+    isFile: false,
+    isSymbolicLink: false,
+    resource: createPath,
+    mtime,
+    ctime,
+  };
+  return baseDir;
+}
+
+export function sketchesToFileStats(sketches: Create.Sketch[]): FileStat[] {
+  const sketchesBaseDirs: Record<string, FileStat> = {};
+
+  for (const sketch of sketches) {
+    const sketchBaseDirFileStat = sketchBaseDir(sketch);
+    sketchesBaseDirs[sketchBaseDirFileStat.resource.toString()] =
+      sketchBaseDirFileStat;
   }
 
-  export function childrenOf(
-    resource: Create.Resource,
-    cache: CreateCache
-  ): Create.Resource[] | undefined {
-    if (resource.type === 'file') {
-      return undefined;
-    }
-    const posixPath = toPosixPath(resource.path);
-    const childSegmentCount = posixSegments(posixPath).length + 1;
-    return Object.keys(cache)
-      .filter(
-        (key) =>
-          key.startsWith(posixPath) &&
-          posixSegments(key).length === childSegmentCount
-      )
-      .map((childPosixPath) => cache[childPosixPath]);
-  }
+  return Object.keys(sketchesBaseDirs).map(
+    (dirUri) => sketchesBaseDirs[dirUri]
+  );
 }
 
 @injectable()
 export class CloudSketchbookTreeModel extends SketchbookTreeModel {
+  @inject(FileService)
+  protected readonly fileService: FileService;
+
   @inject(AuthenticationClientService)
   protected readonly authenticationService: AuthenticationClientService;
-
-  @inject(ConfigService)
-  protected readonly configService: ConfigService;
 
   @inject(CreateApi)
   protected readonly createApi: CreateApi;
@@ -68,14 +61,11 @@ export class CloudSketchbookTreeModel extends SketchbookTreeModel {
   @inject(CloudSketchbookTree)
   protected readonly cloudSketchbookTree: CloudSketchbookTree;
 
-  @inject(LocalCacheFsProvider)
-  protected readonly localCacheFsProvider: LocalCacheFsProvider;
-
-  @inject(CommandRegistry)
-  public readonly commandRegistry: CommandRegistry;
-
   @inject(ArduinoPreferences)
   protected readonly arduinoPreferences: ArduinoPreferences;
+
+  @inject(LocalCacheFsProvider)
+  protected readonly localCacheFsProvider: LocalCacheFsProvider;
 
   @postConstruct()
   protected init(): void {
@@ -85,56 +75,25 @@ export class CloudSketchbookTreeModel extends SketchbookTreeModel {
     );
   }
 
-  async updateRoot(): Promise<void> {
+  async createRoot(): Promise<TreeNode | undefined> {
     const { session } = this.authenticationService;
     if (!session) {
       this.tree.root = undefined;
       return;
     }
     this.createApi.init(this.authenticationService, this.arduinoPreferences);
-
-    const resources = await this.createApi.readDirectory(posix.sep, {
-      recursive: true,
-      secrets: true,
-    });
-
-    const cache = CreateCache.build(resources);
-
-    // also read local files
-    for await (const path of Object.keys(cache)) {
-      if (cache[path].type === 'sketch') {
-        const localUri = LocalCacheUri.root.resolve(path);
-        const exists = await this.fileService.exists(localUri);
-        if (exists) {
-          const fileStat = await this.fileService.resolve(localUri);
-          // add every missing file
-          fileStat.children
-            ?.filter(
-              (child) =>
-                !Object.keys(cache).includes(path + posix.sep + child.name)
-            )
-            .forEach((child) => {
-              const localChild: Create.Resource = {
-                modified_at: '',
-                href: cache[path].href + posix.sep + child.name,
-                mimetype: '',
-                name: child.name,
-                path: cache[path].path + posix.sep + child.name,
-                sketchId: '',
-                type: child.isFile ? 'file' : 'folder',
-              };
-              cache[path + posix.sep + child.name] = localChild;
-            });
-        }
+    this.createApi.wipeCache();
+    const sketches = await this.createApi.sketches();
+    const rootFileStats = sketchesToFileStats(sketches);
+    if (this.workspaceService.opened) {
+      const workspaceNode = WorkspaceNode.createRoot('Remote');
+      for await (const stat of rootFileStats) {
+        workspaceNode.children.push(
+          await this.tree.createWorkspaceRoot(stat, workspaceNode)
+        );
       }
+      return workspaceNode;
     }
-
-    const showAllFiles =
-      this.arduinoPreferences['arduino.sketchbook.showAllFiles'];
-    this.tree.root = CloudSketchbookTree.CloudRootNode.create(
-      cache,
-      showAllFiles
-    );
   }
 
   sketchbookTree(): CloudSketchbookTree {
@@ -143,9 +102,6 @@ export class CloudSketchbookTreeModel extends SketchbookTreeModel {
 
   protected recursivelyFindSketchRoot(node: TreeNode): any {
     if (node && CloudSketchbookTree.CloudSketchDirNode.is(node)) {
-      if (node.hasOwnProperty('underlying')) {
-        return { ...node, uri: node.underlying };
-      }
       return node;
     }
 
@@ -155,5 +111,16 @@ export class CloudSketchbookTreeModel extends SketchbookTreeModel {
 
     // can't find a root, return false
     return false;
+  }
+
+  async revealFile(uri: URI): Promise<TreeNode | undefined> {
+    // we use remote uris as keys for the tree
+    // convert local URIs
+    const remoteuri = this.localCacheFsProvider.from(uri);
+    if (remoteuri) {
+      return super.revealFile(remoteuri);
+    } else {
+      return super.revealFile(uri);
+    }
   }
 }

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-model.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-model.ts
@@ -1,7 +1,7 @@
 import { inject, injectable, postConstruct } from 'inversify';
 import { TreeNode } from '@theia/core/lib/browser/tree';
 import { posixSegments, splitSketchPath } from '../../create/create-paths';
-import { CreateApi, Create } from '../../create/create-api';
+import { CreateApi } from '../../create/create-api';
 import { CloudSketchbookTree } from './cloud-sketchbook-tree';
 import { AuthenticationClientService } from '../../auth/authentication-client-service';
 import { SketchbookTreeModel } from '../sketchbook/sketchbook-tree-model';
@@ -12,6 +12,8 @@ import { FileStat } from '@theia/filesystem/lib/common/files';
 import { LocalCacheFsProvider } from '../../local-cache/local-cache-fs-provider';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import URI from '@theia/core/lib/common/uri';
+import { SketchCache } from './cloud-sketch-cache';
+import { Create } from '../../create/typings';
 
 export function sketchBaseDir(sketch: Create.Sketch): FileStat {
   // extract the sketch path
@@ -67,6 +69,9 @@ export class CloudSketchbookTreeModel extends SketchbookTreeModel {
   @inject(LocalCacheFsProvider)
   protected readonly localCacheFsProvider: LocalCacheFsProvider;
 
+  @inject(SketchCache)
+  protected readonly sketchCache: SketchCache;
+
   @postConstruct()
   protected init(): void {
     super.init();
@@ -82,7 +87,7 @@ export class CloudSketchbookTreeModel extends SketchbookTreeModel {
       return;
     }
     this.createApi.init(this.authenticationService, this.arduinoPreferences);
-    this.createApi.wipeCache();
+    this.sketchCache.init();
     const sketches = await this.createApi.sketches();
     const rootFileStats = sketchesToFileStats(sketches);
     if (this.workspaceService.opened) {

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-widget.tsx
@@ -91,7 +91,7 @@ export class CloudSketchbookTreeWidget extends SketchbookTreeWidget {
       CloudSketchbookTree.CloudSketchDirNode.is(node) &&
       node.commands &&
       (node.id === this.hoveredNodeId ||
-        this.currentSketchUri === node.underlying?.toString())
+        this.currentSketchUri === node.uri.toString())
     ) {
       return Array.from(new Set(node.commands)).map((command) =>
         this.renderInlineCommand(command.id, node)
@@ -135,37 +135,17 @@ export class CloudSketchbookTreeWidget extends SketchbookTreeWidget {
     );
   }
 
-  protected async handleClickEvent(
-    node: any,
+  protected handleDblClickEvent(
+    node: TreeNode,
     event: React.MouseEvent<HTMLElement>
-  ) {
+  ): void {
     event.persist();
 
-    let uri = node.uri;
-    // overwrite the uri using the local-cache
-    const localUri = await this.cloudSketchbookTree.localUri(node);
-    if (node && localUri) {
-      const underlying = await this.fileService.toUnderlyingResource(localUri);
-      uri = underlying;
-    }
-
-    super.handleClickEvent({ ...node, uri }, event);
-  }
-
-  protected async handleDblClickEvent(
-    node: any,
-    event: React.MouseEvent<HTMLElement>
-  ) {
-    event.persist();
-
-    let uri = node.uri;
-    // overwrite the uri using the local-cache
-    // if the localURI does not exists, ignore the double click, so that the sketch is not opened
-    const localUri = await this.cloudSketchbookTree.localUri(node);
-    if (node && localUri) {
-      const underlying = await this.fileService.toUnderlyingResource(localUri);
-      uri = underlying;
-      super.handleDblClickEvent({ ...node, uri }, event);
+    if (
+      CloudSketchbookTree.CloudSketchTreeNode.is(node) &&
+      CloudSketchbookTree.CloudSketchTreeNode.isSynced(node)
+    ) {
+      super.handleDblClickEvent(node, event);
     }
   }
 }

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-widget.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-widget.ts
@@ -16,6 +16,15 @@ export class CloudSketchbookWidget extends SketchbookWidget {
     super.init();
   }
 
+  getTreeWidget(): any {
+    const widget: any = this.sketchbookTreesContainer.selectedWidgets().next();
+
+    if (widget && typeof widget.getTreeWidget !== 'undefined') {
+      return (widget as CloudSketchbookCompositeWidget).getTreeWidget();
+    }
+    return widget;
+  }
+
   checkCloudEnabled() {
     if (this.arduinoPreferences['arduino.cloud.enabled']) {
       this.sketchbookTreesContainer.activateWidget(this.widget);

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree.ts
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree.ts
@@ -1,22 +1,17 @@
 import { inject, injectable } from 'inversify';
-import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { Command } from '@theia/core/lib/common/command';
 import { CompositeTreeNode, TreeNode } from '@theia/core/lib/browser/tree';
 import { DirNode, FileStatNode } from '@theia/filesystem/lib/browser/file-tree';
 import { SketchesService } from '../../../common/protocol';
-import { FileStat } from '@theia/filesystem/lib/common/files';
 import { SketchbookCommands } from './sketchbook-commands';
 import {
   FileNavigatorTree,
-  WorkspaceNode,
+  WorkspaceRootNode,
 } from '@theia/navigator/lib/browser/navigator-tree';
 import { ArduinoPreferences } from '../../arduino-preferences';
 
 @injectable()
 export class SketchbookTree extends FileNavigatorTree {
-  @inject(LabelProvider)
-  protected readonly labelProvider: LabelProvider;
-
   @inject(SketchesService)
   protected readonly sketchesService: SketchesService;
 
@@ -27,61 +22,71 @@ export class SketchbookTree extends FileNavigatorTree {
     const showAllFiles =
       this.arduinoPreferences['arduino.sketchbook.showAllFiles'];
 
-    const children = (
-      await Promise.all(
-        (
-          await super.resolveChildren(parent)
-        ).map((node) => this.maybeDecorateNode(node, showAllFiles))
-      )
-    ).filter((node) => {
-      // filter out hidden nodes
-      if (DirNode.is(node) || FileStatNode.is(node)) {
-        return node.fileStat.name.indexOf('.') !== 0;
+    const children = (await super.resolveChildren(parent)).filter((child) => {
+      // strip libraries and hardware directories
+      if (
+        DirNode.is(child) &&
+        ['libraries', 'hardware'].includes(child.fileStat.name) &&
+        WorkspaceRootNode.is(child.parent)
+      ) {
+        return false;
       }
+
+      // strip files if only directories are admitted
+      if (!DirNode.is(child) && !showAllFiles) {
+        return false;
+      }
+
+      // strip hidden files
+      if (FileStatNode.is(child) && child.fileStat.name.indexOf('.') === 0) {
+        return false;
+      }
+
       return true;
     });
 
-    // filter out hardware and libraries
-    if (WorkspaceNode.is(parent.parent)) {
-      return children
-        .filter(DirNode.is)
-        .filter(
-          (node) =>
-            ['libraries', 'hardware'].indexOf(
-              this.labelProvider.getName(node)
-            ) === -1
-        );
+    if (children.length === 0) {
+      delete (parent as any).expanded;
     }
 
-    // return the Arduino directory containing all user sketches
-    if (WorkspaceNode.is(parent)) {
-      return children;
-    }
-
-    return children;
-    // return this.filter.filter(super.resolveChildren(parent));
+    return await Promise.all(
+      children.map(
+        async (childNode) => await this.decorateNode(childNode, showAllFiles)
+      )
+    );
   }
 
-  protected async maybeDecorateNode(
+  protected async isSketchNode(node: DirNode): Promise<boolean> {
+    const sketch = await this.sketchesService.maybeLoadSketch(
+      node.uri.toString()
+    );
+    return !!sketch;
+  }
+
+  /**
+   * Add commands available for the given node
+   * @param node
+   * @returns
+   */
+  protected async augmentSketchNode(node: DirNode): Promise<void> {
+    Object.assign(node, {
+      type: 'sketch',
+      commands: [SketchbookCommands.OPEN_SKETCHBOOK_CONTEXT_MENU],
+    });
+  }
+
+  protected async decorateNode(
     node: TreeNode,
     showAllFiles: boolean
   ): Promise<TreeNode> {
-    if (DirNode.is(node)) {
-      const sketch = await this.sketchesService.maybeLoadSketch(
-        node.uri.toString()
-      );
-      if (sketch) {
-        Object.assign(node, {
-          type: 'sketch',
-          commands: [SketchbookCommands.OPEN_SKETCHBOOK_CONTEXT_MENU],
-        });
-        if (!showAllFiles) {
-          delete (node as any).expanded;
-          node.children = [];
-        } else {
-          node.expanded = false;
-        }
-        return node;
+    if (DirNode.is(node) && (await this.isSketchNode(node))) {
+      await this.augmentSketchNode(node);
+
+      if (!showAllFiles) {
+        delete (node as any).expanded;
+        (node as any).children = [];
+      } else {
+        (node as any).expanded = false;
       }
     }
     return node;
@@ -89,25 +94,6 @@ export class SketchbookTree extends FileNavigatorTree {
 }
 
 export namespace SketchbookTree {
-  export interface RootNode extends DirNode {
-    readonly showAllFiles: boolean;
-  }
-  export namespace RootNode {
-    export function is(node: TreeNode & Partial<RootNode>): node is RootNode {
-      return typeof node.showAllFiles === 'boolean';
-    }
-
-    export function create(
-      fileStat: FileStat,
-      showAllFiles: boolean
-    ): RootNode {
-      return Object.assign(DirNode.createRoot(fileStat), {
-        showAllFiles,
-        visible: false,
-      });
-    }
-  }
-
   export interface SketchDirNode extends DirNode {
     readonly type: 'sketch';
     readonly commands?: Command[];

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget-contribution.ts
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget-contribution.ts
@@ -100,10 +100,7 @@ export class SketchbookWidgetContribution
 
     registry.registerCommand(SketchbookCommands.OPEN_NEW_WINDOW, {
       execute: async (arg) => {
-        const underlying = await this.fileService.toUnderlyingResource(
-          arg.node.uri
-        );
-        return this.workspaceService.open(underlying);
+        return this.workspaceService.open(arg.node.uri);
       },
       isEnabled: (arg) =>
         !!arg && 'node' in arg && SketchbookTree.SketchDirNode.is(arg.node),
@@ -214,7 +211,8 @@ export class SketchbookWidgetContribution
     if (Navigatable.is(widget)) {
       const resourceUri = widget.getResourceUri();
       if (resourceUri) {
-        const { model } = (await this.widget).getTreeWidget();
+        const treeWidget = (await this.widget).getTreeWidget();
+        const { model } = treeWidget;
         const node = await model.revealFile(resourceUri);
         if (SelectableTreeNode.is(node)) {
           model.selectNode(node);


### PR DESCRIPTION
## Why
A major re-design of the sketchbook tree is needed in order to enable a number of features.

## What to expect
- improved performances when refreshing the sketch tree. Resources are now loaded *on demand* meaning you will notice a short delay when opening a directory for the first time. A caching system is in place in order to make subsequent actions more quick
- The sketchbook tree highlights the file currently marked as "active" in the editor. The containing folders are automatically expanded if closed, in order to help the users immediately see the location of the files they are working on
- Creating a file in the local file system automatically adds it to the sketchbook tree and make it selectable. This is required in order to allow creation/removal/rename of files in the "local copy" of a remote sketchbook
- overall performance improvements: mapping between remote sketches and local files is done once, as soon as the cache is generated. This ensures less access to the fileSystem and hence a snappier experience of the feature