### PR TITLE
[ATL-493] Support platforms installed in directories.user

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -178,12 +178,14 @@ PID: ${PID}`;
 
     // Installed boards
     for (const board of installedBoards) {
-      const { packageId, packageName, fqbn, name } = board;
+      const { packageId, packageName, fqbn, name, manuallyInstalled } = board;
 
+      const packageLabel =
+        packageName + `${manuallyInstalled ? ' (in Sketchbook)' : ''}`;
       // Platform submenu
       const platformMenuPath = [...boardsPackagesGroup, packageId];
       // Note: Registering the same submenu twice is a noop. No need to group the boards per platform.
-      this.menuModelRegistry.registerSubmenu(platformMenuPath, packageName);
+      this.menuModelRegistry.registerSubmenu(platformMenuPath, packageLabel);
 
       const id = `arduino-select-board--${fqbn}`;
       const command = { id };

--- a/arduino-ide-extension/src/common/protocol/boards-service.ts
+++ b/arduino-ide-extension/src/common/protocol/boards-service.ts
@@ -345,6 +345,7 @@ export interface Board {
 export interface BoardWithPackage extends Board {
   readonly packageName: string;
   readonly packageId: string;
+  readonly manuallyInstalled: boolean;
 }
 export namespace BoardWithPackage {
   export function is(
@@ -527,6 +528,7 @@ export namespace Board {
       packageName: string;
       packageId: string;
       details?: string;
+      manuallyInstalled: boolean;
     }>;
   export function decorateBoards(
     selectedBoard: Board | undefined,

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -233,6 +233,7 @@ export class BoardsServiceImpl
               fqbn: board.getFqbn(),
               packageId: platform.getId(),
               packageName: platform.getName(),
+              manuallyInstalled: platform.getManuallyInstalled(),
             });
           }
         }


### PR DESCRIPTION
Add `{in Sketchbook)` label to manually installed board packages.
Should solve #126 