### PR TITLE
[ATL-1570] Install core notification not to appear on board unplug

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-auto-installer.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-auto-installer.ts
@@ -44,9 +44,10 @@ export class BoardsAutoInstaller implements FrontendApplicationContribution {
   }
 
   protected ensureCoreExists(config: BoardsConfig.Config): void {
-    const { selectedBoard } = config;
+    const { selectedBoard, selectedPort } = config;
     if (
       selectedBoard &&
+      selectedPort &&
       !this.notifications.find((board) => Board.sameAs(board, selectedBoard))
     ) {
       this.notifications.push(selectedBoard);


### PR DESCRIPTION
### Why
Currently, the event of "board selection" that activates the notification is triggered both by board selection and plug/unplug of the board.

This causes the notification to install Cores to be displayed in 3 scenarios:
- a board is selected
- a selected board is plugged in
- a selected board is plugged out

The latter event is confusing, as opening the notification when the board is not plugged is not desirable.


### How

Before showing the notification, check if the selected board is also connected to a port. If it's not connected it means it is unplugged and the notification should not be displayed