### PR TITLE
[ATL-1556] Sort board families in Tool menu

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -185,7 +185,9 @@ PID: ${PID}`;
       // Platform submenu
       const platformMenuPath = [...boardsPackagesGroup, packageId];
       // Note: Registering the same submenu twice is a noop. No need to group the boards per platform.
-      this.menuModelRegistry.registerSubmenu(platformMenuPath, packageLabel);
+      this.menuModelRegistry.registerSubmenu(platformMenuPath, packageLabel, {
+        order: packageName,
+      });
 
       const id = `arduino-select-board--${fqbn}`;
       const command = { id };


### PR DESCRIPTION
### Why
Boards in the tool menu are not sorted properly, and make it difficult to select the right one when many platforms are installed.

### How
Add "order" option to the menu elements equal to the name of the platform, so that they are displayed alphabetically

### Taks
[Jira Task](https://arduino.atlassian.net/browse/ATL-1556)