### PR TITLE
[ATL-483] mac not to quit with all windows closed

### DIFF
--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -172,4 +172,13 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
   get windows(): BrowserWindow[] {
     return this._windows.slice();
   }
+
+  /**
+   * "Gently" close all windows, application will not stop if a `beforeunload` handler returns `false`.
+   */
+  requestStop(): void {
+    if (process.platform !== 'darwin') {
+      app.quit();
+    }
+  }
 }


### PR DESCRIPTION
### Why
As [reported](https://github.com/arduino/arduino-pro-ide/issues/334#issuecomment-688855191) closing the IDE when the last window is closed is an uncommon pattern in IDEs, and for good. This will enable opening projects from within the IDE2 even when no projects are currently open.

### How
Listen to quit event and close the application only if not running on macOS

[Jira task](https://arduino.atlassian.net/browse/ATL-483)