### PR TITLE
Translating Arduino-IDE using Theia's nls API

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -16,6 +16,7 @@ import {
   StatusBar,
   StatusBarAlignment,
 } from '@theia/core/lib/browser';
+import { nls } from '@theia/core/lib/browser/nls';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
 import { CommonMenus } from '@theia/core/lib/browser/common-frontend-contribution';
@@ -225,7 +226,10 @@ export class ArduinoFrontendContribution
     if (!window.navigator.onLine) {
       // tslint:disable-next-line:max-line-length
       this.messageService.warn(
-        'You appear to be offline. Without an Internet connection, the Arduino CLI might not be able to download the required resources and could cause malfunction. Please connect to the Internet and restart the application.'
+        nls.localize(
+          'arduino/common/offlineIndicator',
+          'You appear to be offline. Without an Internet connection, the Arduino CLI might not be able to download the required resources and could cause malfunction. Please connect to the Internet and restart the application.'
+        )
       );
     }
     const updateStatusBar = ({
@@ -236,15 +240,22 @@ export class ArduinoFrontendContribution
         alignment: StatusBarAlignment.RIGHT,
         text: selectedBoard
           ? `$(microchip) ${selectedBoard.name}`
-          : '$(close) no board selected',
+          : `$(close) ${nls.localize(
+              'arduino/common/noBoardSelected',
+              'No board selected'
+            )}`,
         className: 'arduino-selected-board',
       });
       if (selectedBoard) {
         this.statusBar.setElement('arduino-selected-port', {
           alignment: StatusBarAlignment.RIGHT,
           text: selectedPort
-            ? `on ${Port.toString(selectedPort)}`
-            : '[not connected]',
+            ? nls.localize(
+                'arduino/common/selectedOn',
+                'on {0}',
+                Port.toString(selectedPort)
+              )
+            : nls.localize('arduino/common/notConnected', '[not connected]'),
           className: 'arduino-selected-port',
         });
       }
@@ -437,7 +448,7 @@ export class ArduinoFrontendContribution
     registry.registerItem({
       id: 'toggle-serial-monitor',
       command: MonitorViewContribution.TOGGLE_SERIAL_MONITOR_TOOLBAR,
-      tooltip: 'Serial Monitor',
+      tooltip: nls.localize('arduino/common/serialMonitor', 'Serial Monitor'),
     });
   }
 
@@ -472,11 +483,20 @@ export class ArduinoFrontendContribution
     registry.getMenu(MAIN_MENU_BAR).removeNode(menuId(TerminalMenus.TERMINAL));
     registry.getMenu(MAIN_MENU_BAR).removeNode(menuId(CommonMenus.VIEW));
 
-    registry.registerSubmenu(ArduinoMenus.SKETCH, 'Sketch');
-    registry.registerSubmenu(ArduinoMenus.TOOLS, 'Tools');
+    registry.registerSubmenu(
+      ArduinoMenus.SKETCH,
+      nls.localize('arduino/menu/sketch', 'Sketch')
+    );
+    registry.registerSubmenu(
+      ArduinoMenus.TOOLS,
+      nls.localize('arduino/menu/tools', 'Tools')
+    );
     registry.registerMenuAction(ArduinoMenus.SKETCH__MAIN_GROUP, {
       commandId: ArduinoCommands.TOGGLE_COMPILE_FOR_DEBUG.id,
-      label: 'Optimize for Debugging',
+      label: nls.localize(
+        'arduino/debug/optimizeForDebugging',
+        'Optimize for Debugging'
+      ),
       order: '4',
     });
   }
@@ -490,11 +510,16 @@ export class ArduinoFrontendContribution
       }
       await this.ensureOpened(mainFileUri, true);
       if (mainFileUri.endsWith('.pde')) {
-        const message = `The '${sketch.name}' still uses the old \`.pde\` format. Do you want to switch to the new \`.ino\` extension?`;
+        const message = nls.localize(
+          'arduino/common/oldFormat',
+          "The '{0}' still uses the old `.pde` format. Do you want to switch to the new `.ino` extension?",
+          sketch.name
+        );
+        const yes = nls.localize('vscode/extensionsUtils/yes', 'Yes');
         this.messageService
-          .info(message, 'Later', 'Yes')
+          .info(message, nls.localize('arduino/common/later', 'Later'), yes)
           .then(async (answer) => {
-            if (answer === 'Yes') {
+            if (answer === yes) {
               this.commandRegistry.executeCommand(
                 SaveAsSketch.Commands.SAVE_AS_SKETCH.id,
                 {

--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -253,6 +253,7 @@ import {
   UploadCertificateDialogProps,
   UploadCertificateDialogWidget,
 } from './dialogs/certificate-uploader/certificate-uploader-dialog';
+import { nls } from '@theia/core/lib/browser/nls';
 
 const ElementQueries = require('css-element-queries/src/ElementQueries');
 
@@ -371,7 +372,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(BoardsConfigDialogWidget).toSelf().inSingletonScope();
   bind(BoardsConfigDialog).toSelf().inSingletonScope();
   bind(BoardsConfigDialogProps).toConstantValue({
-    title: 'Select Board',
+    title: nls.localize('arduino/common/selectBoard', 'Select Board'),
   });
 
   // Core service

--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -6,6 +6,7 @@ import {
   PreferenceContribution,
   PreferenceSchema,
 } from '@theia/core/lib/browser/preferences';
+import { nls } from '@theia/core/lib/browser/nls';
 import { CompilerWarningLiterals, CompilerWarnings } from '../common/protocol';
 
 export const ArduinoConfigSchema: PreferenceSchema = {
@@ -13,24 +14,34 @@ export const ArduinoConfigSchema: PreferenceSchema = {
   properties: {
     'arduino.language.log': {
       type: 'boolean',
-      description:
-        "True if the Arduino Language Server should generate log files into the sketch folder. Otherwise, false. It's false by default.",
+      description: nls.localize(
+        'arduino/preferences/language.log',
+        "True if the Arduino Language Server should generate log files into the sketch folder. Otherwise, false. It's false by default."
+      ),
       default: false,
     },
     'arduino.compile.verbose': {
       type: 'boolean',
-      description: 'True for verbose compile output. False by default',
+      description: nls.localize(
+        'arduino/preferences/compile.verbose',
+        'True for verbose compile output. False by default'
+      ),
       default: false,
     },
     'arduino.compile.warnings': {
       enum: [...CompilerWarningLiterals],
-      description:
-        "Tells gcc which warning level to use. It's 'None' by default",
+      description: nls.localize(
+        'arduino/preferences/compile.warnings',
+        "Tells gcc which warning level to use. It's 'None' by default"
+      ),
       default: 'None',
     },
     'arduino.upload.verbose': {
       type: 'boolean',
-      description: 'True for verbose upload output. False by default.',
+      description: nls.localize(
+        'arduino/preferences/upload.verbose',
+        'True for verbose upload output. False by default.'
+      ),
       default: false,
     },
     'arduino.upload.verify': {
@@ -39,81 +50,114 @@ export const ArduinoConfigSchema: PreferenceSchema = {
     },
     'arduino.window.autoScale': {
       type: 'boolean',
-      description:
-        'True if the user interface automatically scales with the font size.',
+      description: nls.localize(
+        'arduino/preferences/window.autoScale',
+        'True if the user interface automatically scales with the font size.'
+      ),
       default: true,
     },
     'arduino.window.zoomLevel': {
       type: 'number',
-      description:
-        'Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.',
+      description: nls.localize(
+        'arduino/preferences/window.zoomLevel',
+        'Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.'
+      ),
       default: 0,
     },
     'arduino.ide.autoUpdate': {
       type: 'boolean',
-      description:
-        'True to enable automatic update checks. The IDE will check for updates automatically and periodically.',
+      description: nls.localize(
+        'arduino/preferences/ide.autoUpdate',
+        'True to enable automatic update checks. The IDE will check for updates automatically and periodically.'
+      ),
       default: true,
     },
     'arduino.board.certificates': {
       type: 'string',
-      description: 'List of certificates that can be uploaded to boards',
+      description: nls.localize(
+        'arduino/preferences/board.certificates',
+        'List of certificates that can be uploaded to boards'
+      ),
       default: '',
     },
     'arduino.sketchbook.showAllFiles': {
       type: 'boolean',
-      description:
-        'True to show all sketch files inside the sketch. It is false by default.',
+      description: nls.localize(
+        'arduino/preferences/sketchbook.showAllFiles',
+        'True to show all sketch files inside the sketch. It is false by default.'
+      ),
       default: false,
     },
     'arduino.cloud.enabled': {
       type: 'boolean',
-      description:
-        'True if the sketch sync functions are enabled. Defaults to true.',
+      description: nls.localize(
+        'arduino/preferences/cloud.enabled',
+        'True if the sketch sync functions are enabled. Defaults to true.'
+      ),
       default: true,
     },
     'arduino.cloud.pull.warn': {
       type: 'boolean',
-      description:
-        'True if users should be warned before pulling a cloud sketch. Defaults to true.',
+      description: nls.localize(
+        'arduino/preferences/cloud.pull.warn',
+        'True if users should be warned before pulling a cloud sketch. Defaults to true.'
+      ),
       default: true,
     },
     'arduino.cloud.push.warn': {
       type: 'boolean',
-      description:
-        'True if users should be warned before pushing a cloud sketch. Defaults to true.',
+      description: nls.localize(
+        'arduino/preferences/cloud.push.warn',
+        'True if users should be warned before pushing a cloud sketch. Defaults to true.'
+      ),
       default: true,
     },
     'arduino.cloud.pushpublic.warn': {
       type: 'boolean',
-      description:
-        'True if users should be warned before pushing a public sketch to the cloud. Defaults to true.',
+      description: nls.localize(
+        'arduino/preferences/cloud.pushpublic.warn',
+        'True if users should be warned before pushing a public sketch to the cloud. Defaults to true.'
+      ),
       default: true,
     },
     'arduino.cloud.sketchSyncEnpoint': {
       type: 'string',
-      description:
-        'The endpoint used to push and pull sketches from a backend. By default it points to Arduino Cloud API.',
+      description: nls.localize(
+        'arduino/preferences/cloud.sketchSyncEnpoint',
+        'The endpoint used to push and pull sketches from a backend. By default it points to Arduino Cloud API.'
+      ),
       default: 'https://api2.arduino.cc/create',
     },
     'arduino.auth.clientID': {
       type: 'string',
-      description: 'The OAuth2 client ID.',
+      description: nls.localize(
+        'arduino/preferences/auth.clientID',
+        'The OAuth2 client ID.'
+      ),
       default: 'C34Ya6ex77jTNxyKWj01lCe1vAHIaPIo',
     },
     'arduino.auth.domain': {
       type: 'string',
-      description: 'The OAuth2 domain.',
+      description: nls.localize(
+        'arduino/preferences/auth.domain',
+        'The OAuth2 domain.'
+      ),
       default: 'login.arduino.cc',
     },
     'arduino.auth.audience': {
       type: 'string',
-      description: 'The 0Auth2 audience.',
+      description: nls.localize(
+        'arduino/preferences/auth.audience',
+        'The OAuth2 audience.'
+      ),
       default: 'https://api.arduino.cc',
     },
     'arduino.auth.registerUri': {
       type: 'string',
-      description: 'The URI used to register a new user.',
+      description: nls.localize(
+        'arduino/preferences/auth.registerUri',
+        'The URI used to register a new user.'
+      ),
       default: 'https://auth.arduino.cc/login#/register',
     },
   },

--- a/arduino-ide-extension/src/browser/auth/cloud-user-commands.ts
+++ b/arduino-ide-extension/src/browser/auth/cloud-user-commands.ts
@@ -1,15 +1,21 @@
 import { Command } from '@theia/core/lib/common/command';
 
 export namespace CloudUserCommands {
-  export const LOGIN: Command = {
-    id: 'arduino-cloud--login',
-    label: 'Sign in',
-  };
+  export const LOGIN = Command.toLocalizedCommand(
+    {
+      id: 'arduino-cloud--login',
+      label: 'Sign in',
+    },
+    'arduino/cloud/signIn'
+  );
 
-  export const LOGOUT: Command = {
-    id: 'arduino-cloud--logout',
-    label: 'Sign Out',
-  };
+  export const LOGOUT = Command.toLocalizedCommand(
+    {
+      id: 'arduino-cloud--logout',
+      label: 'Sign Out',
+    },
+    'arduino/cloud/signOut'
+  );
 
   export const OPEN_PROFILE_CONTEXT_MENU: Command = {
     id: 'arduino-cloud-sketchbook--open-profile-menu',

--- a/arduino-ide-extension/src/browser/boards/boards-auto-installer.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-auto-installer.ts
@@ -10,6 +10,7 @@ import { BoardsServiceProvider } from './boards-service-provider';
 import { BoardsConfig } from './boards-config';
 import { Installable, ResponseServiceArduino } from '../../common/protocol';
 import { BoardsListWidgetFrontendContribution } from './boards-widget-frontend-contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 /**
  * Listens on `BoardsConfig.Config` changes, if a board is selected which does not
@@ -81,12 +82,23 @@ export class BoardsAutoInstaller implements FrontendApplicationContribution {
           const version = candidate.availableVersions[0]
             ? `[v ${candidate.availableVersions[0]}]`
             : '';
+          const yes = nls.localize('vscode/extensionsUtils/yes', 'Yes');
+          const manualInstall = nls.localize(
+            'arduino/board/installManually',
+            'Install Manually'
+          );
           // tslint:disable-next-line:max-line-length
           this.messageService
             .info(
-              `The \`"${candidate.name} ${version}"\` core has to be installed for the currently selected \`"${selectedBoard.name}"\` board. Do you want to install it now?`,
-              'Install Manually',
-              'Yes'
+              nls.localize(
+                'arduino/board/installNow',
+                'The "{0} {1}" core has to be installed for the currently selected "{2}" board. Do you want to install it now?',
+                candidate.name,
+                version,
+                selectedBoard.name
+              ),
+              manualInstall,
+              yes
             )
             .then(async (answer) => {
               const index = this.notifications.findIndex((board) =>
@@ -95,7 +107,7 @@ export class BoardsAutoInstaller implements FrontendApplicationContribution {
               if (index !== -1) {
                 this.notifications.splice(index, 1);
               }
-              if (answer === 'Yes') {
+              if (answer === yes) {
                 await Installable.installWithProgress({
                   installable: this.boardsService,
                   item: candidate,
@@ -105,7 +117,7 @@ export class BoardsAutoInstaller implements FrontendApplicationContribution {
                 });
                 return;
               }
-              if (answer === 'Install Manually') {
+              if (answer === manualInstall) {
                 this.boardsManagerFrontendContribution
                   .openView({ reveal: true })
                   .then((widget) =>

--- a/arduino-ide-extension/src/browser/boards/boards-config-dialog.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-config-dialog.ts
@@ -6,6 +6,7 @@ import { BoardsConfig } from './boards-config';
 import { BoardsService } from '../../common/protocol/boards-service';
 import { BoardsServiceProvider } from './boards-service-provider';
 import { BoardsConfigDialogWidget } from './boards-config-dialog-widget';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class BoardsConfigDialogProps extends DialogProps {}
@@ -32,8 +33,10 @@ export class BoardsConfigDialog extends AbstractDialog<BoardsConfig.Config> {
     this.contentNode.classList.add('select-board-dialog');
     this.contentNode.appendChild(this.createDescription());
 
-    this.appendCloseButton('CANCEL');
-    this.appendAcceptButton('OK');
+    this.appendCloseButton(
+      nls.localize('vscode/issueMainService/cancel', 'Cancel')
+    );
+    this.appendAcceptButton(nls.localize('vscode/issueMainService/ok', 'OK'));
   }
 
   @postConstruct()
@@ -63,7 +66,10 @@ export class BoardsConfigDialog extends AbstractDialog<BoardsConfig.Config> {
     head.classList.add('head');
 
     const title = document.createElement('div');
-    title.textContent = 'Select Other Board & Port';
+    title.textContent = nls.localize(
+      'arduino/board/configDialogTitle',
+      'Select Other Board & Port'
+    );
     title.classList.add('title');
     head.appendChild(title);
 
@@ -72,8 +78,14 @@ export class BoardsConfigDialog extends AbstractDialog<BoardsConfig.Config> {
     head.appendChild(text);
 
     for (const paragraph of [
-      'Select both a Board and a Port if you want to upload a sketch.',
-      'If you only select a Board you will be able just to compile, but not to upload your sketch.',
+      nls.localize(
+        'arduino/board/configDialog1',
+        'Select both a Board and a Port if you want to upload a sketch.'
+      ),
+      nls.localize(
+        'arduino/board/configDialog2',
+        'If you only select a Board you will be able just to compile, but not to upload your sketch.'
+      ),
     ]) {
       const p = document.createElement('div');
       p.textContent = paragraph;
@@ -117,7 +129,10 @@ export class BoardsConfigDialog extends AbstractDialog<BoardsConfig.Config> {
   protected isValid(value: BoardsConfig.Config): DialogError {
     if (!value.selectedBoard) {
       if (value.selectedPort) {
-        return 'Please pick a board connected to the port you have selected.';
+        return nls.localize(
+          'arduino/board/pleasePickBoard',
+          'Please pick a board connected to the port you have selected.'
+        );
       }
       return false;
     }

--- a/arduino-ide-extension/src/browser/boards/boards-config.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-config.tsx
@@ -11,6 +11,7 @@ import {
 } from '../../common/protocol/boards-service';
 import { NotificationCenter } from '../notification-center';
 import { BoardsServiceProvider } from './boards-service-provider';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace BoardsConfig {
   export interface Config {
@@ -302,7 +303,12 @@ export class BoardsConfig extends React.Component<
   protected renderPortsFooter(): React.ReactNode {
     return (
       <div className="noselect">
-        <label title="Shows all available ports when enabled">
+        <label
+          title={nls.localize(
+            'arduino/board/showAllAvailablePorts',
+            'Shows all available ports when enabled'
+          )}
+        >
           <input
             type="checkbox"
             defaultChecked={this.state.showAllPorts}

--- a/arduino-ide-extension/src/browser/boards/boards-data-menu-updater.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-data-menu-updater.ts
@@ -12,6 +12,7 @@ import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { BoardsDataStore } from './boards-data-store';
 import { MainMenuManager } from '../../common/main-menu-manager';
 import { ArduinoMenus, unregisterSubmenu } from '../menu/arduino-menus';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class BoardsDataMenuUpdater implements FrontendApplicationContribution {
@@ -115,9 +116,13 @@ export class BoardsDataMenuUpdater implements FrontendApplicationContribution {
               ...ArduinoMenus.TOOLS__BOARD_SETTINGS_GROUP,
               'z02_programmers',
             ];
+            const programmerNls = nls.localize(
+              'arduino/board/programmer',
+              'Programmer'
+            );
             const label = selectedProgrammer
-              ? `Programmer: "${selectedProgrammer.name}"`
-              : 'Programmer';
+              ? `${programmerNls}: "${selectedProgrammer.name}"`
+              : programmerNls;
             this.menuRegistry.registerSubmenu(programmersMenuPath, label);
             this.toDisposeOnBoardChange.push(
               Disposable.create(() =>

--- a/arduino-ide-extension/src/browser/boards/boards-list-widget.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-list-widget.ts
@@ -5,11 +5,12 @@ import {
 } from '../../common/protocol/boards-service';
 import { ListWidget } from '../widgets/component-list/list-widget';
 import { ListItemRenderer } from '../widgets/component-list/list-item-renderer';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class BoardsListWidget extends ListWidget<BoardsPackage> {
   static WIDGET_ID = 'boards-list-widget';
-  static WIDGET_LABEL = 'Boards Manager';
+  static WIDGET_LABEL = nls.localize('arduino/boardsManager', 'Boards Manager');
 
   constructor(
     @inject(BoardsService) protected service: BoardsService,
@@ -52,7 +53,12 @@ export class BoardsListWidget extends ListWidget<BoardsPackage> {
   }): Promise<void> {
     await super.install({ item, progressId, version });
     this.messageService.info(
-      `Successfully installed platform ${item.name}:${version}`,
+      nls.localize(
+        'arduino/board/succesfullyInstalledPlatform',
+        'Successfully installed platform {0}:{1}',
+        item.name,
+        version
+      ),
       { timeout: 3000 }
     );
   }
@@ -66,7 +72,12 @@ export class BoardsListWidget extends ListWidget<BoardsPackage> {
   }): Promise<void> {
     await super.uninstall({ item, progressId });
     this.messageService.info(
-      `Successfully uninstalled platform ${item.name}:${item.installedVersion}`,
+      nls.localize(
+        'arduino/board/succesfullyUninstalledPlatform',
+        'Successfully uninstalled platform {0}:{1}',
+        item.name,
+        item.installedVersion!
+      ),
       { timeout: 3000 }
     );
   }

--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -18,6 +18,7 @@ import { naturalCompare } from '../../common/utils';
 import { NotificationCenter } from '../notification-center';
 import { ArduinoCommands } from '../arduino-commands';
 import { StorageWrapper } from '../storage-wrapper';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class BoardsServiceProvider implements FrontendApplicationContribution {
@@ -134,14 +135,20 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
         selectedBoard.packageId === event.item.id &&
         !installedBoard
       ) {
+        const yes = nls.localize('vscode/extensionsUtils/yes', 'Yes');
         this.messageService
           .warn(
-            `Could not find previously selected board '${selectedBoard.name}' in installed platform '${event.item.name}'. Please manually reselect the board you want to use. Do you want to reselect it now?`,
-            'Reselect later',
-            'Yes'
+            nls.localize(
+              'arduino/board/couldNotFindPreviouslySelected',
+              "Could not find previously selected board '{0}' in installed platform '{1}'. Please manually reselect the board you want to use. Do you want to reselect it now?",
+              selectedBoard.name,
+              event.item.name
+            ),
+            nls.localize('arduino/board/reselectLater', 'Reselect later'),
+            yes
           )
           .then(async (answer) => {
-            if (answer === 'Yes') {
+            if (answer === yes) {
               this.commandService.executeCommand(
                 ArduinoCommands.OPEN_BOARDS_DIALOG.id,
                 selectedBoard.name
@@ -277,9 +284,12 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
 
     if (!config.selectedBoard) {
       if (!options.silent) {
-        this.messageService.warn('No boards selected.', {
-          timeout: 3000,
-        });
+        this.messageService.warn(
+          nls.localize('arduino/board/noneSelected', 'No boards selected.'),
+          {
+            timeout: 3000,
+          }
+        );
       }
       return false;
     }
@@ -301,9 +311,16 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
     const { name } = config.selectedBoard;
     if (!config.selectedPort) {
       if (!options.silent) {
-        this.messageService.warn(`No ports selected for board: '${name}'.`, {
-          timeout: 3000,
-        });
+        this.messageService.warn(
+          nls.localize(
+            'arduino/board/noPortsSelected',
+            "No ports selected for board: '{0}'.",
+            name
+          ),
+          {
+            timeout: 3000,
+          }
+        );
       }
       return false;
     }
@@ -311,7 +328,11 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
     if (!config.selectedBoard.fqbn) {
       if (!options.silent) {
         this.messageService.warn(
-          `The FQBN is not available for the selected board ${name}. Do you have the corresponding core installed?`,
+          nls.localize(
+            'arduino/board/noFQBN',
+            'The FQBN is not available for the selected board "{0}". Do you have the corresponding core installed?',
+            name
+          ),
           { timeout: 3000 }
         );
       }
@@ -407,7 +428,7 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
       }
       if (!board) {
         availableBoards.push({
-          name: 'Unknown',
+          name: nls.localize('arduino/common/unknown', 'Unknown'),
           port: boardPort,
           state,
         });

--- a/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
@@ -9,6 +9,7 @@ import {
   BoardsServiceProvider,
   AvailableBoard,
 } from './boards-service-provider';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export interface BoardsDropDownListCoords {
   readonly top: number;
@@ -152,7 +153,10 @@ export class BoardsToolBarItem extends React.Component<
     const { coords, availableBoards } = this.state;
     const boardsConfig = this.props.boardsServiceClient.boardsConfig;
     const title = BoardsConfig.Config.toString(boardsConfig, {
-      default: 'no board selected',
+      default: nls.localize(
+        'arduino/common/noBoardSelected',
+        'No board selected'
+      ),
     });
     const decorator = (() => {
       const selectedBoard = availableBoards.find(({ selected }) => selected);

--- a/arduino-ide-extension/src/browser/contributions/about.ts
+++ b/arduino-ide-extension/src/browser/contributions/about.ts
@@ -12,6 +12,7 @@ import {
 } from './contribution';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { ConfigService } from '../../common/protocol';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class About extends Contribution {
@@ -30,7 +31,11 @@ export class About extends Contribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.HELP__ABOUT_GROUP, {
       commandId: About.Commands.ABOUT_APP.id,
-      label: `About ${this.applicationName}`,
+      label: nls.localize(
+        'arduino/about/label',
+        'About {0}',
+        this.applicationName
+      ),
       order: '0',
     });
   }
@@ -42,16 +47,24 @@ export class About extends Contribution {
       status: cliStatus,
     } = await this.configService.getVersion();
     const buildDate = this.buildDate;
-    const detail = (showAll: boolean) => `Version: ${remote.app.getVersion()}
-Date: ${buildDate ? buildDate : 'dev build'}${
-      buildDate && showAll ? ` (${this.ago(buildDate)})` : ''
-    }
-CLI Version: ${version}${cliStatus ? ` ${cliStatus}` : ''} [${commit}]
-
-${showAll ? `Copyright © ${new Date().getFullYear()} Arduino SA` : ''}
-`;
-    const ok = 'OK';
-    const copy = 'Copy';
+    const detail = (showAll: boolean) =>
+      nls.localize(
+        'arduino/about/detail',
+        'Version: {0}\nDate: {1}{2}\nCLI Version: {3}{4} [{5}]\n\n{6}',
+        remote.app.getVersion(),
+        buildDate ? buildDate : nls.localize('', 'dev build'),
+        buildDate && showAll ? ` (${this.ago(buildDate)})` : '',
+        version,
+        cliStatus ? ` ${cliStatus}` : '',
+        commit,
+        nls.localize(
+          'arduino/about/copyright',
+          'Copyright © {0} Arduino SA',
+          new Date().getFullYear().toString()
+        )
+      );
+    const ok = nls.localize('vscode/issueMainService/ok', 'OK');
+    const copy = nls.localize('vscode/textInputActions/copy', 'Copy');
     const buttons = !isWindows && !isOSX ? [copy, ok] : [ok, copy];
     const { response } = await remote.dialog.showMessageBox(
       remote.getCurrentWindow(),
@@ -85,26 +98,86 @@ ${showAll ? `Copyright © ${new Date().getFullYear()} Arduino SA` : ''}
     const other = moment(isoTime);
     let result = now.diff(other, 'minute');
     if (result < 60) {
-      return result === 1 ? `${result} minute ago` : `${result} minute ago`;
+      return result === 1
+        ? nls.localize(
+            'vscode/date/date.fromNow.minutes.singular.ago',
+            '{0} minute ago',
+            result.toString()
+          )
+        : nls.localize(
+            'vscode/date/date.fromNow.minutes.plural.ago',
+            '{0} minutes ago',
+            result.toString()
+          );
     }
     result = now.diff(other, 'hour');
     if (result < 25) {
-      return result === 1 ? `${result} hour ago` : `${result} hours ago`;
+      return result === 1
+        ? nls.localize(
+            'vscode/date/date.fromNow.hours.singular.ago',
+            '{0} hour ago',
+            result.toString()
+          )
+        : nls.localize(
+            'vscode/date/date.fromNow.hours.plural.ago',
+            '{0} hours ago',
+            result.toString()
+          );
     }
     result = now.diff(other, 'day');
     if (result < 8) {
-      return result === 1 ? `${result} day ago` : `${result} days ago`;
+      return result === 1
+        ? nls.localize(
+            'vscode/date/date.fromNow.days.singular.ago',
+            '{0} day ago',
+            result.toString()
+          )
+        : nls.localize(
+            'vscode/date/date.fromNow.days.plural.ago',
+            '{0} days ago',
+            result.toString()
+          );
     }
     result = now.diff(other, 'week');
     if (result < 5) {
-      return result === 1 ? `${result} week ago` : `${result} weeks ago`;
+      return result === 1
+        ? nls.localize(
+            'vscode/date/date.fromNow.weeks.singular.ago',
+            '{0} week ago',
+            result.toString()
+          )
+        : nls.localize(
+            'vscode/date/date.fromNow.weeks.plural.ago',
+            '{0} weeks ago',
+            result.toString()
+          );
     }
     result = now.diff(other, 'month');
     if (result < 13) {
-      return result === 1 ? `${result} month ago` : `${result} months ago`;
+      return result === 1
+        ? nls.localize(
+            'vscode/date/date.fromNow.months.singular.ago',
+            '{0} month ago',
+            result.toString()
+          )
+        : nls.localize(
+            'vscode/date/date.fromNow.months.plural.ago',
+            '{0} months ago',
+            result.toString()
+          );
     }
     result = now.diff(other, 'year');
-    return result === 1 ? `${result} year ago` : `${result} years ago`;
+    return result === 1
+      ? nls.localize(
+          'vscode/date/date.fromNow.years.singular.ago',
+          '{0} year ago',
+          result.toString()
+        )
+      : nls.localize(
+          'vscode/date/date.fromNow.years.plural.ago',
+          '{0} years ago',
+          result.toString()
+        );
   }
 }
 

--- a/arduino-ide-extension/src/browser/contributions/add-file.ts
+++ b/arduino-ide-extension/src/browser/contributions/add-file.ts
@@ -9,6 +9,7 @@ import {
   URI,
 } from './contribution';
 import { FileDialogService } from '@theia/filesystem/lib/browser';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class AddFile extends SketchContribution {
@@ -24,7 +25,7 @@ export class AddFile extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.SKETCH__UTILS_GROUP, {
       commandId: AddFile.Commands.ADD_FILE.id,
-      label: 'Add File...',
+      label: nls.localize('arduino/contributions/addFile', 'Add File') + '...',
       order: '2',
     });
   }
@@ -35,7 +36,7 @@ export class AddFile extends SketchContribution {
       return;
     }
     const toAddUri = await this.fileDialogService.showOpenDialog({
-      title: 'Add File',
+      title: nls.localize('arduino/contributions/addFile', 'Add File'),
       canSelectFiles: true,
       canSelectFolders: false,
       canSelectMany: false,
@@ -50,9 +51,16 @@ export class AddFile extends SketchContribution {
     if (exists) {
       const { response } = await remote.dialog.showMessageBox({
         type: 'question',
-        title: 'Replace',
-        buttons: ['Cancel', 'OK'],
-        message: `Replace the existing version of ${filename}?`,
+        title: nls.localize('arduino/contributions/replaceTitle', 'Replace'),
+        buttons: [
+          nls.localize('vscode/issueMainService/cancel', 'Cancel'),
+          nls.localize('vscode/issueMainService/ok', 'OK'),
+        ],
+        message: nls.localize(
+          'arduino/replaceMsg',
+          'Replace the existing version of {0}?',
+          filename
+        ),
       });
       if (response === 0) {
         // Cancel
@@ -60,9 +68,15 @@ export class AddFile extends SketchContribution {
       }
     }
     await this.fileService.copy(toAddUri, targetUri, { overwrite: true });
-    this.messageService.info('One file added to the sketch.', {
-      timeout: 2000,
-    });
+    this.messageService.info(
+      nls.localize(
+        'arduino/contributions/fileAdded',
+        'One file added to the sketch.'
+      ),
+      {
+        timeout: 2000,
+      }
+    );
   }
 }
 

--- a/arduino-ide-extension/src/browser/contributions/add-zip-library.ts
+++ b/arduino-ide-extension/src/browser/contributions/add-zip-library.ts
@@ -15,6 +15,7 @@ import {
   CommandRegistry,
   MenuModelRegistry,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class AddZipLibrary extends SketchContribution {
@@ -44,7 +45,7 @@ export class AddZipLibrary extends SketchContribution {
     });
     registry.registerMenuAction([...includeLibMenuPath, '1_install'], {
       commandId: AddZipLibrary.Commands.ADD_ZIP_LIBRARY.id,
-      label: 'Add .ZIP Library...',
+      label: nls.localize('arduino/library/addZip', 'Add .ZIP Library...'),
       order: '1',
     });
   }
@@ -53,12 +54,15 @@ export class AddZipLibrary extends SketchContribution {
     const homeUri = await this.envVariableServer.getHomeDirUri();
     const defaultPath = await this.fileService.fsPath(new URI(homeUri));
     const { canceled, filePaths } = await remote.dialog.showOpenDialog({
-      title: "Select a zip file containing the library you'd like to add",
+      title: nls.localize(
+        'arduino/selectZip',
+        "Select a zip file containing the library you'd like to add"
+      ),
       defaultPath,
       properties: ['openFile'],
       filters: [
         {
-          name: 'Library',
+          name: nls.localize('arduino/library/zipLibrary', 'Library'),
           extensions: ['zip'],
         },
       ],
@@ -71,9 +75,12 @@ export class AddZipLibrary extends SketchContribution {
         if (error instanceof AlreadyInstalledError) {
           const result = await new ConfirmDialog({
             msg: error.message,
-            title: 'Do you want to overwrite the existing library?',
-            ok: 'Yes',
-            cancel: 'No',
+            title: nls.localize(
+              'arduino/library/overwriteExistingLibrary',
+              'Do you want to overwrite the existing library?'
+            ),
+            ok: nls.localize('vscode/extensionsUtils/yes', 'Yes'),
+            cancel: nls.localize('vscode/extensionsUtils/no', 'No'),
           }).open();
           if (result) {
             await this.doInstall(zipUri, true);
@@ -87,14 +94,18 @@ export class AddZipLibrary extends SketchContribution {
     try {
       await Installable.doWithProgress({
         messageService: this.messageService,
-        progressText: `Processing ${new URI(zipUri).path.base}`,
+        progressText:
+          nls.localize('arduino/common/processing', 'Processing') +
+          ` ${new URI(zipUri).path.base}`,
         responseService: this.responseService,
         run: () => this.libraryService.installZip({ zipUri, overwrite }),
       });
       this.messageService.info(
-        `Successfully installed library from ${
+        nls.localize(
+          'arduino/library/successfullyInstalledZipLibrary',
+          'Successfully installed library from {0} archive',
           new URI(zipUri).path.base
-        } archive`,
+        ),
         { timeout: 3000 }
       );
     } catch (error) {
@@ -104,12 +115,19 @@ export class AddZipLibrary extends SketchContribution {
           const name = match[1].trim();
           if (name) {
             throw new AlreadyInstalledError(
-              `A library folder named ${name} already exists. Do you want to overwrite it?`,
+              nls.localize(
+                'arduino/library/namedLibraryAlreadyExists',
+                'A library folder named {0} already exists. Do you want to overwrite it?',
+                name
+              ),
               name
             );
           } else {
             throw new AlreadyInstalledError(
-              'A library already exists. Do you want to overwrite it?'
+              nls.localize(
+                'arduino/library/libraryAlreadyExists',
+                'A library already exists. Do you want to overwrite it?'
+              )
             );
           }
         }

--- a/arduino-ide-extension/src/browser/contributions/archive-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/archive-sketch.ts
@@ -9,6 +9,7 @@ import {
   CommandRegistry,
   MenuModelRegistry,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class ArchiveSketch extends SketchContribution {
@@ -21,7 +22,7 @@ export class ArchiveSketch extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.TOOLS__MAIN_GROUP, {
       commandId: ArchiveSketch.Commands.ARCHIVE_SKETCH.id,
-      label: 'Archive Sketch',
+      label: nls.localize('arduino/sketch/archiveSketch', 'Archive Sketch'),
       order: '1',
     });
   }
@@ -42,7 +43,10 @@ export class ArchiveSketch extends SketchContribution {
       new URI(config.sketchDirUri).resolve(archiveBasename)
     );
     const { filePath, canceled } = await remote.dialog.showSaveDialog({
-      title: 'Save sketch folder as...',
+      title: nls.localize(
+        'arduino/sketch/saveSketchAs',
+        'Save sketch folder as...'
+      ),
       defaultPath,
     });
     if (!filePath || canceled) {
@@ -53,9 +57,16 @@ export class ArchiveSketch extends SketchContribution {
       return;
     }
     await this.sketchService.archive(sketch, destinationUri.toString());
-    this.messageService.info(`Created archive '${archiveBasename}'.`, {
-      timeout: 2000,
-    });
+    this.messageService.info(
+      nls.localize(
+        'arduino/sketch/createdArchive',
+        "Created archive '{0}'.",
+        archiveBasename
+      ),
+      {
+        timeout: 2000,
+      }
+    );
   }
 }
 

--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -23,6 +23,7 @@ import {
   Port,
 } from '../../common/protocol';
 import { SketchContribution, Command, CommandRegistry } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class BoardSelection extends SketchContribution {
@@ -53,19 +54,29 @@ export class BoardSelection extends SketchContribution {
           this.boardsServiceProvider.boardsConfig;
         if (!selectedBoard) {
           this.messageService.info(
-            'Please select a board to obtain board info.'
+            nls.localize(
+              'arduino/board/selectBoardForInfo',
+              'Please select a board to obtain board info.'
+            )
           );
           return;
         }
         if (!selectedBoard.fqbn) {
           this.messageService.info(
-            `The platform for the selected '${selectedBoard.name}' board is not installed.`
+            nls.localize(
+              'arduino/board/platformMissing',
+              "The platform for the selected '{0}' board is not installed.",
+              selectedBoard.name
+            )
           );
           return;
         }
         if (!selectedPort) {
           this.messageService.info(
-            'Please select a port to obtain board info.'
+            nls.localize(
+              'arduino/board/selectPortForInfo',
+              'Please select a port to obtain board info.'
+            )
           );
           return;
         }
@@ -78,11 +89,11 @@ export class BoardSelection extends SketchContribution {
 VID: ${VID}
 PID: ${PID}`;
           await remote.dialog.showMessageBox(remote.getCurrentWindow(), {
-            message: 'Board Info',
-            title: 'Board Info',
+            message: nls.localize('arduino/board/boardInfo', 'Board Info'),
+            title: nls.localize('arduino/board/boardInfo', 'Board Info'),
             type: 'info',
             detail,
-            buttons: ['OK'],
+            buttons: [nls.localize('vscode/issueMainService/ok', 'OK')],
           });
         }
       },
@@ -127,7 +138,9 @@ PID: ${PID}`;
     // The board specific items, and the rest, have order with `z`. We needed something between `0` and `z` with natural-order.
     this.menuModelRegistry.registerSubmenu(
       boardsSubmenuPath,
-      `Board${!!boardsSubmenuLabel ? `: "${boardsSubmenuLabel}"` : ''}`,
+      nls.localize('arduino/board/board', 'Board') + !!boardsSubmenuLabel
+        ? `: "${boardsSubmenuLabel}"`
+        : '',
       { order: '100' }
     );
     this.toDisposeBeforeMenuRebuild.push(
@@ -144,7 +157,9 @@ PID: ${PID}`;
     const portsSubmenuLabel = config.selectedPort?.address;
     this.menuModelRegistry.registerSubmenu(
       portsSubmenuPath,
-      `Port${!!portsSubmenuLabel ? `: "${portsSubmenuLabel}"` : ''}`,
+      nls.localize('arduino/board/port', 'Port') + portsSubmenuLabel
+        ? `: "${portsSubmenuLabel}"`
+        : '',
       { order: '101' }
     );
     this.toDisposeBeforeMenuRebuild.push(
@@ -155,7 +170,7 @@ PID: ${PID}`;
 
     const getBoardInfo = {
       commandId: BoardSelection.Commands.GET_BOARD_INFO.id,
-      label: 'Get Board Info',
+      label: nls.localize('arduino/board/getBoardInfo', 'Get Board Info'),
       order: '103',
     };
     this.menuModelRegistry.registerMenuAction(
@@ -173,7 +188,7 @@ PID: ${PID}`;
 
     this.menuModelRegistry.registerMenuAction(boardsManagerGroup, {
       commandId: `${BoardsListWidget.WIDGET_ID}:toggle`,
-      label: 'Boards Manager...',
+      label: `${BoardsListWidget.WIDGET_LABEL}...`,
     });
 
     // Installed boards
@@ -181,7 +196,12 @@ PID: ${PID}`;
       const { packageId, packageName, fqbn, name, manuallyInstalled } = board;
 
       const packageLabel =
-        packageName + `${manuallyInstalled ? ' (in Sketchbook)' : ''}`;
+        packageName +
+        `${
+          manuallyInstalled
+            ? nls.localize('arduino/board/inSketchbook', ' (in Sketchbook)')
+            : ''
+        }`;
       // Platform submenu
       const platformMenuPath = [...boardsPackagesGroup, packageId];
       // Note: Registering the same submenu twice is a noop. No need to group the boards per platform.

--- a/arduino-ide-extension/src/browser/contributions/burn-bootloader.ts
+++ b/arduino-ide-extension/src/browser/contributions/burn-bootloader.ts
@@ -11,6 +11,7 @@ import {
   CommandRegistry,
   MenuModelRegistry,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class BurnBootloader extends SketchContribution {
@@ -38,7 +39,10 @@ export class BurnBootloader extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.TOOLS__BOARD_SETTINGS_GROUP, {
       commandId: BurnBootloader.Commands.BURN_BOOTLOADER.id,
-      label: 'Burn Bootloader',
+      label: nls.localize(
+        'arduino/bootloader/burnBootloader',
+        'Burn Bootloader'
+      ),
       order: 'z99',
     });
   }
@@ -68,9 +72,15 @@ export class BurnBootloader extends SketchContribution {
         verify,
         verbose,
       });
-      this.messageService.info('Done burning bootloader.', {
-        timeout: 3000,
-      });
+      this.messageService.info(
+        nls.localize(
+          'arduino/bootloader/doneBurningBootloader',
+          'Done burning bootloader.'
+        ),
+        {
+          timeout: 3000,
+        }
+      );
     } catch (e) {
       this.messageService.error(e.toString());
     } finally {

--- a/arduino-ide-extension/src/browser/contributions/close.ts
+++ b/arduino-ide-extension/src/browser/contributions/close.ts
@@ -15,6 +15,7 @@ import {
   KeybindingRegistry,
   URI,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 /**
  * Closes the `current` closeable editor, or any closeable current widget from the main area, or the current sketch window.
@@ -64,10 +65,25 @@ export class Close extends SketchContribution {
         if (isTemp && (await this.wasTouched(uri))) {
           const { response } = await remote.dialog.showMessageBox({
             type: 'question',
-            buttons: ["Don't Save", 'Cancel', 'Save'],
-            message:
-              'Do you want to save changes to this sketch before closing?',
-            detail: "If you don't save, your changes will be lost.",
+            buttons: [
+              nls.localize(
+                'vscode/abstractTaskService/saveBeforeRun.dontSave',
+                "Don't Save"
+              ),
+              nls.localize('vscode/issueMainService/cancel', 'Cancel'),
+              nls.localize(
+                'vscode/abstractTaskService/saveBeforeRun.save',
+                'Save'
+              ),
+            ],
+            message: nls.localize(
+              'arduino/common/saveChangesToSketch',
+              'Do you want to save changes to this sketch before closing?'
+            ),
+            detail: nls.localize(
+              'arduino/common/loseChanges',
+              "If you don't save, your changes will be lost."
+            ),
           });
           if (response === 1) {
             // Cancel
@@ -93,7 +109,7 @@ export class Close extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.FILE__SKETCH_GROUP, {
       commandId: Close.Commands.CLOSE.id,
-      label: 'Close',
+      label: nls.localize('vscode/editor.contribution/close', 'Close'),
       order: '5',
     });
   }

--- a/arduino-ide-extension/src/browser/contributions/debug.ts
+++ b/arduino-ide-extension/src/browser/contributions/debug.ts
@@ -12,6 +12,7 @@ import {
   SketchContribution,
   TabBarToolbarRegistry,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class Debug extends SketchContribution {
@@ -33,7 +34,10 @@ export class Debug extends SketchContribution {
   /**
    * If `undefined`, debugging is enabled. Otherwise, the reason why it's disabled.
    */
-  protected _disabledMessages?: string = 'No board selected'; // Initial pessimism.
+  protected _disabledMessages?: string = nls.localize(
+    'arduino/common/noBoardSelected',
+    'No board selected'
+  ); // Initial pessimism.
   protected disabledMessageDidChangeEmitter = new Emitter<string | undefined>();
   protected onDisabledMessageDidChange =
     this.disabledMessageDidChangeEmitter.event;
@@ -51,8 +55,12 @@ export class Debug extends SketchContribution {
     command: Debug.Commands.START_DEBUGGING.id,
     tooltip: `${
       this.disabledMessage
-        ? `Debug - ${this.disabledMessage}`
-        : 'Start Debugging'
+        ? nls.localize(
+            'arduino/debug/debugWithMessage',
+            'Debug - {0}',
+            this.disabledMessage
+          )
+        : Debug.Commands.START_DEBUGGING.label
     }`,
     priority: 3,
     onDidChange: this.onDisabledMessageDidChange as Event<void>,
@@ -63,8 +71,12 @@ export class Debug extends SketchContribution {
       () =>
         (this.debugToolbarItem.tooltip = `${
           this.disabledMessage
-            ? `Debug - ${this.disabledMessage}`
-            : 'Start Debugging'
+            ? nls.localize(
+                'arduino/debug/debugWithMessage',
+                'Debug - {0}',
+                this.disabledMessage
+              )
+            : Debug.Commands.START_DEBUGGING.label
         }`)
     );
     const refreshState = async (
@@ -72,22 +84,37 @@ export class Debug extends SketchContribution {
         .selectedBoard
     ) => {
       if (!board) {
-        this.disabledMessage = 'No board selected';
+        this.disabledMessage = nls.localize(
+          'arduino/common/noBoardSelected',
+          'No board selected'
+        );
         return;
       }
       const fqbn = board.fqbn;
       if (!fqbn) {
-        this.disabledMessage = `Platform is not installed for '${board.name}'`;
+        this.disabledMessage = nls.localize(
+          'arduino/debug/noPlatformInstalledFor',
+          "Platform is not installed for '{0}'",
+          board.name
+        );
         return;
       }
       const details = await this.boardService.getBoardDetails({ fqbn });
       if (!details) {
-        this.disabledMessage = `Platform is not installed for '${board.name}'`;
+        this.disabledMessage = nls.localize(
+          'arduino/debug/noPlatformInstalledFor',
+          "Platform is not installed for '{0}'",
+          board.name
+        );
         return;
       }
       const { debuggingSupported } = details;
       if (!debuggingSupported) {
-        this.disabledMessage = `Debugging is not supported by '${board.name}'`;
+        this.disabledMessage = nls.localize(
+          'arduino/debug/debuggingNotSupported',
+          "Debugging is not supported by '{0}'",
+          board.name
+        );
       } else {
         this.disabledMessage = undefined;
       }
@@ -155,10 +182,13 @@ export class Debug extends SketchContribution {
 
 export namespace Debug {
   export namespace Commands {
-    export const START_DEBUGGING: Command = {
-      id: 'arduino-start-debug',
-      label: 'Start Debugging',
-      category: 'Arduino',
-    };
+    export const START_DEBUGGING = Command.toLocalizedCommand(
+      {
+        id: 'arduino-start-debug',
+        label: 'Start Debugging',
+        category: 'Arduino',
+      },
+      'vscode/debug.contribution/startDebuggingHelp'
+    );
   }
 }

--- a/arduino-ide-extension/src/browser/contributions/edit-contributions.ts
+++ b/arduino-ide-extension/src/browser/contributions/edit-contributions.ts
@@ -11,6 +11,7 @@ import {
   CommandRegistry,
 } from './contribution';
 import { ArduinoMenus } from '../menu/arduino-menus';
+import { nls } from '@theia/core/lib/browser/nls';
 
 // TODO: [macOS]: to remove `Start Dictation...` and `Emoji & Symbol` see this thread: https://github.com/electron/electron/issues/8283#issuecomment-269522072
 // Depends on https://github.com/eclipse-theia/theia/pull/7964
@@ -101,7 +102,10 @@ ${value}
     });
     registry.registerMenuAction(ArduinoMenus.EDIT__TEXT_CONTROL_GROUP, {
       commandId: EditContributions.Commands.COPY_FOR_FORUM.id,
-      label: 'Copy for Forum (Markdown)',
+      label: nls.localize(
+        'arduino/editor/copyForForum',
+        'Copy for Forum (Markdown)'
+      ),
       order: '2',
     });
     registry.registerMenuAction(ArduinoMenus.EDIT__TEXT_CONTROL_GROUP, {
@@ -114,62 +118,83 @@ ${value}
     });
     registry.registerMenuAction(ArduinoMenus.EDIT__TEXT_CONTROL_GROUP, {
       commandId: EditContributions.Commands.GO_TO_LINE.id,
-      label: 'Go to Line...',
+      label: nls.localize(
+        'vscode/standaloneStrings/gotoLineActionLabel',
+        'Go to Line...'
+      ),
       order: '5',
     });
 
     registry.registerMenuAction(ArduinoMenus.EDIT__CODE_CONTROL_GROUP, {
       commandId: EditContributions.Commands.TOGGLE_COMMENT.id,
-      label: 'Comment/Uncomment',
+      label: nls.localize(
+        'arduino/editor/commentUncomment',
+        'Comment/Uncomment'
+      ),
       order: '0',
     });
     registry.registerMenuAction(ArduinoMenus.EDIT__CODE_CONTROL_GROUP, {
       commandId: EditContributions.Commands.INDENT_LINES.id,
-      label: 'Increase Indent',
+      label: nls.localize('arduino/editor/increaseIndent', 'Increase Indent'),
       order: '1',
     });
     registry.registerMenuAction(ArduinoMenus.EDIT__CODE_CONTROL_GROUP, {
       commandId: EditContributions.Commands.OUTDENT_LINES.id,
-      label: 'Decrease Indent',
+      label: nls.localize('arduino/editor/decreaseIndent', 'Decrease Indent'),
       order: '2',
     });
 
     registry.registerMenuAction(ArduinoMenus.EDIT__FONT_CONTROL_GROUP, {
       commandId: EditContributions.Commands.INCREASE_FONT_SIZE.id,
-      label: 'Increase Font Size',
+      label: nls.localize(
+        'arduino/editor/increaseFontSize',
+        'Increase Font Size'
+      ),
       order: '0',
     });
     registry.registerMenuAction(ArduinoMenus.EDIT__FONT_CONTROL_GROUP, {
       commandId: EditContributions.Commands.DECREASE_FONT_SIZE.id,
-      label: 'Decrease Font Size',
+      label: nls.localize(
+        'arduino/editor/decreaseFontSize',
+        'Decrease Font Size'
+      ),
       order: '1',
     });
 
     registry.registerMenuAction(ArduinoMenus.EDIT__FIND_GROUP, {
       commandId: EditContributions.Commands.FIND.id,
-      label: 'Find',
+      label: nls.localize('vscode/findController/startFindAction', 'Find'),
       order: '0',
     });
     registry.registerMenuAction(ArduinoMenus.EDIT__FIND_GROUP, {
       commandId: EditContributions.Commands.FIND_NEXT.id,
-      label: 'Find Next',
+      label: nls.localize(
+        'vscode/findController/findNextMatchAction',
+        'Find Next'
+      ),
       order: '1',
     });
     registry.registerMenuAction(ArduinoMenus.EDIT__FIND_GROUP, {
       commandId: EditContributions.Commands.FIND_PREVIOUS.id,
-      label: 'Find Previous',
+      label: nls.localize(
+        'vscode/findController/findPreviousMatchAction',
+        'Find Previous'
+      ),
       order: '2',
     });
     registry.registerMenuAction(ArduinoMenus.EDIT__FIND_GROUP, {
       commandId: EditContributions.Commands.USE_FOR_FIND.id,
-      label: 'Use Selection for Find', // XXX: The Java IDE uses `Use Selection For Find`.
+      label: nls.localize(
+        'vscode/findController/startFindWithSelectionAction',
+        'Use Selection for Find'
+      ), // XXX: The Java IDE uses `Use Selection For Find`.
       order: '3',
     });
 
     // `Tools`
     registry.registerMenuAction(ArduinoMenus.TOOLS__MAIN_GROUP, {
       commandId: EditContributions.Commands.AUTO_FORMAT.id,
-      label: 'Auto Format', // XXX: The Java IDE uses `Use Selection For Find`.
+      label: nls.localize('arduino/editor/autoFormat', 'Auto Format'), // XXX: The Java IDE uses `Use Selection For Find`.
       order: '0',
     });
   }

--- a/arduino-ide-extension/src/browser/contributions/examples.ts
+++ b/arduino-ide-extension/src/browser/contributions/examples.ts
@@ -22,6 +22,7 @@ import {
 } from './contribution';
 import { NotificationCenter } from '../notification-center';
 import { Board, Sketch, SketchContainer } from '../../common/protocol';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export abstract class Examples extends SketchContribution {
@@ -69,9 +70,13 @@ export abstract class Examples extends SketchContribution {
     }
     // Registering the same submenu multiple times has no side-effect.
     // TODO: unregister submenu? https://github.com/eclipse-theia/theia/issues/7300
-    registry.registerSubmenu(ArduinoMenus.FILE__EXAMPLES_SUBMENU, 'Examples', {
-      order: '4',
-    });
+    registry.registerSubmenu(
+      ArduinoMenus.FILE__EXAMPLES_SUBMENU,
+      nls.localize('arduino/examples/menu', 'Examples'),
+      {
+        order: '4',
+      }
+    );
   }
 
   registerRecursively(
@@ -166,11 +171,19 @@ export class BuiltInExamples extends Examples {
       sketchContainers = await this.examplesService.builtIns();
     } catch (e) {
       console.error('Could not initialize built-in examples.', e);
-      this.messageService.error('Could not initialize built-in examples.');
+      this.messageService.error(
+        nls.localize(
+          'arduino/examples/couldNotInitializeExamples',
+          'Could not initialize built-in examples.'
+        )
+      );
       return;
     }
     this.toDispose.dispose();
-    for (const container of ['Built-in examples', ...sketchContainers]) {
+    for (const container of [
+      nls.localize('arduino/examples/builtInExamples', 'Built-in examples'),
+      ...sketchContainers,
+    ]) {
       this.registerRecursively(
         container,
         ArduinoMenus.EXAMPLES__BUILT_IN_GROUP,
@@ -211,13 +224,22 @@ export class LibraryExamples extends Examples {
         fqbn,
       });
       if (user.length) {
-        (user as any).unshift('Examples from Custom Libraries');
+        (user as any).unshift(
+          nls.localize(
+            'arduino/examples/customLibrary',
+            'Examples from Custom Libraries'
+          )
+        );
       }
       if (name && fqbn && current.length) {
-        (current as any).unshift(`Examples for ${name}`);
+        (current as any).unshift(
+          nls.localize('arduino/examples/for', 'Examples for {0}', name)
+        );
       }
       if (any.length) {
-        (any as any).unshift('Examples for any board');
+        (any as any).unshift(
+          nls.localize('arduino/examples/forAny', 'Examples for any board')
+        );
       }
       for (const container of user) {
         this.registerRecursively(

--- a/arduino-ide-extension/src/browser/contributions/help.ts
+++ b/arduino-ide-extension/src/browser/contributions/help.ts
@@ -12,6 +12,7 @@ import {
   CommandRegistry,
   KeybindingRegistry,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class Help extends Contribution {
@@ -61,8 +62,8 @@ export class Help extends Contribution {
         }
         if (!searchFor) {
           searchFor = await this.quickInputService.input({
-            prompt: 'Search on Arduino.cc',
-            placeHolder: 'Type a keyword',
+            prompt: nls.localize('arduino/help/search', 'Search on Arduino.cc'),
+            placeHolder: nls.localize('arduino/help/keyword', 'Type a keyword'),
           });
         }
         if (searchFor) {
@@ -128,37 +129,37 @@ export namespace Help {
   export namespace Commands {
     export const GETTING_STARTED: Command = {
       id: 'arduino-getting-started',
-      label: 'Getting Started',
+      label: nls.localize('arduino/help/gettingStarted', 'Getting Started'),
       category: 'Arduino',
     };
     export const ENVIRONMENT: Command = {
       id: 'arduino-environment',
-      label: 'Environment',
+      label: nls.localize('arduino/help/environment', 'Environment'),
       category: 'Arduino',
     };
     export const TROUBLESHOOTING: Command = {
       id: 'arduino-troubleshooting',
-      label: 'Troubleshooting',
+      label: nls.localize('arduino/help/troubleshooting', 'Troubleshooting'),
       category: 'Arduino',
     };
     export const REFERENCE: Command = {
       id: 'arduino-reference',
-      label: 'Reference',
+      label: nls.localize('arduino/help/reference', 'Reference'),
       category: 'Arduino',
     };
     export const FIND_IN_REFERENCE: Command = {
       id: 'arduino-find-in-reference',
-      label: 'Find in Reference',
+      label: nls.localize('arduino/help/findInReference', 'Find in Reference'),
       category: 'Arduino',
     };
     export const FAQ: Command = {
       id: 'arduino-faq',
-      label: 'Frequently Asked Questions',
+      label: nls.localize('arduino/help/faq', 'Frequently Asked Questions'),
       category: 'Arduino',
     };
     export const VISIT_ARDUINO: Command = {
       id: 'arduino-visit-arduino',
-      label: 'Visit Arduino.cc',
+      label: nls.localize('arduino/help/visit', 'Visit Arduino.cc'),
       category: 'Arduino',
     };
   }

--- a/arduino-ide-extension/src/browser/contributions/include-library.ts
+++ b/arduino-ide-extension/src/browser/contributions/include-library.ts
@@ -15,6 +15,7 @@ import { LibraryListWidget } from '../library/library-list-widget';
 import { BoardsServiceProvider } from '../boards/boards-service-provider';
 import { SketchContribution, Command, CommandRegistry } from './contribution';
 import { NotificationCenter } from '../notification-center';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class IncludeLibrary extends SketchContribution {
@@ -59,13 +60,20 @@ export class IncludeLibrary extends SketchContribution {
       ...ArduinoMenus.SKETCH__UTILS_GROUP,
       '0_include',
     ];
-    registry.registerSubmenu(includeLibMenuPath, 'Include Library', {
-      order: '1',
-    });
+    registry.registerSubmenu(
+      includeLibMenuPath,
+      nls.localize('arduino/library/include', 'Include Library'),
+      {
+        order: '1',
+      }
+    );
     // `Manage Libraries...` group.
     registry.registerMenuAction([...includeLibMenuPath, '0_manage'], {
       commandId: `${LibraryListWidget.WIDGET_ID}:toggle`,
-      label: 'Manage Libraries...',
+      label: nls.localize(
+        'arduino/library/manageLibraries',
+        'Manage Libraries...'
+      ),
     });
   }
 
@@ -101,10 +109,17 @@ export class IncludeLibrary extends SketchContribution {
       const userMenuPath = [...includeLibMenuPath, '3_contributed'];
       const { user, rest } = LibraryPackage.groupByLocation(libraries);
       if (rest.length) {
-        (rest as any).unshift('Arduino libraries');
+        (rest as any).unshift(
+          nls.localize('arduino/library/arduinoLibraries', 'Arduino libraries')
+        );
       }
       if (user.length) {
-        (user as any).unshift('Contributed libraries');
+        (user as any).unshift(
+          nls.localize(
+            'arduino/library/contributedLibraries',
+            'Contributed libraries'
+          )
+        );
       }
 
       for (const library of user) {

--- a/arduino-ide-extension/src/browser/contributions/new-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/new-sketch.ts
@@ -1,3 +1,4 @@
+import { nls } from '@theia/core/lib/browser/nls';
 import { injectable } from 'inversify';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { ArduinoToolbar } from '../toolbar/arduino-toolbar';
@@ -27,7 +28,7 @@ export class NewSketch extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.FILE__SKETCH_GROUP, {
       commandId: NewSketch.Commands.NEW_SKETCH.id,
-      label: 'New',
+      label: nls.localize('arduino/sketch/new', 'New'),
       order: '0',
     });
   }
@@ -43,7 +44,7 @@ export class NewSketch extends SketchContribution {
     registry.registerItem({
       id: NewSketch.Commands.NEW_SKETCH__TOOLBAR.id,
       command: NewSketch.Commands.NEW_SKETCH__TOOLBAR.id,
-      tooltip: 'New',
+      tooltip: nls.localize('arduino/sketch/new', 'New'),
       priority: 3,
     });
   }

--- a/arduino-ide-extension/src/browser/contributions/open-recent-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-recent-sketch.ts
@@ -14,6 +14,7 @@ import { ArduinoMenus } from '../menu/arduino-menus';
 import { MainMenuManager } from '../../common/main-menu-manager';
 import { OpenSketch } from './open-sketch';
 import { NotificationCenter } from '../notification-center';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class OpenRecentSketch extends SketchContribution {
@@ -48,7 +49,7 @@ export class OpenRecentSketch extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerSubmenu(
       ArduinoMenus.FILE__OPEN_RECENT_SUBMENU,
-      'Open Recent',
+      nls.localize('arduino/sketch/openRecent', 'Open Recent'),
       { order: '2' }
     );
   }

--- a/arduino-ide-extension/src/browser/contributions/open-sketch-external.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch-external.ts
@@ -9,6 +9,7 @@ import {
   MenuModelRegistry,
   KeybindingRegistry,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class OpenSketchExternal extends SketchContribution {
@@ -21,7 +22,7 @@ export class OpenSketchExternal extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.SKETCH__UTILS_GROUP, {
       commandId: OpenSketchExternal.Commands.OPEN_EXTERNAL.id,
-      label: 'Show Sketch Folder',
+      label: nls.localize('arduino/sketch/showFolder', 'Show Sketch Folder'),
       order: '0',
     });
   }
@@ -36,7 +37,7 @@ export class OpenSketchExternal extends SketchContribution {
   protected async openExternal(): Promise<void> {
     const uri = await this.sketchServiceClient.currentSketchFile();
     if (uri) {
-      const exists = this.fileService.exists(new URI(uri));
+      const exists = await this.fileService.exists(new URI(uri));
       if (exists) {
         const fsPath = await this.fileService.fsPath(new URI(uri));
         if (fsPath) {

--- a/arduino-ide-extension/src/browser/contributions/open-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch.ts
@@ -22,6 +22,7 @@ import { ExamplesService } from '../../common/protocol/examples-service';
 import { BuiltInExamples } from './examples';
 import { Sketchbook } from './sketchbook';
 import { SketchContainer } from '../../common/protocol';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class OpenSketch extends SketchContribution {
@@ -70,7 +71,10 @@ export class OpenSketch extends SketchContribution {
             ArduinoMenus.OPEN_SKETCH__CONTEXT__OPEN_GROUP,
             {
               commandId: OpenSketch.Commands.OPEN_SKETCH.id,
-              label: 'Open...',
+              label: nls.localize(
+                'vscode/workspaceActions/openFileFolder',
+                'Open...'
+              ),
             }
           );
           this.toDispose.push(
@@ -115,7 +119,7 @@ export class OpenSketch extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.FILE__SKETCH_GROUP, {
       commandId: OpenSketch.Commands.OPEN_SKETCH.id,
-      label: 'Open...',
+      label: nls.localize('vscode/workspaceActions/openFileFolder', 'Open...'),
       order: '1',
     });
   }
@@ -131,7 +135,7 @@ export class OpenSketch extends SketchContribution {
     registry.registerItem({
       id: OpenSketch.Commands.OPEN_SKETCH__TOOLBAR.id,
       command: OpenSketch.Commands.OPEN_SKETCH__TOOLBAR.id,
-      tooltip: 'Open',
+      tooltip: nls.localize('vscode/dialogMainService/open', 'Open'),
       priority: 4,
     });
   }
@@ -155,7 +159,7 @@ export class OpenSketch extends SketchContribution {
       properties: ['createDirectory', 'openFile'],
       filters: [
         {
-          name: 'Sketch',
+          name: nls.localize('arduino/sketch/sketch', 'Sketch'),
           extensions: ['ino', 'pde'],
         },
       ],
@@ -178,10 +182,18 @@ export class OpenSketch extends SketchContribution {
       const name = new URI(sketchFileUri).path.name;
       const nameWithExt = this.labelProvider.getName(new URI(sketchFileUri));
       const { response } = await remote.dialog.showMessageBox({
-        title: 'Moving',
+        title: nls.localize('arduino/sketch/moving', 'Moving'),
         type: 'question',
-        buttons: ['Cancel', 'OK'],
-        message: `The file "${nameWithExt}" needs to be inside a sketch folder named as "${name}".\nCreate this folder, move the file, and continue?`,
+        buttons: [
+          nls.localize('vscode/issueMainService/cancel', 'Cancel'),
+          nls.localize('vscode/issueMainService/ok', 'OK'),
+        ],
+        message: nls.localize(
+          'arduino/sketch/movingMsg',
+          'The file "{0}" needs to be inside a sketch folder named as "{1}".\nCreate this folder, move the file, and continue?',
+          nameWithExt,
+          name
+        ),
       });
       if (response === 1) {
         // OK
@@ -190,8 +202,12 @@ export class OpenSketch extends SketchContribution {
         if (exists) {
           await remote.dialog.showMessageBox({
             type: 'error',
-            title: 'Error',
-            message: `A folder named "${name}" already exists. Can't open sketch.`,
+            title: nls.localize('vscode/dialog/dialogErrorMessage', 'Error'),
+            message: nls.localize(
+              'arduino/sketch/cantOpen',
+              'A folder named "{0}" already exists. Can\'t open sketch.',
+              name
+            ),
           });
           return undefined;
         }

--- a/arduino-ide-extension/src/browser/contributions/quit-app.ts
+++ b/arduino-ide-extension/src/browser/contributions/quit-app.ts
@@ -9,6 +9,7 @@ import {
   CommandRegistry,
 } from './contribution';
 import { ArduinoMenus } from '../menu/arduino-menus';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class QuitApp extends Contribution {
@@ -25,7 +26,7 @@ export class QuitApp extends Contribution {
     if (!isOSX) {
       registry.registerMenuAction(ArduinoMenus.FILE__QUIT_GROUP, {
         commandId: QuitApp.Commands.QUIT_APP.id,
-        label: 'Quit',
+        label: nls.localize('vscode/bulkEditService/quit', 'Quit'),
         order: '0',
       });
     }

--- a/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
@@ -10,6 +10,7 @@ import {
   MenuModelRegistry,
   KeybindingRegistry,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class SaveAsSketch extends SketchContribution {
@@ -22,7 +23,7 @@ export class SaveAsSketch extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.FILE__SKETCH_GROUP, {
       commandId: SaveAsSketch.Commands.SAVE_AS_SKETCH.id,
-      label: 'Save As...',
+      label: nls.localize('vscode/fileCommands/saveAs', 'Save As...'),
       order: '7',
     });
   }
@@ -73,7 +74,10 @@ export class SaveAsSketch extends SketchContribution {
       : sketchDirUri.resolve(sketch.name);
     const defaultPath = await this.fileService.fsPath(defaultUri);
     const { filePath, canceled } = await remote.dialog.showSaveDialog({
-      title: 'Save sketch folder as...',
+      title: nls.localize(
+        'arduino/sketch/saveFolderAs',
+        'Save sketch folder as...'
+      ),
       defaultPath,
     });
     if (!filePath || canceled) {

--- a/arduino-ide-extension/src/browser/contributions/save-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/save-sketch.ts
@@ -10,6 +10,7 @@ import {
   KeybindingRegistry,
   TabBarToolbarRegistry,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class SaveSketch extends SketchContribution {
@@ -28,7 +29,7 @@ export class SaveSketch extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.FILE__SKETCH_GROUP, {
       commandId: SaveSketch.Commands.SAVE_SKETCH.id,
-      label: 'Save',
+      label: nls.localize('vscode/fileCommands/save', 'Save'),
       order: '6',
     });
   }
@@ -44,7 +45,7 @@ export class SaveSketch extends SketchContribution {
     registry.registerItem({
       id: SaveSketch.Commands.SAVE_SKETCH__TOOLBAR.id,
       command: SaveSketch.Commands.SAVE_SKETCH__TOOLBAR.id,
-      tooltip: 'Save',
+      tooltip: nls.localize('vscode/fileCommands/save', 'Save'),
       priority: 5,
     });
   }

--- a/arduino-ide-extension/src/browser/contributions/settings.ts
+++ b/arduino-ide-extension/src/browser/contributions/settings.ts
@@ -8,6 +8,7 @@ import {
 } from './contribution';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { Settings as Preferences, SettingsDialog } from '../settings';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class Settings extends SketchContribution {
@@ -40,7 +41,11 @@ export class Settings extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.FILE__PREFERENCES_GROUP, {
       commandId: Settings.Commands.OPEN.id,
-      label: 'Preferences...',
+      label:
+        nls.localize(
+          'vscode/preferences.contribution/preferences',
+          'Preferences'
+        ) + '...',
       order: '0',
     });
     registry.registerSubmenu(ArduinoMenus.FILE__ADVANCED_SUBMENU, 'Advanced');
@@ -58,7 +63,11 @@ export namespace Settings {
   export namespace Commands {
     export const OPEN: Command = {
       id: 'arduino-settings-open',
-      label: 'Open Preferences...',
+      label:
+        nls.localize(
+          'vscode/preferences.contribution/openSettings2',
+          'Open Preferences'
+        ) + '...',
       category: 'Arduino',
     };
   }

--- a/arduino-ide-extension/src/browser/contributions/sketch-control.ts
+++ b/arduino-ide-extension/src/browser/contributions/sketch-control.ts
@@ -21,6 +21,7 @@ import { ArduinoMenus, PlaceholderMenuNode } from '../menu/arduino-menus';
 import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
 import { SketchesServiceClientImpl } from '../../common/protocol/sketches-service-client-impl';
 import { LocalCacheFsProvider } from '../local-cache/local-cache-fs-provider';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class SketchControl extends SketchContribution {
@@ -93,7 +94,7 @@ export class SketchControl extends SketchContribution {
               ArduinoMenus.SKETCH_CONTROL__CONTEXT__MAIN_GROUP,
               {
                 commandId: WorkspaceCommands.FILE_RENAME.id,
-                label: 'Rename',
+                label: nls.localize('vscode/fileActions/rename', 'Rename'),
                 order: '1',
               }
             );
@@ -107,7 +108,7 @@ export class SketchControl extends SketchContribution {
           } else {
             const renamePlaceholder = new PlaceholderMenuNode(
               ArduinoMenus.SKETCH_CONTROL__CONTEXT__MAIN_GROUP,
-              'Rename'
+              nls.localize('vscode/fileActions/rename', 'Rename')
             );
             this.menuRegistry.registerMenuNode(
               ArduinoMenus.SKETCH_CONTROL__CONTEXT__MAIN_GROUP,
@@ -130,7 +131,7 @@ export class SketchControl extends SketchContribution {
               ArduinoMenus.SKETCH_CONTROL__CONTEXT__MAIN_GROUP,
               {
                 commandId: WorkspaceCommands.FILE_DELETE.id, // TODO: customize delete. Wipe sketch if deleting main file. Close window.
-                label: 'Delete',
+                label: nls.localize('vscode/fileActions/delete', 'Delete'),
                 order: '2',
               }
             );
@@ -144,7 +145,7 @@ export class SketchControl extends SketchContribution {
           } else {
             const deletePlaceholder = new PlaceholderMenuNode(
               ArduinoMenus.SKETCH_CONTROL__CONTEXT__MAIN_GROUP,
-              'Delete'
+              nls.localize('vscode/fileActions/delete', 'Delete')
             );
             this.menuRegistry.registerMenuNode(
               ArduinoMenus.SKETCH_CONTROL__CONTEXT__MAIN_GROUP,
@@ -204,7 +205,7 @@ export class SketchControl extends SketchContribution {
       ArduinoMenus.SKETCH_CONTROL__CONTEXT__MAIN_GROUP,
       {
         commandId: WorkspaceCommands.NEW_FILE.id,
-        label: 'New Tab',
+        label: nls.localize('vscode/menubar/mNewTab', 'New Tab'),
         order: '0',
       }
     );
@@ -213,7 +214,7 @@ export class SketchControl extends SketchContribution {
       ArduinoMenus.SKETCH_CONTROL__CONTEXT__NAVIGATION_GROUP,
       {
         commandId: CommonCommands.PREVIOUS_TAB.id,
-        label: 'Previous Tab',
+        label: nls.localize('vscode/menubar/mShowPreviousTab', 'Previous Tab'),
         order: '0',
       }
     );
@@ -221,7 +222,7 @@ export class SketchControl extends SketchContribution {
       ArduinoMenus.SKETCH_CONTROL__CONTEXT__NAVIGATION_GROUP,
       {
         commandId: CommonCommands.NEXT_TAB.id,
-        label: 'Next Tab',
+        label: nls.localize('vscode/menubar/mShowNextTab', 'Next Tab'),
         order: '0',
       }
     );

--- a/arduino-ide-extension/src/browser/contributions/sketchbook.ts
+++ b/arduino-ide-extension/src/browser/contributions/sketchbook.ts
@@ -7,6 +7,7 @@ import { NotificationCenter } from '../notification-center';
 import { Examples } from './examples';
 import { SketchContainer } from '../../common/protocol';
 import { OpenSketch } from './open-sketch';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class Sketchbook extends Examples {
@@ -38,7 +39,7 @@ export class Sketchbook extends Examples {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerSubmenu(
       ArduinoMenus.FILE__SKETCHBOOK_SUBMENU,
-      'Sketchbook',
+      nls.localize('arduino/sketch/sketchbook', 'Sketchbook'),
       { order: '3' }
     );
   }

--- a/arduino-ide-extension/src/browser/contributions/upload-certificate.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-certificate.ts
@@ -18,6 +18,7 @@ import {
   certificateList,
 } from '../dialogs/certificate-uploader/utils';
 import { ArduinoFirmwareUploader } from '../../common/protocol/arduino-firmware-uploader';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class UploadCertificate extends Contribution {
@@ -111,25 +112,28 @@ export namespace UploadCertificate {
   export namespace Commands {
     export const OPEN: Command = {
       id: 'arduino-upload-certificate-open',
-      label: 'Upload SSL Root Certificates',
+      label: nls.localize(
+        'arduino/certificate/uploadRootCertificates',
+        'Upload SSL Root Certificates'
+      ),
       category: 'Arduino',
     };
 
     export const OPEN_CERT_CONTEXT: Command = {
       id: 'arduino-certificate-open-context',
-      label: 'Open context',
+      label: nls.localize('arduino/certificate/openContext', 'Open context'),
       category: 'Arduino',
     };
 
     export const REMOVE_CERT: Command = {
       id: 'arduino-certificate-remove',
-      label: 'Remove',
+      label: nls.localize('arduino/certificate/remove', 'Remove'),
       category: 'Arduino',
     };
 
     export const UPLOAD_CERT: Command = {
       id: 'arduino-certificate-upload',
-      label: 'Upload',
+      label: nls.localize('arduino/certificate/upload', 'Upload'),
       category: 'Arduino',
     };
   }

--- a/arduino-ide-extension/src/browser/contributions/upload-firmware.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-firmware.ts
@@ -7,6 +7,7 @@ import {
 } from './contribution';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { UploadFirmwareDialog } from '../dialogs/firmware-uploader/firmware-uploader-dialog';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class UploadFirmware extends Contribution {
@@ -42,7 +43,10 @@ export namespace UploadFirmware {
   export namespace Commands {
     export const OPEN: Command = {
       id: 'arduino-upload-firmware-open',
-      label: 'WiFi101 /  WiFiNINA Firmware Updater',
+      label: nls.localize(
+        'arduino/firmware/updater',
+        'WiFi101 /  WiFiNINA Firmware Updater'
+      ),
       category: 'Arduino',
     };
   }

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -14,6 +14,7 @@ import {
   KeybindingRegistry,
   TabBarToolbarRegistry,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class UploadSketch extends SketchContribution {
@@ -59,12 +60,15 @@ export class UploadSketch extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.SKETCH__MAIN_GROUP, {
       commandId: UploadSketch.Commands.UPLOAD_SKETCH.id,
-      label: 'Upload',
+      label: nls.localize('arduino/sketch/upload', 'Upload'),
       order: '1',
     });
     registry.registerMenuAction(ArduinoMenus.SKETCH__MAIN_GROUP, {
       commandId: UploadSketch.Commands.UPLOAD_SKETCH_USING_PROGRAMMER.id,
-      label: 'Upload Using Programmer',
+      label: nls.localize(
+        'arduino/sketch/uploadUsingProgrammer',
+        'Upload Using Programmer'
+      ),
       order: '2',
     });
   }
@@ -84,7 +88,7 @@ export class UploadSketch extends SketchContribution {
     registry.registerItem({
       id: UploadSketch.Commands.UPLOAD_SKETCH_TOOLBAR.id,
       command: UploadSketch.Commands.UPLOAD_SKETCH_TOOLBAR.id,
-      tooltip: 'Upload',
+      tooltip: nls.localize('arduino/sketch/upload', 'Upload'),
       priority: 1,
       onDidChange: this.onDidChange,
     });
@@ -161,7 +165,10 @@ export class UploadSketch extends SketchContribution {
       } else {
         await this.coreService.upload(options);
       }
-      this.messageService.info('Done uploading.', { timeout: 3000 });
+      this.messageService.info(
+        nls.localize('arduino/sketch/doneUploading', 'Done uploading.'),
+        { timeout: 3000 }
+      );
     } catch (e) {
       this.messageService.error(e.toString());
     } finally {
@@ -183,7 +190,11 @@ export class UploadSketch extends SketchContribution {
           }
         } catch (waitError) {
           this.messageService.error(
-            `Could not reconnect to serial monitor. ${waitError.toString()}`
+            nls.localize(
+              'arduino/sketch/couldNotConnectToMonitor',
+              'Could not reconnect to serial monitor. {0}',
+              waitError.toString()
+            )
           );
         }
       }

--- a/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
@@ -13,6 +13,7 @@ import {
   KeybindingRegistry,
   TabBarToolbarRegistry,
 } from './contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class VerifySketch extends SketchContribution {
@@ -52,12 +53,15 @@ export class VerifySketch extends SketchContribution {
   registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.SKETCH__MAIN_GROUP, {
       commandId: VerifySketch.Commands.VERIFY_SKETCH.id,
-      label: 'Verify/Compile',
+      label: nls.localize('arduino/sketch/verifyOrCompile', 'Verify/Compile'),
       order: '0',
     });
     registry.registerMenuAction(ArduinoMenus.SKETCH__MAIN_GROUP, {
       commandId: VerifySketch.Commands.EXPORT_BINARIES.id,
-      label: 'Export Compiled Binary',
+      label: nls.localize(
+        'arduino/sketch/exportBinary',
+        'Export Compiled Binary'
+      ),
       order: '3',
     });
   }
@@ -77,7 +81,7 @@ export class VerifySketch extends SketchContribution {
     registry.registerItem({
       id: VerifySketch.Commands.VERIFY_SKETCH_TOOLBAR.id,
       command: VerifySketch.Commands.VERIFY_SKETCH_TOOLBAR.id,
-      tooltip: 'Verify',
+      tooltip: nls.localize('arduino/sketch/verify', 'Verify'),
       priority: 0,
       onDidChange: this.onDidChange,
     });
@@ -118,7 +122,10 @@ export class VerifySketch extends SketchContribution {
         sourceOverride,
         compilerWarnings,
       });
-      this.messageService.info('Done compiling.', { timeout: 3000 });
+      this.messageService.info(
+        nls.localize('arduino/sketch/doneCompiling', 'Done compiling.'),
+        { timeout: 3000 }
+      );
     } catch (e) {
       this.messageService.error(e.toString());
     } finally {

--- a/arduino-ide-extension/src/browser/dialogs/certificate-uploader/certificate-add-new.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/certificate-uploader/certificate-add-new.tsx
@@ -1,3 +1,4 @@
+import { nls } from '@theia/core/lib/browser/nls';
 import * as React from 'react';
 
 export const CertificateAddComponent = ({
@@ -22,10 +23,18 @@ export const CertificateAddComponent = ({
       }}
     >
       <label>
-        <div>Add URL to fetch SSL certificate</div>
+        <div>
+          {nls.localize(
+            'arduino/certificate/addURL',
+            'Add URL to fetch SSL certificate'
+          )}
+        </div>
         <input
           className="theia-input"
-          placeholder="Enter URL"
+          placeholder={nls.localize(
+            'arduino/certificate/enterURL',
+            'Enter URL'
+          )}
           type="text"
           name="add"
           onChange={handleChange}

--- a/arduino-ide-extension/src/browser/dialogs/certificate-uploader/certificate-uploader-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/certificate-uploader/certificate-uploader-component.tsx
@@ -4,6 +4,7 @@ import { AvailableBoard } from '../../boards/boards-service-provider';
 import { CertificateListComponent } from './certificate-list';
 import { SelectBoardComponent } from './select-board-components';
 import { CertificateAddComponent } from './certificate-add-new';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const CertificateUploaderComponent = ({
   availableBoards,
@@ -71,7 +72,12 @@ export const CertificateUploaderComponent = ({
     <>
       <div className="dialogSection">
         <div className="dialogRow">
-          <strong className="fl1">1. Select certificate to upload</strong>
+          <strong className="fl1">
+            {nls.localize(
+              'arduino/certificate/selectCertificateToUpload',
+              '1. Select certificate to upload'
+            )}
+          </strong>
           <Tippy
             content={
               <CertificateAddComponent
@@ -93,7 +99,8 @@ export const CertificateUploaderComponent = ({
                 showAdd ? setShowAdd(false) : setShowAdd(true);
               }}
             >
-              Add New <span className="fa fa-caret-down caret"></span>
+              {nls.localize('arduino/certificate/addNew', 'Add New')}{' '}
+              <span className="fa fa-caret-down caret"></span>
             </button>
           </Tippy>
         </div>
@@ -108,7 +115,12 @@ export const CertificateUploaderComponent = ({
       </div>
       <div className="dialogSection">
         <div className="dialogRow">
-          <strong>2. Select destination board and upload certificate</strong>
+          <strong>
+            {nls.localize(
+              'arduino/certificate/selectDestinationBoardToUpload',
+              '2. Select destination board and upload certificate'
+            )}
+          </strong>
         </div>
         <div className="dialogRow">
           <div className="fl1">
@@ -126,19 +138,28 @@ export const CertificateUploaderComponent = ({
             {installFeedback === 'installing' && (
               <div className="success">
                 <div className="spinner" />
-                Uploading certificates.
+                {nls.localize(
+                  'arduino/certificate/uploadingCertificates',
+                  'Uploading certificates.'
+                )}
               </div>
             )}
             {installFeedback === 'ok' && (
               <div className="success">
                 <i className="fa fa-info status-icon" />
-                Cetificates uploaded.
+                {nls.localize(
+                  'arduino/certificate/certificatesUploaded',
+                  'Certificates uploaded.'
+                )}
               </div>
             )}
             {installFeedback === 'fail' && (
               <div className="warn">
                 <i className="fa fa-exclamation status-icon" />
-                Upload failed. Please try again.
+                {nls.localize(
+                  'arduino/certificate/uploadFailed',
+                  'Upload failed. Please try again.'
+                )}
               </div>
             )}
           </div>
@@ -148,7 +169,7 @@ export const CertificateUploaderComponent = ({
             onClick={installCertificates}
             disabled={selectedCerts.length === 0 || !selectedBoard}
           >
-            Upload
+            {nls.localize('arduino/certificate/upload', 'Upload')}
           </button>
         </div>
       </div>

--- a/arduino-ide-extension/src/browser/dialogs/certificate-uploader/certificate-uploader-dialog.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/certificate-uploader/certificate-uploader-dialog.tsx
@@ -18,6 +18,7 @@ import {
 import { CommandRegistry } from '@theia/core/lib/common/command';
 import { certificateList, sanifyCertString } from './utils';
 import { ArduinoFirmwareUploader } from '../../../common/protocol/arduino-firmware-uploader';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class UploadCertificateDialogWidget extends ReactWidget {
@@ -140,7 +141,12 @@ export class UploadCertificateDialog extends AbstractDialog<void> {
     @inject(UploadCertificateDialogProps)
     protected readonly props: UploadCertificateDialogProps
   ) {
-    super({ title: 'Upload SSL Root Certificates' });
+    super({
+      title: nls.localize(
+        'arduino/certificate/uploadRootCertificates',
+        'Upload SSL Root Certificates'
+      ),
+    });
     this.contentNode.classList.add('certificate-uploader-dialog');
     this.acceptButton = undefined;
   }

--- a/arduino-ide-extension/src/browser/dialogs/certificate-uploader/select-board-components.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/certificate-uploader/select-board-components.tsx
@@ -1,3 +1,4 @@
+import { nls } from '@theia/core/lib/browser/nls';
 import * as React from 'react';
 import { AvailableBoard } from '../../boards/boards-service-provider';
 import { ArduinoSelect } from '../../widgets/arduino-select';
@@ -39,7 +40,10 @@ export const SelectBoardComponent = ({
       return;
     }
 
-    let placeholderTxt = 'Select a board...';
+    let placeholderTxt = nls.localize(
+      'arduino/certificate/selectBoard',
+      'Select a board...'
+    );
     let selBoard = -1;
     const updatableBoards = availableBoards.filter(
       (board) => board.port && board.fqbn && updatableFqbns.includes(board.fqbn)
@@ -49,13 +53,21 @@ export const SelectBoardComponent = ({
         selBoard = i;
       }
       return {
-        label: `${board.name} at ${board.port?.address}`,
+        label: nls.localize(
+          'arduino/certificate/boardAtPort',
+          '{0} at {1}',
+          board.name,
+          board.port?.address ?? ''
+        ),
         value: board.fqbn || '',
       };
     });
 
     if (boardsList.length === 0) {
-      placeholderTxt = 'No supported board connected';
+      placeholderTxt = nls.localize(
+        'arduino/certificate/noSupportedBoardConnected',
+        'No supported board connected'
+      );
     }
 
     setSelectBoardPlaceholder(placeholderTxt);
@@ -80,7 +92,12 @@ export const SelectBoardComponent = ({
       value={
         (selectedBoard && {
           value: selectedBoard.fqbn,
-          label: `${selectedBoard.name} at ${selectedBoard.port?.address}`,
+          label: nls.localize(
+            'arduino/certificate/boardAtPort',
+            '{0} at {1}',
+            selectedBoard.name,
+            selectedBoard.port?.address ?? ''
+          ),
         }) ||
         null
       }

--- a/arduino-ide-extension/src/browser/dialogs/cloud-share-sketch-dialog.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/cloud-share-sketch-dialog.tsx
@@ -6,6 +6,7 @@ import { clipboard } from 'electron';
 import { ReactWidget, DialogProps } from '@theia/core/lib/browser';
 import { AbstractDialog } from '../theia/dialogs/dialogs';
 import { CreateApi } from '../create/create-api';
+import { nls } from '@theia/core/lib/browser/nls';
 
 const RadioButton = (props: {
   id: string;
@@ -59,12 +60,20 @@ export const ShareSketchComponent = ({
 
   return (
     <div id="widget-container arduino-sharesketch-dialog">
-      <p>Choose visibility of your Sketch:</p>
+      <p>
+        {nls.localize(
+          'arduino/cloud/chooseSketchVisibility',
+          'Choose visibility of your Sketch:'
+        )}
+      </p>
       <RadioButton
         changed={radioChangeHandler}
         id="1"
         isSelected={treeNode.isPublic === false}
-        label="Private. Only you can view the Sketch."
+        label={nls.localize(
+          'arduino/cloud/privateVisibility',
+          'Private. Only you can view the Sketch.'
+        )}
         value="private"
         isDisabled={loading}
       />
@@ -72,14 +81,17 @@ export const ShareSketchComponent = ({
         changed={radioChangeHandler}
         id="2"
         isSelected={treeNode.isPublic === true}
-        label="Public. Anyone with the link can view the Sketch."
+        label={nls.localize(
+          'arduino/cloud/publicVisibility',
+          'Public. Anyone with the link can view the Sketch.'
+        )}
         value="public"
         isDisabled={loading}
       />
 
       {treeNode.isPublic && (
         <div>
-          <p>Link:</p>
+          <p>{nls.localize('arduino/cloud/link', 'Link:')}</p>
           <div className="sketch-link">
             <input
               type="text"
@@ -92,10 +104,10 @@ export const ShareSketchComponent = ({
               value="copy"
               className="theia-button secondary"
             >
-              Copy
+              {nls.localize('vscode/textInputActions/copy', 'Copy')}
             </button>
           </div>
-          <p>Embed:</p>
+          <p>{nls.localize('arduino/cloud/embed', 'Embed:')}</p>
           <div className="sketch-link-embed">
             <textarea
               readOnly

--- a/arduino-ide-extension/src/browser/dialogs/do-not-ask-again-dialog.ts
+++ b/arduino-ide-extension/src/browser/dialogs/do-not-ask-again-dialog.ts
@@ -6,6 +6,7 @@ import {
   ConfirmDialogProps,
   DialogError,
 } from '@theia/core/lib/browser/dialogs';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class DoNotAskAgainDialogProps extends ConfirmDialogProps {
@@ -31,7 +32,10 @@ export class DoNotAskAgainConfirmDialog extends ConfirmDialog {
     const doNotAskAgainLabel = document.createElement('label');
     doNotAskAgainLabel.classList.add('flex-line');
     doNotAskAgainNode.appendChild(doNotAskAgainLabel);
-    doNotAskAgainLabel.textContent = "Don't ask again";
+    doNotAskAgainLabel.textContent = nls.localize(
+      'arduino/dialog/dontAskAgain',
+      "Don't ask again"
+    );
     this.doNotAskAgainCheckbox = document.createElement('input');
     this.doNotAskAgainCheckbox.setAttribute('align-self', 'center');
     doNotAskAgainLabel.appendChild(this.doNotAskAgainCheckbox);

--- a/arduino-ide-extension/src/browser/dialogs/firmware-uploader/firmware-uploader-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/firmware-uploader/firmware-uploader-component.tsx
@@ -1,3 +1,4 @@
+import { nls } from '@theia/core/lib/browser/nls';
 import * as React from 'react';
 import {
   ArduinoFirmwareUploader,
@@ -106,7 +107,9 @@ export const FirmwareUploaderComponent = ({
     <>
       <div className="dialogSection">
         <div className="dialogRow">
-          <label htmlFor="board-select">Select board</label>
+          <label htmlFor="board-select">
+            {nls.localize('arduino/firmware/selectBoard', 'Select Board')}
+          </label>
         </div>
         <div className="dialogRow">
           <div className="fl1">
@@ -128,7 +131,7 @@ export const FirmwareUploaderComponent = ({
             }
             onClick={fetchFirmwares}
           >
-            Check Updates
+            {nls.localize('arduino/firmware/checkUpdates', 'Check Updates')}
           </button>
         </div>
       </div>
@@ -137,7 +140,10 @@ export const FirmwareUploaderComponent = ({
           <div className="dialogSection">
             <div className="dialogRow">
               <label htmlFor="firmware-select" className="fl1">
-                Select firmware version
+                {nls.localize(
+                  'arduino/firmware/selectVersion',
+                  'Select firmware version'
+                )}
               </label>
               <ArduinoSelect
                 id="firmware-select"
@@ -167,7 +173,7 @@ export const FirmwareUploaderComponent = ({
                 }
                 onClick={installFirmware}
               >
-                Install
+                {nls.localize('arduino/firmware/install', 'Install')}
               </button>
             </div>
           </div>
@@ -175,25 +181,37 @@ export const FirmwareUploaderComponent = ({
             {installFeedback === null && (
               <div className="dialogRow warn">
                 <i className="fa fa-exclamation status-icon" />
-                Installation will overwrite the Sketch on the board.
+                {nls.localize(
+                  'arduino/firmware/overwriteSketch',
+                  'Installation will overwrite the Sketch on the board.'
+                )}
               </div>
             )}
             {installFeedback === 'installing' && (
               <div className="dialogRow success">
                 <div className="spinner" />
-                Installing firmware.
+                {nls.localize(
+                  'arduino/firmware/installingFirmware',
+                  'Installing firmware.'
+                )}
               </div>
             )}
             {installFeedback === 'ok' && (
               <div className="dialogRow success">
                 <i className="fa fa-info status-icon" />
-                Firmware succesfully installed.
+                {nls.localize(
+                  'arduino/firmware/successfullyInstalled',
+                  'Firmware succesfully installed.'
+                )}
               </div>
             )}
             {installFeedback === 'fail' && (
               <div className="dialogRow warn">
                 <i className="fa fa-exclamation status-icon" />
-                Installation failed. Please try again.
+                {nls.localize(
+                  'arduino/firmware/failedInstall',
+                  'Installation failed. Please try again.'
+                )}
               </div>
             )}
           </div>

--- a/arduino-ide-extension/src/browser/library/library-list-widget.ts
+++ b/arduino-ide-extension/src/browser/library/library-list-widget.ts
@@ -10,11 +10,15 @@ import {
 import { ListWidget } from '../widgets/component-list/list-widget';
 import { Installable } from '../../common/protocol';
 import { ListItemRenderer } from '../widgets/component-list/list-item-renderer';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class LibraryListWidget extends ListWidget<LibraryPackage> {
   static WIDGET_ID = 'library-list-widget';
-  static WIDGET_LABEL = 'Library Manager';
+  static WIDGET_LABEL = nls.localize(
+    'arduino/library/title',
+    'Library Manager'
+  );
 
   constructor(
     @inject(LibraryService) protected service: LibraryService,
@@ -61,11 +65,20 @@ export class LibraryListWidget extends ListWidget<LibraryPackage> {
     let installDependencies: boolean | undefined = undefined;
     if (dependencies.length) {
       const message = document.createElement('div');
-      message.innerHTML = `The library <b>${item.name}:${version}</b> needs ${
+      message.innerHTML =
         dependencies.length === 1
-          ? 'another dependency'
-          : 'some other dependencies'
-      } currently not installed:`;
+          ? nls.localize(
+              'arduino/library/needsOneDependency',
+              'The library <b>{0}:{1}</b> needs another dependency currently not installed:',
+              item.name,
+              version
+            )
+          : nls.localize(
+              'arduino/library/needsMultipleDependencies',
+              'The library <b>{0}:{1}</b> needs some other dependencies currently not installed:',
+              item.name,
+              version
+            );
       const listContainer = document.createElement('div');
       listContainer.style.maxHeight = '300px';
       listContainer.style.overflowY = 'auto';
@@ -80,16 +93,34 @@ export class LibraryListWidget extends ListWidget<LibraryPackage> {
       listContainer.appendChild(list);
       message.appendChild(listContainer);
       const question = document.createElement('div');
-      question.textContent = `Would you like to install ${
+      question.textContent =
         dependencies.length === 1
-          ? 'the missing dependency'
-          : 'all the missing dependencies'
-      }?`;
+          ? nls.localize(
+              'arduino/library/installOneMissingDependency',
+              'Would you like to install the missing dependency?'
+            )
+          : nls.localize(
+              'arduino/library/installMissingDependencies',
+              'Would you like to install all the missing dependencies?'
+            );
       message.appendChild(question);
       const result = await new MessageBoxDialog({
-        title: `Dependencies for library ${item.name}:${version}`,
+        title: nls.localize(
+          'arduino/library/dependenciesForLibrary',
+          'Dependencies for library {0}:{1}',
+          item.name,
+          version
+        ),
         message,
-        buttons: ['Install all', `Install ${item.name} only`, 'Cancel'],
+        buttons: [
+          nls.localize('arduino/library/installAll', 'Install all'),
+          nls.localize(
+            'arduino/library/installOnly',
+            'Install {0} only',
+            item.name
+          ),
+          nls.localize('vscode/issueMainService/cancel', 'Cancel'),
+        ],
         maxWidth: 740, // Aligned with `settings-dialog.css`.
       }).open();
 
@@ -116,7 +147,12 @@ export class LibraryListWidget extends ListWidget<LibraryPackage> {
         installDependencies,
       });
       this.messageService.info(
-        `Successfully installed library ${item.name}:${version}`,
+        nls.localize(
+          'arduino/library/installedSuccessfully',
+          'Successfully installed library {0}:{1}',
+          item.name,
+          version
+        ),
         { timeout: 3000 }
       );
     }
@@ -131,7 +167,12 @@ export class LibraryListWidget extends ListWidget<LibraryPackage> {
   }): Promise<void> {
     await super.uninstall({ item, progressId });
     this.messageService.info(
-      `Successfully uninstalled library ${item.name}:${item.installedVersion}`,
+      nls.localize(
+        'arduino/library/uninstalledSuccessfully',
+        'Successfully uninstalled library {0}:{1}',
+        item.name,
+        item.installedVersion!
+      ),
       { timeout: 3000 }
     );
   }
@@ -143,7 +184,9 @@ class MessageBoxDialog extends AbstractDialog<MessageBoxDialog.Result> {
   constructor(protected readonly options: MessageBoxDialog.Options) {
     super(options);
     this.contentNode.appendChild(this.createMessageNode(this.options.message));
-    (options.buttons || ['OK']).forEach((text, index) => {
+    (
+      options.buttons || [nls.localize('vscode/issueMainService/ok', 'OK')]
+    ).forEach((text, index) => {
       const button = this.createButton(text);
       button.classList.add(index === 0 ? 'main' : 'secondary');
       this.controlPanel.appendChild(button);

--- a/arduino-ide-extension/src/browser/library/library-widget-frontend-contribution.ts
+++ b/arduino-ide-extension/src/browser/library/library-widget-frontend-contribution.ts
@@ -4,6 +4,7 @@ import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-con
 import { MenuModelRegistry } from '@theia/core';
 import { LibraryListWidget } from './library-list-widget';
 import { ArduinoMenus } from '../menu/arduino-menus';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class LibraryListWidgetFrontendContribution
@@ -31,7 +32,10 @@ export class LibraryListWidgetFrontendContribution
     if (this.toggleCommand) {
       menus.registerMenuAction(ArduinoMenus.TOOLS__MAIN_GROUP, {
         commandId: this.toggleCommand.id,
-        label: 'Manage Libraries...',
+        label: nls.localize(
+          'arduino/library/manageLibraries',
+          'Manage Libraries...'
+        ),
         order: '3',
       });
     }

--- a/arduino-ide-extension/src/browser/monitor/monitor-connection.ts
+++ b/arduino-ide-extension/src/browser/monitor/monitor-connection.ts
@@ -20,6 +20,7 @@ import {
 import { BoardsConfig } from '../boards/boards-config';
 import { MonitorModel } from './monitor-model';
 import { NotificationCenter } from '../notification-center';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class MonitorConnection {
@@ -145,7 +146,11 @@ export class MonitorConnection {
         }
         case MonitorError.ErrorCodes.DEVICE_BUSY: {
           this.messageService.warn(
-            `Connection failed. Serial port is busy: ${Port.toString(port)}.`,
+            nls.localize(
+              'arduino/monitor/connectionBusy',
+              'Connection failed. Serial port is busy: {0}',
+              Port.toString(port)
+            ),
             options
           );
           shouldReconnect = this.autoConnect;
@@ -154,18 +159,26 @@ export class MonitorConnection {
         }
         case MonitorError.ErrorCodes.DEVICE_NOT_CONFIGURED: {
           this.messageService.info(
-            `Disconnected ${Board.toString(board, {
-              useFqbn: false,
-            })} from ${Port.toString(port)}.`,
+            nls.localize(
+              'arduino/monitor/disconnected',
+              'Disconnected {0} from {1}.',
+              Board.toString(board, {
+                useFqbn: false,
+              }),
+              Port.toString(port)
+            ),
             options
           );
           break;
         }
         case undefined: {
           this.messageService.error(
-            `Unexpected error. Reconnecting ${Board.toString(
-              board
-            )} on port ${Port.toString(port)}.`,
+            nls.localize(
+              'arduino/monitor/unexpectedError',
+              'Unexpected error. Reconnecting {0} on port {1}.',
+              Board.toString(board),
+              Port.toString(port)
+            ),
             options
           );
           console.error(JSON.stringify(error));
@@ -179,11 +192,14 @@ export class MonitorConnection {
       if (shouldReconnect) {
         if (this.monitorErrors.length >= 10) {
           this.messageService.warn(
-            `Failed to reconnect ${Board.toString(board, {
-              useFqbn: false,
-            })} to the the serial-monitor after 10 consecutive attempts. The ${Port.toString(
-              port
-            )} serial port is busy. after 10 consecutive attempts.`
+            nls.localize(
+              'arduino/monitor/failedReconnect',
+              'Failed to reconnect {0} to the the serial-monitor after 10 consecutive attempts. The {1} serial port is busy.',
+              Board.toString(board, {
+                useFqbn: false,
+              }),
+              Port.toString(port)
+            )
           );
           this.monitorErrors.length = 0;
         } else {
@@ -194,9 +210,15 @@ export class MonitorConnection {
           }
           const timeout = attempts * 1000;
           this.messageService.warn(
-            `Reconnecting ${Board.toString(board, {
-              useFqbn: false,
-            })} to ${Port.toString(port)} in ${attempts} seconds...`,
+            nls.localize(
+              'arduino/monitor/reconnect',
+              'Reconnecting {0} to {1} in {2] seconds...',
+              Board.toString(board, {
+                useFqbn: false,
+              }),
+              Port.toString(port),
+              attempts.toString()
+            ),
             { timeout }
           );
           this.reconnectTimeout = window.setTimeout(

--- a/arduino-ide-extension/src/browser/monitor/monitor-view-contribution.tsx
+++ b/arduino-ide-extension/src/browser/monitor/monitor-view-contribution.tsx
@@ -10,22 +10,32 @@ import {
 import { ArduinoToolbar } from '../toolbar/arduino-toolbar';
 import { MonitorModel } from './monitor-model';
 import { ArduinoMenus } from '../menu/arduino-menus';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace SerialMonitor {
   export namespace Commands {
-    export const AUTOSCROLL: Command = {
-      id: 'serial-monitor-autoscroll',
-      label: 'Autoscroll',
-    };
-    export const TIMESTAMP: Command = {
-      id: 'serial-monitor-timestamp',
-      label: 'Timestamp',
-    };
-    export const CLEAR_OUTPUT: Command = {
-      id: 'serial-monitor-clear-output',
-      label: 'Clear Output',
-      iconClass: 'clear-all',
-    };
+    export const AUTOSCROLL = Command.toLocalizedCommand(
+      {
+        id: 'serial-monitor-autoscroll',
+        label: 'Autoscroll',
+      },
+      'arduino/monitor/autoscroll'
+    );
+    export const TIMESTAMP = Command.toLocalizedCommand(
+      {
+        id: 'serial-monitor-timestamp',
+        label: 'Timestamp',
+      },
+      'arduino/monitor/timestamp'
+    );
+    export const CLEAR_OUTPUT = Command.toLocalizedCommand(
+      {
+        id: 'serial-monitor-clear-output',
+        label: 'Clear Output',
+        iconClass: 'clear-all',
+      },
+      'vscode/output.contribution/clearOutput.label'
+    );
   }
 }
 
@@ -43,7 +53,7 @@ export class MonitorViewContribution
   constructor() {
     super({
       widgetId: MonitorWidget.ID,
-      widgetName: 'Serial Monitor',
+      widgetName: MonitorWidget.LABEL,
       defaultWidgetOptions: {
         area: 'bottom',
       },
@@ -56,7 +66,7 @@ export class MonitorViewContribution
     if (this.toggleCommand) {
       menus.registerMenuAction(ArduinoMenus.TOOLS__MAIN_GROUP, {
         commandId: this.toggleCommand.id,
-        label: 'Serial Monitor',
+        label: MonitorWidget.LABEL,
         order: '5',
       });
     }
@@ -78,7 +88,10 @@ export class MonitorViewContribution
     registry.registerItem({
       id: SerialMonitor.Commands.CLEAR_OUTPUT.id,
       command: SerialMonitor.Commands.CLEAR_OUTPUT.id,
-      tooltip: 'Clear Output',
+      tooltip: nls.localize(
+        'vscode/output.contribution/clearOutput.label',
+        'Clear Output'
+      ),
     });
   }
 
@@ -120,7 +133,10 @@ export class MonitorViewContribution
     return (
       <React.Fragment key="autoscroll-toolbar-item">
         <div
-          title="Toggle Autoscroll"
+          title={nls.localize(
+            'vscode/output.contribution/toggleAutoScroll',
+            'Toggle Autoscroll'
+          )}
           className={`item enabled fa fa-angle-double-down arduino-monitor ${
             this.model.autoscroll ? 'toggled' : ''
           }`}
@@ -139,7 +155,10 @@ export class MonitorViewContribution
     return (
       <React.Fragment key="line-ending-toolbar-item">
         <div
-          title="Toggle Timestamp"
+          title={nls.localize(
+            'arduino/monitor/toggleTimestamp',
+            'Toggle Timestamp'
+          )}
           className={`item enabled fa fa-clock-o arduino-monitor ${
             this.model.timestamp ? 'toggled' : ''
           }`}

--- a/arduino-ide-extension/src/browser/monitor/monitor-widget.tsx
+++ b/arduino-ide-extension/src/browser/monitor/monitor-widget.tsx
@@ -15,9 +15,14 @@ import { MonitorModel } from './monitor-model';
 import { MonitorConnection } from './monitor-connection';
 import { SerialMonitorSendInput } from './serial-monitor-send-input';
 import { SerialMonitorOutput } from './serial-monitor-send-output';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class MonitorWidget extends ReactWidget {
+  static readonly LABEL = nls.localize(
+    'arduino/monitor/title',
+    'Serial Monitor'
+  );
   static readonly ID = 'serial-monitor';
 
   @inject(MonitorModel)
@@ -42,7 +47,7 @@ export class MonitorWidget extends ReactWidget {
   constructor() {
     super();
     this.id = MonitorWidget.ID;
-    this.title.label = 'Serial Monitor';
+    this.title.label = MonitorWidget.LABEL;
     this.title.iconClass = 'monitor-tab-icon';
     this.title.closable = true;
     this.scrollOptions = undefined;
@@ -118,19 +123,25 @@ export class MonitorWidget extends ReactWidget {
   > {
     return [
       {
-        label: 'No Line Ending',
+        label: nls.localize('arduino/monitor/noLineEndings', 'No Line Ending'),
         value: '',
       },
       {
-        label: 'New Line',
+        label: nls.localize('arduino/monitor/newLine', 'New Line'),
         value: '\n',
       },
       {
-        label: 'Carriage Return',
+        label: nls.localize(
+          'arduino/monitor/carriageReturn',
+          'Carriage Return'
+        ),
         value: '\r',
       },
       {
-        label: 'Both NL & CR',
+        label: nls.localize(
+          'arduino/monitor/newLineCarriageReturn',
+          'Both NL & CR'
+        ),
         value: '\r\n',
       },
     ];

--- a/arduino-ide-extension/src/browser/monitor/serial-monitor-send-input.tsx
+++ b/arduino-ide-extension/src/browser/monitor/serial-monitor-send-input.tsx
@@ -3,6 +3,7 @@ import { Key, KeyCode } from '@theia/core/lib/browser/keys';
 import { Board, Port } from '../../common/protocol/boards-service';
 import { MonitorConfig } from '../../common/protocol/monitor-service';
 import { isOSX } from '@theia/core/lib/common/os';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export namespace SerialMonitorSendInput {
   export interface Props {
@@ -44,14 +45,21 @@ export class SerialMonitorSendInput extends React.Component<
   protected get placeholder(): string {
     const { monitorConfig } = this.props;
     if (!monitorConfig) {
-      return 'Not connected. Select a board and a port to connect automatically.';
+      return nls.localize(
+        'arduino/monitor/notConnected',
+        'Not connected. Select a board and a port to connect automatically.'
+      );
     }
     const { board, port } = monitorConfig;
-    return `Message (${
-      isOSX ? '⌘' : 'Ctrl'
-    }+Enter to send message to '${Board.toString(board, {
-      useFqbn: false,
-    })}' on '${Port.toString(port)}')`;
+    return nls.localize(
+      'arduino/monitor/message',
+      "Message ({0} + Enter to send message to '{1}' on '{2}'",
+      isOSX ? '⌘' : nls.localize('vscode/keybindingLabels/ctrlKey', 'Ctrl'),
+      Board.toString(board, {
+        useFqbn: false,
+      }),
+      Port.toString(port)
+    );
   }
 
   protected setRef = (element: HTMLElement | null) => {

--- a/arduino-ide-extension/src/browser/settings.tsx
+++ b/arduino-ide-extension/src/browser/settings.tsx
@@ -33,6 +33,7 @@ import {
   ProxySettings,
 } from '../common/protocol';
 import { AbstractDialog } from './theia/dialogs/dialogs';
+import { nls } from '@theia/core/lib/browser/nls';
 
 const EDITOR_SETTING = 'editor';
 const FONT_SIZE_SETTING = `${EDITOR_SETTING}.fontSize`;
@@ -203,17 +204,27 @@ export class SettingsService {
       const { sketchbookPath, editorFontSize, themeId } = await settings;
       const sketchbookDir = await this.fileSystemExt.getUri(sketchbookPath);
       if (!(await this.fileService.exists(new URI(sketchbookDir)))) {
-        return `Invalid sketchbook location: ${sketchbookPath}`;
+        return nls.localize(
+          'arduino/preferences/invalid.sketchbook.location',
+          'Invalid sketchbook location: {0}',
+          sketchbookPath
+        );
       }
       if (editorFontSize <= 0) {
-        return 'Invalid editor font size. It must be a positive integer.';
+        return nls.localize(
+          'arduino/preferences/invalid.editorFontSize',
+          'Invalid editor font size. It must be a positive integer.'
+        );
       }
       if (
         !ThemeService.get()
           .getThemes()
           .find(({ id }) => id === themeId)
       ) {
-        return 'Invalid theme.';
+        return nls.localize(
+          'arduino/preferences/invalid.theme',
+          'Invalid theme.'
+        );
       }
       return true;
     } catch (err) {
@@ -366,8 +377,8 @@ export class SettingsComponent extends React.Component<
     return (
       <Tabs>
         <TabList>
-          <Tab>Settings</Tab>
-          <Tab>Network</Tab>
+          <Tab>{nls.localize('vscode/settingsTree/settings', 'Settings')}</Tab>
+          <Tab>{nls.localize('arduino/preferences/network', 'Network')}</Tab>
         </TabList>
         <TabPanel>{this.renderSettings()}</TabPanel>
         <TabPanel>{this.renderNetwork()}</TabPanel>
@@ -378,7 +389,10 @@ export class SettingsComponent extends React.Component<
   protected renderSettings(): React.ReactNode {
     return (
       <div className="content noselect">
-        Sketchbook location:
+        {nls.localize(
+          'arduino/preferences/sketchbook.location',
+          'Sketchbook location'
+        ) + ':'}
         <div className="flex-line">
           <input
             className="theia-input stretch"
@@ -390,7 +404,7 @@ export class SettingsComponent extends React.Component<
             className="theia-button shrink"
             onClick={this.browseSketchbookDidClick}
           >
-            Browse
+            {nls.localize('arduino/preferences/browse', 'Browse')}
           </button>
         </div>
         <label className="flex-line">
@@ -399,15 +413,43 @@ export class SettingsComponent extends React.Component<
             checked={this.state.sketchbookShowAllFiles === true}
             onChange={this.sketchbookShowAllFilesDidChange}
           />
-          Show files inside Sketches
+          {nls.localize(
+            'arduino/preferences/files.inside.sketches',
+            'Show files inside Sketches'
+          )}
         </label>
         <div className="flex-line">
           <div className="column">
-            <div className="flex-line">Editor font size:</div>
-            <div className="flex-line">Interface scale:</div>
-            <div className="flex-line">Theme:</div>
-            <div className="flex-line">Show verbose output during:</div>
-            <div className="flex-line">Compiler warnings:</div>
+            <div className="flex-line">
+              {nls.localize(
+                'arduino/preferences/editorFontSize',
+                'Editor font size'
+              ) + ':'}
+            </div>
+            <div className="flex-line">
+              {nls.localize(
+                'arduino/preferences/interfaceScale',
+                'Interface scale'
+              ) + ':'}
+            </div>
+            <div className="flex-line">
+              {nls.localize(
+                'vscode/themes.contribution/selectTheme.label',
+                'Theme'
+              ) + ':'}
+            </div>
+            <div className="flex-line">
+              {nls.localize(
+                'arduino/preferences/showVerbose',
+                'Show verbose output during'
+              )}
+            </div>
+            <div className="flex-line">
+              {nls.localize(
+                'arduino/preferences/compilerWarnings',
+                'Compiler warnings'
+              )}
+            </div>
           </div>
           <div className="column">
             <div className="flex-line">
@@ -428,7 +470,7 @@ export class SettingsComponent extends React.Component<
                   checked={this.state.autoScaleInterface}
                   onChange={this.autoScaleInterfaceDidChange}
                 />
-                Automatic
+                {nls.localize('arduino/preferences/automatic', 'Automatic')}
               </label>
               <input
                 className="theia-input small with-margin"
@@ -448,7 +490,7 @@ export class SettingsComponent extends React.Component<
                   ThemeService.get()
                     .getThemes()
                     .find(({ id }) => id === this.state.themeId)?.label ||
-                  'Unknown'
+                  nls.localize('arduino/common/unknown', 'Unknown')
                 }
                 onChange={this.themeDidChange}
               >
@@ -468,7 +510,7 @@ export class SettingsComponent extends React.Component<
                   checked={this.state.verboseOnCompile}
                   onChange={this.verboseOnCompileDidChange}
                 />
-                compile
+                {nls.localize('arduino/preferences/compile', 'compile')}
               </label>
               <label className="flex-line">
                 <input
@@ -476,7 +518,7 @@ export class SettingsComponent extends React.Component<
                   checked={this.state.verboseOnUpload}
                   onChange={this.verboseOnUploadDidChange}
                 />
-                upload
+                {nls.localize('arduino/preferences/upload', 'upload')}
               </label>
             </div>
             <div className="flex-line">
@@ -500,7 +542,10 @@ export class SettingsComponent extends React.Component<
             checked={this.state.verifyAfterUpload}
             onChange={this.verifyAfterUploadDidChange}
           />
-          Verify code after upload
+          {nls.localize(
+            'arduino/preferences/verifyAfterUpload',
+            'Verify code after upload'
+          )}
         </label>
         <label className="flex-line">
           <input
@@ -509,7 +554,10 @@ export class SettingsComponent extends React.Component<
             onChange={this.checkForUpdatesDidChange}
             disabled={true}
           />
-          Check for updates on startup
+          {nls.localize(
+            'arduino/preferences/checkForUpdates',
+            'Check for updates on startup'
+          )}
         </label>
         <label className="flex-line">
           <input
@@ -517,7 +565,10 @@ export class SettingsComponent extends React.Component<
             checked={this.state.autoSave === 'on'}
             onChange={this.autoSaveDidChange}
           />
-          Auto save
+          {nls.localize(
+            'vscode/fileActions.contribution/miAutoSave',
+            'Auto save'
+          )}
         </label>
         <label className="flex-line">
           <input
@@ -525,7 +576,10 @@ export class SettingsComponent extends React.Component<
             checked={this.state.quickSuggestions.other === true}
             onChange={this.quickSuggestionsOtherDidChange}
           />
-          Editor Quick Suggestions
+          {nls.localize(
+            'arduino/preferences/editorQuickSuggestions',
+            'Editor Quick Suggestions'
+          )}
         </label>
         <label className="flex-line">
           <input
@@ -533,10 +587,16 @@ export class SettingsComponent extends React.Component<
             checked={this.state.enableLsLogs}
             onChange={this.enableLsLogsDidChange}
           />
-          Enable language server logging
+          {nls.localize(
+            'arduino/preferences/languageServerLogging',
+            'Enable language server logging'
+          )}
         </label>
         <div className="flex-line">
-          Additional boards manager URLs:
+          {nls.localize(
+            'arduino/preferences/additionalManagerURLs',
+            'Additional boards manager URLs'
+          ) + ':'}
           <input
             className="theia-input stretch with-margin"
             type="text"
@@ -562,7 +622,7 @@ export class SettingsComponent extends React.Component<
               checked={this.state.network === 'none'}
               onChange={this.noProxyDidChange}
             />
-            No proxy
+            {nls.localize('arduino/preferences/noProxy', 'No proxy')}
           </label>
           <label className="flex-line">
             <input
@@ -570,7 +630,10 @@ export class SettingsComponent extends React.Component<
               checked={this.state.network !== 'none'}
               onChange={this.manualProxyDidChange}
             />
-            Manual proxy configuration
+            {nls.localize(
+              'arduino/preferences/manualProxy',
+              'Manual proxy configuration'
+            )}
           </label>
         </form>
         {this.renderProxySettings()}
@@ -703,8 +766,11 @@ export class SettingsComponent extends React.Component<
 
   protected browseSketchbookDidClick = async () => {
     const uri = await this.props.fileDialogService.showOpenDialog({
-      title: 'Select new sketchbook location',
-      openLabel: 'Choose',
+      title: nls.localize(
+        'arduino/preferences/newSketchbookLocation',
+        'Select new sketchbook location'
+      ),
+      openLabel: nls.localize('arduino/preferences/choose', 'Choose'),
       canSelectFiles: false,
       canSelectMany: false,
       canSelectFolders: true,
@@ -985,8 +1051,10 @@ export class SettingsDialog extends AbstractDialog<Promise<Settings>> {
   ) {
     super(props);
     this.contentNode.classList.add('arduino-settings-dialog');
-    this.appendCloseButton('CANCEL');
-    this.appendAcceptButton('OK');
+    this.appendCloseButton(
+      nls.localize('vscode/issueMainService/cancel', 'Cancel')
+    );
+    this.appendAcceptButton(nls.localize('vscode/issueMainService/ok', 'OK'));
   }
 
   @postConstruct()
@@ -1040,12 +1108,20 @@ export class AdditionalUrlsDialog extends AbstractDialog<string[]> {
   protected readonly textArea: HTMLTextAreaElement;
 
   constructor(urls: string[], windowService: WindowService) {
-    super({ title: 'Additional Boards Manager URLs' });
+    super({
+      title: nls.localize(
+        'arduino/preferences/additionalManagerURLs',
+        'Additional Boards Manager URLs'
+      ),
+    });
 
     this.contentNode.classList.add('additional-urls-dialog');
 
     const description = document.createElement('div');
-    description.textContent = 'Enter additional URLs, one for each row';
+    description.textContent = nls.localize(
+      'arduino/preferences/enterAdditionalURLs',
+      'Enter additional URLs, one for each row'
+    );
     description.style.marginBottom = '5px';
     this.contentNode.appendChild(description);
 
@@ -1063,7 +1139,10 @@ export class AdditionalUrlsDialog extends AbstractDialog<string[]> {
 
     const anchor = document.createElement('div');
     anchor.classList.add('link');
-    anchor.textContent = 'Click for a list of unofficial board support URLs';
+    anchor.textContent = nls.localize(
+      'arduino/preferences/unofficialBoardSupport',
+      'Click for a list of unofficial board support URLs'
+    );
     anchor.style.marginTop = '5px';
     anchor.style.cursor = 'pointer';
     this.addEventListener(anchor, 'click', () =>
@@ -1074,8 +1153,10 @@ export class AdditionalUrlsDialog extends AbstractDialog<string[]> {
     );
     this.contentNode.appendChild(anchor);
 
-    this.appendAcceptButton('OK');
-    this.appendCloseButton('Cancel');
+    this.appendAcceptButton(nls.localize('vscode/issueMainService/ok', 'OK'));
+    this.appendCloseButton(
+      nls.localize('vscode/issueMainService/cancel', 'Cancel')
+    );
   }
 
   get value(): string[] {

--- a/arduino-ide-extension/src/browser/theia/core/application-shell.ts
+++ b/arduino-ide-extension/src/browser/theia/core/application-shell.ts
@@ -15,6 +15,7 @@ import {
 import { Sketch } from '../../../common/protocol';
 import { SaveAsSketch } from '../../contributions/save-as-sketch';
 import { SketchesServiceClientImpl } from '../../../common/protocol/sketches-service-client-impl';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class ApplicationShell extends TheiaApplicationShell {
@@ -85,7 +86,10 @@ export class ApplicationShell extends TheiaApplicationShell {
       this.connectionStatusService.currentStatus === ConnectionStatus.OFFLINE
     ) {
       this.messageService.error(
-        'Could not save the sketch. Please copy your unsaved work into your favorite text editor, and restart the IDE.'
+        nls.localize(
+          'theia/core/couldNotSave',
+          'Could not save the sketch. Please copy your unsaved work into your favorite text editor, and restart the IDE.'
+        )
       );
       return; // Theia does not reject on failed save: https://github.com/eclipse-theia/theia/pull/8803
     }

--- a/arduino-ide-extension/src/browser/theia/core/connection-status-service.ts
+++ b/arduino-ide-extension/src/browser/theia/core/connection-status-service.ts
@@ -8,6 +8,7 @@ import {
 } from '@theia/core/lib/browser/connection-status-service';
 import { ArduinoDaemon } from '../../../common/protocol';
 import { NotificationCenter } from '../../notification-center';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class FrontendConnectionStatusService extends TheiaFrontendConnectionStatusService {
@@ -63,10 +64,19 @@ export class ApplicationConnectionStatusContribution extends TheiaApplicationCon
   protected handleOffline(): void {
     this.statusBar.setElement('connection-status', {
       alignment: StatusBarAlignment.LEFT,
-      text: this.isRunning ? 'Offline' : '$(bolt) CLI Daemon Offline',
+      text: this.isRunning
+        ? nls.localize('theia/core/offline', 'Offline')
+        : '$(bolt) ' +
+          nls.localize('theia/core/daemonOffline', 'CLI Daemon Offline'),
       tooltip: this.isRunning
-        ? 'Cannot connect to the backend.'
-        : 'Cannot connect to the CLI daemon.',
+        ? nls.localize(
+            'theia/core/cannotConnectBackend',
+            'Cannot connect to the backend.'
+          )
+        : nls.localize(
+            'theia/core/cannotConnectDaemon',
+            'Cannot connect to the CLI daemon.'
+          ),
       priority: 5000,
     });
     this.toDisposeOnOnline.push(

--- a/arduino-ide-extension/src/browser/theia/debug/debug-session-manager.ts
+++ b/arduino-ide-extension/src/browser/theia/debug/debug-session-manager.ts
@@ -3,51 +3,63 @@ import { DebugError } from '@theia/debug/lib/common/debug-service';
 import { DebugSession } from '@theia/debug/lib/browser/debug-session';
 import { DebugSessionOptions } from '@theia/debug/lib/browser/debug-session-options';
 import { DebugSessionManager as TheiaDebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class DebugSessionManager extends TheiaDebugSessionManager {
   async start(options: DebugSessionOptions): Promise<DebugSession | undefined> {
-    return this.progressService.withProgress('Start...', 'debug', async () => {
-      try {
-        // Only save when dirty. To avoid saving temporary sketches.
-        // This is a quick fix for not saving the editor when there are no dirty editors.
-        // // https://github.com/bcmi-labs/arduino-editor/pull/172#issuecomment-741831888
-        if (this.shell.canSaveAll()) {
-          await this.shell.saveAll();
-        }
-        await this.fireWillStartDebugSession();
-        const resolved = await this.resolveConfiguration(options);
+    return this.progressService.withProgress(
+      nls.localize('theia/debug/start', 'Start...'),
+      'debug',
+      async () => {
+        try {
+          // Only save when dirty. To avoid saving temporary sketches.
+          // This is a quick fix for not saving the editor when there are no dirty editors.
+          // // https://github.com/bcmi-labs/arduino-editor/pull/172#issuecomment-741831888
+          if (this.shell.canSaveAll()) {
+            await this.shell.saveAll();
+          }
+          await this.fireWillStartDebugSession();
+          const resolved = await this.resolveConfiguration(options);
 
-        // preLaunchTask isn't run in case of auto restart as well as postDebugTask
-        if (!options.configuration.__restart) {
-          const taskRun = await this.runTask(
-            options.workspaceFolderUri,
-            resolved.configuration.preLaunchTask,
-            true
+          // preLaunchTask isn't run in case of auto restart as well as postDebugTask
+          if (!options.configuration.__restart) {
+            const taskRun = await this.runTask(
+              options.workspaceFolderUri,
+              resolved.configuration.preLaunchTask,
+              true
+            );
+            if (!taskRun) {
+              return undefined;
+            }
+          }
+
+          const sessionId = await this.debug.createDebugSession(
+            resolved.configuration
           );
-          if (!taskRun) {
+          return this.doStart(sessionId, resolved);
+        } catch (e) {
+          if (DebugError.NotFound.is(e)) {
+            this.messageService.error(
+              nls.localize(
+                'theia/debug/typeNotSupported',
+                'The debug session type "{0}" is not supported.',
+                e.data.type
+              )
+            );
             return undefined;
           }
-        }
 
-        const sessionId = await this.debug.createDebugSession(
-          resolved.configuration
-        );
-        return this.doStart(sessionId, resolved);
-      } catch (e) {
-        if (DebugError.NotFound.is(e)) {
           this.messageService.error(
-            `The debug session type "${e.data.type}" is not supported.`
+            nls.localize(
+              'theia/debug/startError',
+              'There was an error starting the debug session, check the logs for more details.'
+            )
           );
-          return undefined;
+          console.error('Error starting the debug session', e);
+          throw e;
         }
-
-        this.messageService.error(
-          'There was an error starting the debug session, check the logs for more details.'
-        );
-        console.error('Error starting the debug session', e);
-        throw e;
       }
-    });
+    );
   }
 }

--- a/arduino-ide-extension/src/browser/theia/editor/editor-widget-factory.ts
+++ b/arduino-ide-extension/src/browser/theia/editor/editor-widget-factory.ts
@@ -5,6 +5,7 @@ import { LabelProvider } from '@theia/core/lib/browser';
 import { EditorWidgetFactory as TheiaEditorWidgetFactory } from '@theia/editor/lib/browser/editor-widget-factory';
 import { SketchesServiceClientImpl } from '../../../common/protocol/sketches-service-client-impl';
 import { SketchesService, Sketch } from '../../../common/protocol';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class EditorWidgetFactory extends TheiaEditorWidgetFactory {
@@ -30,7 +31,11 @@ export class EditorWidgetFactory extends TheiaEditorWidgetFactory {
     if (sketch && Sketch.isInSketch(uri, sketch)) {
       const isTemp = await this.sketchesService.isTemp(sketch);
       if (isTemp) {
-        widget.title.caption = `Unsaved – ${this.labelProvider.getName(uri)}`;
+        widget.title.caption = nls.localize(
+          'theia/editor/unsavedTitle',
+          'Unsaved – {0}',
+          this.labelProvider.getName(uri)
+        );
       }
     }
     return widget;

--- a/arduino-ide-extension/src/browser/theia/keymaps/keymaps-frontend-contribution.ts
+++ b/arduino-ide-extension/src/browser/theia/keymaps/keymaps-frontend-contribution.ts
@@ -5,13 +5,17 @@ import {
   KeymapsCommands,
 } from '@theia/keymaps/lib/browser/keymaps-frontend-contribution';
 import { ArduinoMenus } from '../../menu/arduino-menus';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class KeymapsFrontendContribution extends TheiaKeymapsFrontendContribution {
   registerMenus(menus: MenuModelRegistry): void {
     menus.registerMenuAction(ArduinoMenus.FILE__ADVANCED_SUBMENU, {
       commandId: KeymapsCommands.OPEN_KEYMAPS.id,
-      label: 'Keyboard Shortcuts',
+      label: nls.localize(
+        'vscode/helpActions/miKeyboardShortcuts',
+        'Keyboard Shortcuts'
+      ),
       order: '1',
     });
   }

--- a/arduino-ide-extension/src/browser/theia/messages/notification-center-component.tsx
+++ b/arduino-ide-extension/src/browser/theia/messages/notification-center-component.tsx
@@ -1,13 +1,22 @@
 import * as React from 'react';
 import { NotificationComponent } from './notification-component';
 import { NotificationCenterComponent as TheiaNotificationCenterComponent } from '@theia/messages/lib/browser/notification-center-component';
+import { nls } from '@theia/core/lib/browser/nls';
 
 const PerfectScrollbar = require('react-perfect-scrollbar');
 
 export class NotificationCenterComponent extends TheiaNotificationCenterComponent {
   render(): React.ReactNode {
     const empty = this.state.notifications.length === 0;
-    const title = empty ? 'NO NEW NOTIFICATIONS' : 'NOTIFICATIONS';
+    const title = empty
+      ? nls.localize(
+          'vscode/notificationsCenter/notificationsEmpty',
+          'NO NEW NOTIFICATIONS'
+        )
+      : nls.localize(
+          'vscode/notificationsCenter/notifications',
+          'NOTIFICATIONS'
+        );
     return (
       <div
         className={`theia-notifications-container theia-notification-center ${
@@ -20,12 +29,18 @@ export class NotificationCenterComponent extends TheiaNotificationCenterComponen
             <ul className="theia-notification-actions">
               <li
                 className="collapse"
-                title="Hide Notification Center"
+                title={nls.localize(
+                  'vscode/notificationsStatus/hideNotifications',
+                  'Hide Notification Center'
+                )}
                 onClick={this.onHide}
               />
               <li
                 className="clear-all"
-                title="Clear All"
+                title={nls.localize(
+                  'vscode/notificationsCommands/clearAllNotifications',
+                  'Clear All'
+                )}
                 onClick={this.onClearAll}
               />
             </ul>

--- a/arduino-ide-extension/src/browser/theia/messages/notification-component.tsx
+++ b/arduino-ide-extension/src/browser/theia/messages/notification-component.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { NotificationComponent as TheiaNotificationComponent } from '@theia/messages/lib/browser/notification-component';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export class NotificationComponent extends TheiaNotificationComponent {
   render(): React.ReactNode {
@@ -26,7 +27,11 @@ export class NotificationComponent extends TheiaNotificationComponent {
               {expandable && (
                 <li
                   className={collapsed ? 'expand' : 'collapse'}
-                  title={collapsed ? 'Expand' : 'Collapse'}
+                  title={
+                    collapsed
+                      ? nls.localize('theia/messages/expand', 'Expand')
+                      : nls.localize('theia/messages/collapse', 'Collapse')
+                  }
                   data-message-id={messageId}
                   onClick={this.onToggleExpansion}
                 />
@@ -34,7 +39,7 @@ export class NotificationComponent extends TheiaNotificationComponent {
               {!this.isProgress && (
                 <li
                   className="clear"
-                  title="Clear"
+                  title={nls.localize('vscode/abstractTree/clear', 'Clear')}
                   data-message-id={messageId}
                   onClick={this.onClear}
                 />

--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-commands.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-commands.ts
@@ -15,6 +15,7 @@ import { WorkspaceInputDialog } from './workspace-input-dialog';
 import { SketchesServiceClientImpl } from '../../../common/protocol/sketches-service-client-impl';
 import { SaveAsSketch } from '../../contributions/save-as-sketch';
 import { SingleTextInputDialog } from '@theia/core/lib/browser';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class WorkspaceCommandContribution extends TheiaWorkspaceCommandContribution {
@@ -57,7 +58,7 @@ export class WorkspaceCommandContribution extends TheiaWorkspaceCommandContribut
     const parentUri = parent.resource;
     const dialog = new WorkspaceInputDialog(
       {
-        title: 'Name for new file',
+        title: nls.localize('theia/workspace/fileNewName', 'Name for new file'),
         parentUri,
         validate: (name) => this.validateFileName(name, parent, true),
       },
@@ -93,10 +94,17 @@ export class WorkspaceCommandContribution extends TheiaWorkspaceCommandContribut
     }
     const extension = nameWithExt.split('.').pop();
     if (!extension) {
-      return 'Invalid filename.'; // XXX: this should not happen as we forcefully append `.ino` if it's not there.
+      return nls.localize(
+        'theia/workspace/invalidFilename',
+        'Invalid filename.'
+      ); // XXX: this should not happen as we forcefully append `.ino` if it's not there.
     }
     if (Sketch.Extensions.ALL.indexOf(`.${extension}`) === -1) {
-      return `.${extension} is not a valid extension.`;
+      return nls.localize(
+        'theia/workspace/invalidExtension',
+        '.{0} is not a valid extension',
+        extension
+      );
     }
     return '';
   }
@@ -151,7 +159,7 @@ export class WorkspaceCommandContribution extends TheiaWorkspaceCommandContribut
     }
     const initialValue = uri.path.base;
     const dialog = new SingleTextInputDialog({
-      title: 'New name for file',
+      title: nls.localize('theia/workspace/newFileName', 'New name for file'),
       initialValue,
       initialSelectionRange: {
         start: 0,

--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-delete-handler.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-delete-handler.ts
@@ -3,6 +3,7 @@ import { remote } from 'electron';
 import URI from '@theia/core/lib/common/uri';
 import { WorkspaceDeleteHandler as TheiaWorkspaceDeleteHandler } from '@theia/workspace/lib/browser/workspace-delete-handler';
 import { SketchesServiceClientImpl } from '../../../common/protocol/sketches-service-client-impl';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class WorkspaceDeleteHandler extends TheiaWorkspaceDeleteHandler {
@@ -21,10 +22,16 @@ export class WorkspaceDeleteHandler extends TheiaWorkspaceDeleteHandler {
         .some((uri) => uri === sketch.mainFileUri)
     ) {
       const { response } = await remote.dialog.showMessageBox({
-        title: 'Delete',
+        title: nls.localize('vscode/fileActions/delete', 'Delete'),
         type: 'question',
-        buttons: ['Cancel', 'OK'],
-        message: 'Do you want to delete the current sketch?',
+        buttons: [
+          nls.localize('vscode/issueMainService/cancel', 'Cancel'),
+          nls.localize('vscode/issueMainService/ok', 'OK'),
+        ],
+        message: nls.localize(
+          'theia/workspace/deleteCurrentSketch',
+          'Do you want to delete the current sketch?'
+        ),
       });
       if (response === 1) {
         // OK

--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-input-dialog.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-input-dialog.ts
@@ -6,6 +6,7 @@ import {
   WorkspaceInputDialog as TheiaWorkspaceInputDialog,
   WorkspaceInputDialogProps,
 } from '@theia/workspace/lib/browser/workspace-input-dialog';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export class WorkspaceInputDialog extends TheiaWorkspaceInputDialog {
   protected wasTouched = false;
@@ -16,7 +17,9 @@ export class WorkspaceInputDialog extends TheiaWorkspaceInputDialog {
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider
   ) {
     super(props, labelProvider);
-    this.appendCloseButton('Cancel');
+    this.appendCloseButton(
+      nls.localize('vscode/issueMainService/cancel', 'Cancel')
+    );
   }
 
   protected appendParentPath(): void {

--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-service.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-service.ts
@@ -17,6 +17,7 @@ import {
 import { ArduinoWorkspaceRootResolver } from '../../arduino-workspace-resolver';
 import { BoardsServiceProvider } from '../../boards/boards-service-provider';
 import { BoardsConfig } from '../../boards/boards-config';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class WorkspaceService extends TheiaWorkspaceService {
@@ -89,9 +90,10 @@ export class WorkspaceService extends TheiaWorkspaceService {
           .then(() => this.application.shell.update());
         this.logger.fatal(`Failed to determine the sketch directory: ${err}`);
         this.messageService.error(
-          'There was an error creating the sketch directory. ' +
-            'See the log for more details. ' +
-            'The application will probably not work as expected.'
+          nls.localize(
+            'theia/workspace/sketchDirectoryError',
+            'There was an error creating the sketch directory. See the log for more details. The application will probably not work as expected.'
+          )
         );
         return super.getDefaultWorkspaceUri();
       }

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-composite-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-composite-widget.tsx
@@ -9,6 +9,7 @@ import { UserStatus } from './cloud-user-status';
 import { CloudSketchbookTreeWidget } from './cloud-sketchbook-tree-widget';
 import { AuthenticationClientService } from '../../auth/authentication-client-service';
 import { CloudSketchbookTreeModel } from './cloud-sketchbook-tree-model';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class CloudSketchbookCompositeWidget extends BaseWidget {
@@ -29,7 +30,10 @@ export class CloudSketchbookCompositeWidget extends BaseWidget {
     this.cloudUserStatusNode.classList.add('cloud-status-node');
     this.compositeNode.appendChild(this.cloudUserStatusNode);
     this.node.appendChild(this.compositeNode);
-    this.title.caption = 'Cloud Sketchbook';
+    this.title.caption = nls.localize(
+      'arduino/cloud/cloudSketchbook',
+      'Cloud Sketchbook'
+    );
     this.title.iconClass = 'cloud-sketchbook-tree-icon';
     this.title.closable = false;
     this.id = 'cloud-sketchbook-composite-widget';

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-contributions.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-contributions.ts
@@ -27,6 +27,7 @@ import { SketchesServiceClientImpl } from '../../../common/protocol/sketches-ser
 import { Contribution } from '../../contributions/contribution';
 import { ArduinoPreferences } from '../../arduino-preferences';
 import { MainMenuManager } from '../../../common/main-menu-manager';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export const SKETCHBOOKSYNC__CONTEXT = ['arduino-sketchbook-sync--context'];
 
@@ -60,38 +61,56 @@ export namespace CloudSketchbookCommands {
     }
   }
 
-  export const TOGGLE_CLOUD_SKETCHBOOK: Command = {
-    id: 'arduino-cloud-sketchbook--disable',
-    label: 'Show/Hide Remote Sketchbook',
-  };
+  export const TOGGLE_CLOUD_SKETCHBOOK = Command.toLocalizedCommand(
+    {
+      id: 'arduino-cloud-sketchbook--disable',
+      label: 'Show/Hide Remote Sketchbook',
+    },
+    'arduino/cloud/showHideRemoveSketchbook'
+  );
 
-  export const PULL_SKETCH: Command = {
-    id: 'arduino-cloud-sketchbook--pull-sketch',
-    label: 'Pull Sketch',
-    iconClass: 'pull-sketch-icon',
-  };
+  export const PULL_SKETCH = Command.toLocalizedCommand(
+    {
+      id: 'arduino-cloud-sketchbook--pull-sketch',
+      label: 'Pull Sketch',
+      iconClass: 'pull-sketch-icon',
+    },
+    'arduino/cloud/pullSketch'
+  );
 
-  export const PUSH_SKETCH: Command = {
-    id: 'arduino-cloud-sketchbook--push-sketch',
-    label: 'Push Sketch',
-    iconClass: 'push-sketch-icon',
-  };
+  export const PUSH_SKETCH = Command.toLocalizedCommand(
+    {
+      id: 'arduino-cloud-sketchbook--push-sketch',
+      label: 'Push Sketch',
+      iconClass: 'push-sketch-icon',
+    },
+    'arduino/cloud/pullSketch'
+  );
 
-  export const OPEN_IN_CLOUD_EDITOR: Command = {
-    id: 'arduino-cloud-sketchbook--open-in-cloud-editor',
-    label: 'Open in Cloud Editor',
-  };
+  export const OPEN_IN_CLOUD_EDITOR = Command.toLocalizedCommand(
+    {
+      id: 'arduino-cloud-sketchbook--open-in-cloud-editor',
+      label: 'Open in Cloud Editor',
+    },
+    'arduino/cloud/openInCloudEditor'
+  );
 
-  export const OPEN_SKETCHBOOKSYNC_CONTEXT_MENU: Command = {
-    id: 'arduino-sketchbook-sync--open-sketch-context-menu',
-    label: 'Options...',
-    iconClass: 'sketchbook-tree__opts',
-  };
+  export const OPEN_SKETCHBOOKSYNC_CONTEXT_MENU = Command.toLocalizedCommand(
+    {
+      id: 'arduino-sketchbook-sync--open-sketch-context-menu',
+      label: 'Options...',
+      iconClass: 'sketchbook-tree__opts',
+    },
+    'arduino/cloud/options'
+  );
 
-  export const OPEN_SKETCH_SHARE_DIALOG: Command = {
-    id: 'arduino-cloud-sketchbook--share-modal',
-    label: 'Share...',
-  };
+  export const OPEN_SKETCH_SHARE_DIALOG = Command.toLocalizedCommand(
+    {
+      id: 'arduino-cloud-sketchbook--share-modal',
+      label: 'Share...',
+    },
+    'arduino/cloud/share'
+  );
 
   export const OPEN_PROFILE_CONTEXT_MENU: Command = {
     id: 'arduino-cloud-sketchbook--open-profile-menu',
@@ -192,7 +211,7 @@ export class CloudSketchbookContribution extends Contribution {
       execute: (arg) => {
         new ShareSketchDialog({
           node: arg.node,
-          title: 'Share Sketch',
+          title: nls.localize('arduino/cloud/shareSketch', 'Share Sketch'),
           createApi: this.createApi,
         }).open();
       },

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-model.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-model.ts
@@ -14,6 +14,7 @@ import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import URI from '@theia/core/lib/common/uri';
 import { SketchCache } from './cloud-sketch-cache';
 import { Create } from '../../create/typings';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export function sketchBaseDir(sketch: Create.Sketch): FileStat {
   // extract the sketch path
@@ -91,7 +92,9 @@ export class CloudSketchbookTreeModel extends SketchbookTreeModel {
     const sketches = await this.createApi.sketches();
     const rootFileStats = sketchesToFileStats(sketches);
     if (this.workspaceService.opened) {
-      const workspaceNode = WorkspaceNode.createRoot('Remote');
+      const workspaceNode = WorkspaceNode.createRoot(
+        nls.localize('arduino/cloud/remote', 'Remote')
+      );
       for await (const stat of rootFileStats) {
         workspaceNode.children.push(
           await this.tree.createWorkspaceRoot(stat, workspaceNode)

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-widget.tsx
@@ -11,6 +11,7 @@ import { TreeNode } from '@theia/core/lib/browser/tree';
 import { CompositeTreeNode } from '@theia/core/lib/browser';
 import { shell } from 'electron';
 import { SketchbookTreeWidget } from '../sketchbook/sketchbook-tree-widget';
+import { nls } from '@theia/core/lib/browser/nls';
 
 const LEARN_MORE_URL =
   'https://docs.arduino.cc/software/ide-v2/tutorials/ide-v2-cloud-sketch-sync';
@@ -44,16 +45,26 @@ export class CloudSketchbookTreeWidget extends SketchbookTreeWidget {
         <div className="center item">
           <div>
             <p>
-              <b>Your Sketchbook is empty</b>
+              <b>
+                {nls.localize(
+                  'arduino/cloud/emptySketchbook',
+                  'Your Sketchbook is empty'
+                )}
+              </b>
             </p>
-            <p>Visit Arduino Cloud to create Cloud Sketches.</p>
+            <p>
+              {nls.localize(
+                'arduino/cloud/visitArduinoCloud',
+                'Visit Arduino Cloud to create Cloud Sketches.'
+              )}
+            </p>
           </div>
         </div>
         <button
           className="theia-button"
           onClick={() => shell.openExternal('https://create.arduino.cc/editor')}
         >
-          GO TO CLOUD
+          {nls.localize('cloud/GoToCloud', 'GO TO CLOUD')}
         </button>
         <div className="center item"></div>
       </div>
@@ -102,9 +113,17 @@ export class CloudSketchbookTreeWidget extends SketchbookTreeWidget {
       <div className="cloud-sketchbook-welcome center">
         <div className="center item">
           <div>
-            <p className="sign-in-title">Sign in to Arduino Cloud</p>
+            <p className="sign-in-title">
+              {nls.localize(
+                'arduino/cloud/signInToCloud',
+                'Sign in to Arduino Cloud'
+              )}
+            </p>
             <p className="sign-in-desc">
-              Sync and edit your Arduino Cloud Sketches
+              {nls.localize(
+                'arduino/cloud/syncEditSketches',
+                'Sync and edit your Arduino Cloud Sketches'
+              )}
             </p>
           </div>
         </div>
@@ -114,7 +133,7 @@ export class CloudSketchbookTreeWidget extends SketchbookTreeWidget {
             this.commandRegistry.executeCommand(CloudUserCommands.LOGIN.id)
           }
         >
-          SIGN IN
+          {nls.localize('arduino/cloud/signIn', 'SIGN IN')}
         </button>
         <div className="center item">
           <div
@@ -125,7 +144,7 @@ export class CloudSketchbookTreeWidget extends SketchbookTreeWidget {
               })
             }
           >
-            Learn more
+            {nls.localize('arduino/cloud/learnMore', 'Learn more')}
           </div>
         </div>
       </div>

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree.ts
@@ -34,6 +34,7 @@ import { FileStat } from '@theia/filesystem/lib/common/files';
 import { WorkspaceNode } from '@theia/navigator/lib/browser/navigator-tree';
 import { posix, splitSketchPath } from '../../create/create-paths';
 import { Create } from '../../create/typings';
+import { nls } from '@theia/core/lib/browser/nls';
 
 const MESSAGE_TIMEOUT = 5 * 1000;
 const deepmerge = require('deepmerge').default;
@@ -77,10 +78,13 @@ export class CloudSketchbookTree extends SketchbookTree {
 
     if (warn) {
       const ok = await new DoNotAskAgainConfirmDialog({
-        ok: 'Continue',
-        cancel: 'Cancel',
-        title: 'Push Sketch',
-        msg: 'This is a Public Sketch. Before pushing, make sure any sensitive information is defined in arduino_secrets.h files. You can make a Sketch private from the Share panel.',
+        ok: nls.localize('arduino/cloud/continue', 'Continue'),
+        cancel: nls.localize('vscode/issueMainService/cancel', 'Cancel'),
+        title: nls.localize('arduino/cloud/pushSketch', 'Push Sketch'),
+        msg: nls.localize(
+          'arduino/cloud/pushSketchMsg',
+          'This is a Public Sketch. Before pushing, make sure any sensitive information is defined in arduino_secrets.h files. You can make a Sketch private from the Share panel.'
+        ),
         maxWidth: 400,
         onAccept: () =>
           this.preferenceService.set(
@@ -113,10 +117,13 @@ export class CloudSketchbookTree extends SketchbookTree {
 
     if (warn) {
       const ok = await new DoNotAskAgainConfirmDialog({
-        ok: 'Pull',
-        cancel: 'Cancel',
-        title: 'Pull Sketch',
-        msg: 'Pulling this Sketch from the Cloud will overwrite its local version. Are you sure you want to continue?',
+        ok: nls.localize('arduino/cloud/pull', 'Pull'),
+        cancel: nls.localize('vscode/issueMainService/cancel', 'Cancel'),
+        title: nls.localize('arduino/cloud/pullSketch', 'Pull Sketch'),
+        msg: nls.localize(
+          'arduino/cloud/pullSketchMsg',
+          'Pulling this Sketch from the Cloud will overwrite its local version. Are you sure you want to continue?'
+        ),
         maxWidth: 400,
         onAccept: () =>
           this.preferenceService.set(
@@ -141,15 +148,27 @@ export class CloudSketchbookTree extends SketchbookTree {
       this.sketchCache.purgeByPath(node.remoteUri.path.toString());
 
       node.commands = commandsCopy;
-      this.messageService.info(`Done pulling ‘${node.fileStat.name}’.`, {
-        timeout: MESSAGE_TIMEOUT,
-      });
+      this.messageService.info(
+        nls.localize(
+          'arduino/cloud/donePulling',
+          'Done pulling ‘{0}’.',
+          node.fileStat.name
+        ),
+        {
+          timeout: MESSAGE_TIMEOUT,
+        }
+      );
     });
   }
 
   async push(node: CloudSketchbookTree.CloudSketchDirNode): Promise<void> {
     if (!CloudSketchbookTree.CloudSketchTreeNode.isSynced(node)) {
-      throw new Error('Cannot push to Cloud. It is not yet pulled.');
+      throw new Error(
+        nls.localize(
+          'arduino/cloud/notYetPulled',
+          'Cannot push to Cloud. It is not yet pulled.'
+        )
+      );
     }
 
     const pushPublic = await this.pushPublicWarn(node);
@@ -161,9 +180,9 @@ export class CloudSketchbookTree extends SketchbookTree {
 
     if (warn) {
       const ok = await new DoNotAskAgainConfirmDialog({
-        ok: 'Push',
-        cancel: 'Cancel',
-        title: 'Push Sketch',
+        ok: nls.localize('arduino/cloud/push', 'Push'),
+        cancel: nls.localize('vscode/issueMainService/cancel', 'Cancel'),
+        title: nls.localize('arduino/cloud/pushSketch', 'Push Sketch'),
         msg: 'Pushing this Sketch will overwrite its Cloud version. Are you sure you want to continue?',
         maxWidth: 400,
         onAccept: () =>
@@ -180,7 +199,10 @@ export class CloudSketchbookTree extends SketchbookTree {
     this.runWithState(node, 'pushing', async (node) => {
       if (!CloudSketchbookTree.CloudSketchTreeNode.isSynced(node)) {
         throw new Error(
-          'You have to pull first to be able to push to the Cloud.'
+          nls.localize(
+            'arduino/cloud/pullFirst',
+            'You have to pull first to be able to push to the Cloud.'
+          )
         );
       }
       const commandsCopy = node.commands;
@@ -194,9 +216,16 @@ export class CloudSketchbookTree extends SketchbookTree {
       this.sketchCache.purgeByPath(node.remoteUri.path.toString());
 
       node.commands = commandsCopy;
-      this.messageService.info(`Done pushing ‘${node.fileStat.name}’.`, {
-        timeout: MESSAGE_TIMEOUT,
-      });
+      this.messageService.info(
+        nls.localize(
+          'arduino/cloud/donePushing',
+          'Done pushing ‘{0}’.',
+          node.fileStat.name
+        ),
+        {
+          timeout: MESSAGE_TIMEOUT,
+        }
+      );
     });
   }
 

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-user-status.tsx
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-user-status.tsx
@@ -6,8 +6,8 @@ import {
 import { CloudSketchbookTreeModel } from './cloud-sketchbook-tree-model';
 import { AuthenticationClientService } from '../../auth/authentication-client-service';
 import { CloudUserCommands } from '../../auth/cloud-user-commands';
-import { firstToUpperCase } from '../../../common/utils';
 import { AuthenticationSessionAccountInformation } from '../../../common/protocol/authentication-service';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export class UserStatus extends React.Component<
   UserStatus.Props,
@@ -59,7 +59,9 @@ export class UserStatus extends React.Component<
                 : 'offline-status-icon'
             }`}
           />
-          {firstToUpperCase(this.state.status)}
+          {this.state.status === 'connected'
+            ? nls.localize('arduino/cloud/connected', 'Connected')
+            : nls.localize('arduino/cloud/offline', 'Offline')}
         </div>
         <div className="actions item flex-line">
           <div
@@ -89,7 +91,10 @@ export class UserStatus extends React.Component<
             {this.state.accountInfo?.picture && (
               <img
                 src={this.state.accountInfo?.picture}
-                alt="Profile picture"
+                alt={nls.localize(
+                  'arduino/cloud/profilePicture',
+                  'Profile picture'
+                )}
               />
             )}
           </div>

--- a/arduino-ide-extension/src/browser/widgets/component-list/filterable-list-container.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/filterable-list-container.tsx
@@ -12,6 +12,7 @@ import { ListWidget } from './list-widget';
 import { ComponentList } from './component-list';
 import { ListItemRenderer } from './list-item-renderer';
 import { ResponseServiceArduino } from '../../../common/protocol';
+import { nls } from '@theia/core/lib/browser/nls';
 
 export class FilterableListContainer<
   T extends ArduinoComponent
@@ -112,7 +113,9 @@ export class FilterableListContainer<
     const { install, searchable } = this.props;
     await Installable.doWithProgress({
       ...this.props,
-      progressText: `Processing ${item.name}:${version}`,
+      progressText:
+        nls.localize('arduino/common/processing', 'Processing') +
+        ` ${item.name}:${version}`,
       run: ({ progressId }) => install({ item, progressId, version }),
     });
     const items = await searchable.search({ query: this.state.filterText });
@@ -121,10 +124,14 @@ export class FilterableListContainer<
 
   protected async uninstall(item: T): Promise<void> {
     const ok = await new ConfirmDialog({
-      title: 'Uninstall',
-      msg: `Do you want to uninstall ${item.name}?`,
-      ok: 'Yes',
-      cancel: 'No',
+      title: nls.localize('arduino/component/uninstall', 'Uninstall'),
+      msg: nls.localize(
+        'arduino/component/uninstallMsg',
+        'Do you want to uninstall {0}?',
+        item.name
+      ),
+      ok: nls.localize('vscode/extensionsUtils/yes', 'Yes'),
+      cancel: nls.localize('vscode/extensionsUtils/no', 'No'),
     }).open();
     if (!ok) {
       return;
@@ -132,9 +139,11 @@ export class FilterableListContainer<
     const { uninstall, searchable } = this.props;
     await Installable.doWithProgress({
       ...this.props,
-      progressText: `Processing ${item.name}${
-        item.installedVersion ? `:${item.installedVersion}` : ''
-      }`,
+      progressText:
+        nls.localize('arduino/common/processing', 'Processing') +
+        ` ${item.name}${
+          item.installedVersion ? `:${item.installedVersion}` : ''
+        }`,
       run: ({ progressId }) => uninstall({ item, progressId }),
     });
     const items = await searchable.search({ query: this.state.filterText });

--- a/arduino-ide-extension/src/browser/widgets/component-list/list-item-renderer.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/list-item-renderer.tsx
@@ -4,6 +4,7 @@ import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { Installable } from '../../../common/protocol/installable';
 import { ArduinoComponent } from '../../../common/protocol/arduino-component';
 import { ComponentListItem } from './component-list-item';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class ListItemRenderer<T extends ArduinoComponent> {
@@ -33,7 +34,7 @@ export class ListItemRenderer<T extends ArduinoComponent> {
       const author = <span className="author">{item.author}</span>;
       nameAndAuthor = (
         <span>
-          {name} by {author}
+          {name} {nls.localize('arduino/component/by', 'by')} {author}
         </span>
       );
     } else if (item.name) {
@@ -41,12 +42,22 @@ export class ListItemRenderer<T extends ArduinoComponent> {
     } else if ((item as any).id) {
       nameAndAuthor = <span className="name">{(item as any).id}</span>;
     } else {
-      nameAndAuthor = <span className="name">Unknown</span>;
+      nameAndAuthor = (
+        <span className="name">
+          {nls.localize('arduino/common/unknown', 'Unknown')}
+        </span>
+      );
     }
     const onClickUninstall = () => uninstall(item);
     const installedVersion = !!item.installedVersion && (
       <div className="version-info">
-        <span className="version">Version {item.installedVersion}</span>
+        <span className="version">
+          {nls.localize(
+            'arduino/component/version',
+            'Version {0}',
+            item.installedVersion
+          )}
+        </span>
         <span className="installed" onClick={onClickUninstall} />
       </div>
     );
@@ -56,13 +67,13 @@ export class ListItemRenderer<T extends ArduinoComponent> {
 
     const moreInfo = !!item.moreInfoLink && (
       <a href={item.moreInfoLink} onClick={this.onMoreInfoClick}>
-        More info
+        {nls.localize('arduino/component/moreInfo', 'More info')}
       </a>
     );
     const onClickInstall = () => install(item);
     const installButton = item.installable && (
       <button className="theia-button install" onClick={onClickInstall}>
-        INSTALL
+        {nls.localize('arduino/component/install', 'INSTALL')}
       </button>
     );
 

--- a/arduino-ide-extension/src/browser/widgets/component-list/search-bar.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/search-bar.tsx
@@ -1,3 +1,4 @@
+import { nls } from '@theia/core/lib/browser/nls';
 import * as React from 'react';
 
 export class SearchBar extends React.Component<SearchBar.Props> {
@@ -12,7 +13,10 @@ export class SearchBar extends React.Component<SearchBar.Props> {
         ref={this.setRef}
         className={`theia-input ${SearchBar.Styles.SEARCH_BAR_CLASS}`}
         type="text"
-        placeholder="Filter your search..."
+        placeholder={nls.localize(
+          'arduino/component/filterSearch',
+          'Filter your search...'
+        )}
         size={1}
         value={this.props.filterText}
         onChange={this.handleFilterTextChange}

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-commands.ts
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-commands.ts
@@ -1,15 +1,21 @@
 import { Command } from '@theia/core/lib/common/command';
 
 export namespace SketchbookCommands {
-  export const OPEN_NEW_WINDOW: Command = {
-    id: 'arduino-sketchbook--open-sketch-new-window',
-    label: 'Open Sketch in New Window',
-  };
+  export const OPEN_NEW_WINDOW = Command.toLocalizedCommand(
+    {
+      id: 'arduino-sketchbook--open-sketch-new-window',
+      label: 'Open Sketch in New Window',
+    },
+    'arduino/sketch/openSketchInNewWindow'
+  );
 
-  export const REVEAL_IN_FINDER: Command = {
-    id: 'arduino-sketchbook--reveal-in-finder',
-    label: 'Open Folder',
-  };
+  export const REVEAL_IN_FINDER = Command.toLocalizedCommand(
+    {
+      id: 'arduino-sketchbook--reveal-in-finder',
+      label: 'Open Folder',
+    },
+    'arduino/sketch/openFolder'
+  );
 
   export const OPEN_SKETCHBOOK_CONTEXT_MENU: Command = {
     id: 'arduino-sketchbook--open-sketch-context-menu',

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
@@ -17,6 +17,7 @@ import { ArduinoPreferences } from '../../arduino-preferences';
 import { SketchesServiceClientImpl } from '../../../common/protocol/sketches-service-client-impl';
 import { SelectableTreeNode } from '@theia/core/lib/browser/tree/tree-selection';
 import { Sketch } from '../../contributions/contribution';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class SketchbookTreeWidget extends FileTreeWidget {
@@ -41,7 +42,10 @@ export class SketchbookTreeWidget extends FileTreeWidget {
     super(props, model, contextMenuRenderer);
     this.id = 'arduino-sketchbook-tree-widget';
     this.title.iconClass = 'sketchbook-tree-icon';
-    this.title.caption = 'Local Sketchbook';
+    this.title.caption = nls.localize(
+      'arduino/sketch/titleLocalSketchbook',
+      'Local Sketchbook'
+    );
     this.title.closable = false;
   }
 

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget-contribution.ts
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget-contribution.ts
@@ -69,7 +69,7 @@ export class SketchbookWidgetContribution
   constructor() {
     super({
       widgetId: 'arduino-sketchbook-widget',
-      widgetName: 'Sketchbook',
+      widgetName: SketchbookWidget.LABEL,
       defaultWidgetOptions: {
         area: 'left',
         rank: 1,

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget.tsx
@@ -6,9 +6,12 @@ import { Message, MessageLoop } from '@phosphor/messaging';
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { BaseWidget } from '@theia/core/lib/browser/widgets/widget';
 import { SketchbookTreeWidget } from './sketchbook-tree-widget';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class SketchbookWidget extends BaseWidget {
+  static LABEL = nls.localize('arduino/sketch/titleSketchbook', 'Sketchbook');
+
   @inject(SketchbookTreeWidget)
   protected readonly localSketchbookTreeWidget: SketchbookTreeWidget;
 
@@ -17,8 +20,8 @@ export class SketchbookWidget extends BaseWidget {
   constructor() {
     super();
     this.id = 'arduino-sketchbook-widget';
-    this.title.caption = 'Sketchbook';
-    this.title.label = 'Sketchbook';
+    this.title.caption = SketchbookWidget.LABEL;
+    this.title.label = SketchbookWidget.LABEL;
     this.title.iconClass = 'fa fa-arduino-folder';
     this.title.closable = true;
     this.node.tabIndex = 0;

--- a/arduino-ide-extension/src/electron-browser/electron-window-service.ts
+++ b/arduino-ide-extension/src/electron-browser/electron-window-service.ts
@@ -7,6 +7,7 @@ import {
 } from '@theia/core/lib/browser/connection-status-service';
 import { ElectronWindowService as TheiaElectronWindowService } from '@theia/core/lib/electron-browser/window/electron-window-service';
 import { SplashService } from '../electron-common/splash-service';
+import { nls } from '@theia/core/lib/browser/nls';
 
 @injectable()
 export class ElectronWindowService extends TheiaElectronWindowService {
@@ -30,14 +31,26 @@ export class ElectronWindowService extends TheiaElectronWindowService {
     const offline =
       this.connectionStatusService.currentStatus === ConnectionStatus.OFFLINE;
     const detail = offline
-      ? 'Could not save the sketch. Please copy your unsaved work into your favorite text editor, and restart the IDE.'
-      : 'Any unsaved changes will not be saved.';
+      ? nls.localize(
+          'arduino/electron/couldNotSave',
+          'Could not save the sketch. Please copy your unsaved work into your favorite text editor, and restart the IDE.'
+        )
+      : nls.localize(
+          'arduino/electron/unsavedChanges',
+          'Any unsaved changes will not be saved.'
+        );
     const electronWindow = remote.getCurrentWindow();
     const response = remote.dialog.showMessageBoxSync(electronWindow, {
       type: 'question',
-      buttons: ['Yes', 'No'],
-      title: 'Confirm',
-      message: 'Are you sure you want to close the sketch?',
+      buttons: [
+        nls.localize('vscode/extensionsUtils/yes', 'Yes'),
+        nls.localize('vscode/extensionsUtils/no', 'No'),
+      ],
+      title: nls.localize('vscode/Default/ConfirmTitle', 'Confirm'),
+      message: nls.localize(
+        'arduino/sketch/close',
+        'Are you sure you want to close the sketch?'
+      ),
       detail,
     });
     return response === 0; // 'Yes', close the window.


### PR DESCRIPTION
Hi team,

this PR adds translation keys for all user-facing strings inside of the Arduino-IDE using the Theia localization (nls) API. 

Be aware that this does not add actual translations for the app. However, some strings are nevertheless translated, as they are contained by the vscode language pack.

### How to test

0. Start the app and observe that all user-facing strings are still correct (in English)
1. Download a language pack of your choice from the vscode marketplace/ovsx registry.
2. Unzip it and place it into the `plugins` folder
3. Start the application and run the `Configure Display Language` command and change to your new language
4. Open the `File` menu.
5. Observe that some menu entries have been changed.