### PR TITLE
Fix `Tools > Board` and `Tools > Port` labels

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -138,9 +138,7 @@ PID: ${PID}`;
     // The board specific items, and the rest, have order with `z`. We needed something between `0` and `z` with natural-order.
     this.menuModelRegistry.registerSubmenu(
       boardsSubmenuPath,
-      nls.localize('arduino/board/board', 'Board') + !!boardsSubmenuLabel
-        ? `: "${boardsSubmenuLabel}"`
-        : '',
+      nls.localize('arduino/board/board', 'Board{0}', !!boardsSubmenuLabel ? `: "${boardsSubmenuLabel}"` : ''),
       { order: '100' }
     );
     this.toDisposeBeforeMenuRebuild.push(
@@ -157,9 +155,7 @@ PID: ${PID}`;
     const portsSubmenuLabel = config.selectedPort?.address;
     this.menuModelRegistry.registerSubmenu(
       portsSubmenuPath,
-      nls.localize('arduino/board/port', 'Port') + portsSubmenuLabel
-        ? `: "${portsSubmenuLabel}"`
-        : '',
+      nls.localize('arduino/board/port', 'Port{0}', portsSubmenuLabel ? `: "${portsSubmenuLabel}"` : ''),
       { order: '101' }
     );
     this.toDisposeBeforeMenuRebuild.push(
@@ -197,10 +193,9 @@ PID: ${PID}`;
 
       const packageLabel =
         packageName +
-        `${
-          manuallyInstalled
-            ? nls.localize('arduino/board/inSketchbook', ' (in Sketchbook)')
-            : ''
+        `${manuallyInstalled
+          ? nls.localize('arduino/board/inSketchbook', ' (in Sketchbook)')
+          : ''
         }`;
       // Platform submenu
       const platformMenuPath = [...boardsPackagesGroup, packageId];
@@ -273,9 +268,8 @@ PID: ${PID}`;
             });
           }
           for (const { name, fqbn } of boards) {
-            const id = `arduino-select-port--${address}${
-              fqbn ? `--${fqbn}` : ''
-            }`;
+            const id = `arduino-select-port--${address}${fqbn ? `--${fqbn}` : ''
+              }`;
             const command = { id };
             const handler = {
               execute: () => {


### PR DESCRIPTION

Previously:
![image](https://user-images.githubusercontent.com/3314350/137706103-d91d04f0-b9ac-4e69-9b7d-7e1230678d74.png)

Now: 
![image](https://user-images.githubusercontent.com/3314350/137706029-b7a8c174-4067-4495-b926-778e6ae11bcc.png)
