### PR TITLE
Fix duplicated id children warnings

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-config.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-config.tsx
@@ -266,7 +266,7 @@ export class BoardsConfig extends React.Component<
         <div className="boards list">
           {Array.from(distinctBoards.values()).map((board) => (
             <Item<BoardWithPackage>
-              key={`${board.name}-${board.packageName}`}
+              key={toKey(board)}
               item={board}
               label={board.name}
               details={board.details}


### PR DESCRIPTION
This fixes an issue that caused tons of annoying warnings that flooded the console.

Previously:
![image](https://user-images.githubusercontent.com/3314350/137768196-14137a97-80b1-4bc0-8b98-b77f5eed5d30.png)


Now:
![image](https://user-images.githubusercontent.com/3314350/137768264-a4424ba4-744c-4e3f-84ec-716c338a640c.png)
