### PR TITLE
Fix cortex-debug related debugging issue

### DIFF
--- a/arduino-ide-extension/src/browser/theia/debug/debug-session-manager.ts
+++ b/arduino-ide-extension/src/browser/theia/debug/debug-session-manager.ts
@@ -62,6 +62,7 @@ export class DebugSessionManager extends TheiaDebugSessionManager {
       }
     );
   }
+  // TODO: remove as https://github.com/eclipse-theia/theia/issues/10164 is fixed
   async terminateSessions(): Promise<void> {
     await super.terminateSessions();
     this.destroy(this.currentSession?.id);


### PR DESCRIPTION
Closes https://github.com/arduino/arduino-ide/issues/527

As we can assume that the backend session is indeed destroyed (gdb session), we can simply destroy the frontend session without worrying about a dangling debug session somewhere.

Be aware, that this is connected to an upstream Theia issue: https://github.com/eclipse-theia/theia/issues/10164

#### How to test

1. Create a debug session
2. Stop the debugger
3. The debug session should have been stopped correctly