### PR TITLE
Disable Breadcrumbs

### DIFF
--- a/browser-app/package.json
+++ b/browser-app/package.json
@@ -44,7 +44,8 @@
             "other": false,
             "comments": false,
             "strings": false
-          }
+          },
+          "breadcrumbs.enabled": false
         }
       }
     },

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -47,7 +47,8 @@
             "other": false,
             "comments": false,
             "strings": false
-          }
+          },
+          "breadcrumbs.enabled": false
         }
       }
     },


### PR DESCRIPTION
## Why
In the last update of Theia we included breadcrumbs just below the tab name. This is an optional feature that we do not plan to support, hence needs to disabled by default. Advanced users can still enable breadcrumbs using the **unsupported** theia preferences via theia preference panel.

## How
Set the breadcrumbs to be disabled by default