### PR TITLE
Fix tabs ordering

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -508,7 +508,6 @@ export class ArduinoFrontendContribution
       for (const uri of [mainFileUri, ...rootFolderFileUris]) {
         await this.ensureOpened(uri);
       }
-      await this.ensureOpened(mainFileUri, true);
       if (mainFileUri.endsWith('.pde')) {
         const message = nls.localize(
           'arduino/common/oldFormat',

--- a/arduino-ide-extension/src/browser/theia/core/shell-layout-restorer.ts
+++ b/arduino-ide-extension/src/browser/theia/core/shell-layout-restorer.ts
@@ -35,13 +35,18 @@ export class ShellLayoutRestorer extends TheiaShellLayoutRestorer {
 
     const layoutData = await this.inflate(serializedLayoutData);
     // workaround to remove duplicated tabs
+    const filesUri: string[] = [];
     if ((layoutData as any)?.mainPanel?.main?.widgets) {
       (layoutData as any).mainPanel.main.widgets = (
         layoutData as any
-      ).mainPanel.main.widgets.filter(
-        (widget: any) =>
-          widget.constructionOptions.factoryId !== 'code-editor-opener'
-      );
+      ).mainPanel.main.widgets.filter((widget: any) => {
+        const uri = widget.getResourceUri().toString();
+        if (filesUri.includes(uri)) {
+          return false;
+        }
+        filesUri.push(uri);
+        return true;
+      });
     }
 
     await app.shell.setLayoutData(layoutData);


### PR DESCRIPTION
## Why
After the latest Theia inclusion, tabs order gets scrambled. This is particularly true when the Sketch has multiple .ino files and/or a file different from the main .ino file was selected the last time the sketch was opened

## How
- Changed the cleanup script that finds duplicated tabs in monaco
- removed the now useless force open on the main .ino file. This was actually causing the issue as forcing the open of the file that was already opened caused the close of the original one and a new open in the last position