### PR TITLE
Remove language server log preference

### DIFF
--- a/arduino-ide-extension/src/browser/settings.tsx
+++ b/arduino-ide-extension/src/browser/settings.tsx
@@ -44,7 +44,6 @@ const WINDOW_SETTING = `${ARDUINO_SETTING}.window`;
 // const IDE_SETTING = `${ARDUINO_SETTING}.ide`;
 const COMPILE_SETTING = `${ARDUINO_SETTING}.compile`;
 const UPLOAD_SETTING = `${ARDUINO_SETTING}.upload`;
-const LANGUAGE_SETTING = `${ARDUINO_SETTING}.language`;
 const SKETCHBOOK_SETTING = `${ARDUINO_SETTING}.sketchbook`;
 const AUTO_SCALE_SETTING = `${WINDOW_SETTING}.autoScale`;
 const ZOOM_LEVEL_SETTING = `${WINDOW_SETTING}.zoomLevel`;
@@ -53,7 +52,6 @@ const COMPILE_VERBOSE_SETTING = `${COMPILE_SETTING}.verbose`;
 const COMPILE_WARNINGS_SETTING = `${COMPILE_SETTING}.warnings`;
 const UPLOAD_VERBOSE_SETTING = `${UPLOAD_SETTING}.verbose`;
 const UPLOAD_VERIFY_SETTING = `${UPLOAD_SETTING}.verify`;
-const LANGUAGE_LOG_SETTING = `${LANGUAGE_SETTING}.log`;
 const SHOW_ALL_FILES_SETTING = `${SKETCHBOOK_SETTING}.showAllFiles`;
 
 export interface Settings extends Index {
@@ -69,7 +67,6 @@ export interface Settings extends Index {
   compilerWarnings: CompilerWarnings; // `arduino.compile.warnings`
   verboseOnUpload: boolean; // `arduino.upload.verbose`
   verifyAfterUpload: boolean; // `arduino.upload.verify`
-  enableLsLogs: boolean; // `arduino.language.log`
   sketchbookShowAllFiles: boolean; // `arduino.sketchbook.showAllFiles`
 
   sketchbookPath: string; // CLI
@@ -127,7 +124,6 @@ export class SettingsService {
       compilerWarnings,
       verboseOnUpload,
       verifyAfterUpload,
-      enableLsLogs,
       sketchbookShowAllFiles,
       cliConfig,
     ] = await Promise.all([
@@ -151,7 +147,6 @@ export class SettingsService {
       this.preferenceService.get<any>(COMPILE_WARNINGS_SETTING, 'None'),
       this.preferenceService.get<boolean>(UPLOAD_VERBOSE_SETTING, true),
       this.preferenceService.get<boolean>(UPLOAD_VERIFY_SETTING, true),
-      this.preferenceService.get<boolean>(LANGUAGE_LOG_SETTING, true),
       this.preferenceService.get<boolean>(SHOW_ALL_FILES_SETTING, false),
       this.configService.getConfiguration(),
     ]);
@@ -169,7 +164,6 @@ export class SettingsService {
       compilerWarnings,
       verboseOnUpload,
       verifyAfterUpload,
-      enableLsLogs,
       sketchbookShowAllFiles,
       additionalUrls,
       sketchbookPath,
@@ -249,7 +243,6 @@ export class SettingsService {
       compilerWarnings,
       verboseOnUpload,
       verifyAfterUpload,
-      enableLsLogs,
       sketchbookPath,
       additionalUrls,
       network,
@@ -313,11 +306,6 @@ export class SettingsService {
       this.preferenceService.set(
         UPLOAD_VERIFY_SETTING,
         verifyAfterUpload,
-        PreferenceScope.User
-      ),
-      this.preferenceService.set(
-        LANGUAGE_LOG_SETTING,
-        enableLsLogs,
         PreferenceScope.User
       ),
       this.preferenceService.set(
@@ -581,17 +569,6 @@ export class SettingsComponent extends React.Component<
             'Editor Quick Suggestions'
           )}
         </label>
-        <label className="flex-line">
-          <input
-            type="checkbox"
-            checked={this.state.enableLsLogs}
-            onChange={this.enableLsLogsDidChange}
-          />
-          {nls.localize(
-            'arduino/preferences/languageServerLogging',
-            'Enable language server logging'
-          )}
-        </label>
         <div className="flex-line">
           {nls.localize(
             'arduino/preferences/additionalManagerURLs',
@@ -812,12 +789,6 @@ export class SettingsComponent extends React.Component<
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
     this.setState({ autoScaleInterface: event.target.checked });
-  };
-
-  protected enableLsLogsDidChange = (
-    event: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    this.setState({ enableLsLogs: event.target.checked });
   };
 
   protected interfaceScaleDidChange = (


### PR DESCRIPTION
## What
Remove the `Enable language server logging` option in the preferences

## Why
This option was needed in the early development and testing phase of the Arduino Language Server. However, this is not something the target user will ever have a need for, so it only makes the IDE less friendly.
