### PR TITLE
IDE to run CLI with auto assigned port

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -151,7 +151,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.20.1"
+      "version": "0.20.2-rc1"
     },
     "fwuploader": {
       "version": "2.0.0"

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -151,7 +151,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.20.2-rc1"
+      "version": "0.20.2"
     },
     "fwuploader": {
       "version": "2.0.0"

--- a/arduino-ide-extension/scripts/download-ls.js
+++ b/arduino-ide-extension/scripts/download-ls.js
@@ -4,7 +4,7 @@
 // - https://downloads.arduino.cc/arduino-language-server/clangd/clangd_${VERSION}_${SUFFIX}
 
 (() => {
-  const DEFAULT_ALS_VERSION = '0.5.0-rc2';
+  const DEFAULT_ALS_VERSION = '0.5.0-rc6';
   const DEFAULT_CLANGD_VERSION = 'snapshot_20210124';
 
   const path = require('path');

--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -374,7 +374,7 @@ export class ArduinoFrontendContribution
           'arduino.languageserver.start',
           {
             lsPath,
-            cliDaemonAddr: `localhost:${config.daemon.port}`,
+            cliDaemonAddr: `localhost:${config.daemon.port}`, // TODO: verify if this port is coming from the BE
             clangdPath,
             log: currentSketchPath ? currentSketchPath : log,
             cliDaemonInstance: '1',

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -63,7 +63,9 @@ export class UploadSketch extends SketchContribution {
     if (!fqbn) {
       return '';
     }
-    const address = boardsConfig.selectedBoard?.port?.address;
+    const address =
+      boardsConfig.selectedBoard?.port?.address ||
+      boardsConfig.selectedPort?.address;
     if (!address) {
       return '';
     }
@@ -277,8 +279,8 @@ export class UploadSketch extends SketchContribution {
         { timeout: 3000 }
       );
     } catch (e) {
-      let errorMessage = "";
-      if (typeof e === "string") {
+      let errorMessage = '';
+      if (typeof e === 'string') {
         errorMessage = e;
       } else {
         errorMessage = e.toString();

--- a/arduino-ide-extension/src/common/protocol/arduino-daemon.ts
+++ b/arduino-ide-extension/src/common/protocol/arduino-daemon.ts
@@ -2,4 +2,5 @@ export const ArduinoDaemonPath = '/services/arduino-daemon';
 export const ArduinoDaemon = Symbol('ArduinoDaemon');
 export interface ArduinoDaemon {
   isRunning(): Promise<boolean>;
+  getPort(): Promise<string>;
 }

--- a/arduino-ide-extension/src/node/config-service-impl.ts
+++ b/arduino-ide-extension/src/node/config-service-impl.ts
@@ -75,9 +75,11 @@ export class ConfigServiceImpl
 
   async getConfiguration(): Promise<Config> {
     await this.ready.promise;
-    return this.config;
+    await this.daemon.ready;
+    return { ...this.config, daemon: { port: await this.daemon.getPort() } };
   }
 
+  // Used by frontend to update the config.
   async setConfiguration(config: Config): Promise<void> {
     await this.ready.promise;
     if (Config.sameAs(this.config, config)) {
@@ -108,7 +110,9 @@ export class ConfigServiceImpl
     copyDefaultCliConfig.locale = locale || 'en';
     const proxy = Network.stringify(network);
     copyDefaultCliConfig.network = { proxy };
-    const { port } = copyDefaultCliConfig.daemon;
+
+    // always use the port of the daemon
+    const port = await this.daemon.getPort();
     await this.updateDaemon(port, copyDefaultCliConfig);
     await this.writeDaemonState(port);
 

--- a/arduino-ide-extension/src/node/core-client-provider.ts
+++ b/arduino-ide-extension/src/node/core-client-provider.ts
@@ -48,9 +48,9 @@ export class CoreClientProvider extends GrpcClientProvider<CoreClientProvider.Cl
     this._initialized = new Deferred<void>();
   }
 
-  protected async reconcileClient(
-    port: string | number | undefined
-  ): Promise<void> {
+  protected async reconcileClient(): Promise<void> {
+    const port = await this.daemon.getPort();
+
     if (port && port === this._port) {
       // No need to create a new gRPC client, but we have to update the indexes.
       if (this._client && !(this._client instanceof Error)) {
@@ -58,7 +58,7 @@ export class CoreClientProvider extends GrpcClientProvider<CoreClientProvider.Cl
         this.onClientReadyEmitter.fire();
       }
     } else {
-      await super.reconcileClient(port);
+      await super.reconcileClient();
       this.onClientReadyEmitter.fire();
     }
   }
@@ -66,13 +66,10 @@ export class CoreClientProvider extends GrpcClientProvider<CoreClientProvider.Cl
   @postConstruct()
   protected async init(): Promise<void> {
     this.daemon.ready.then(async () => {
-      const cliConfig = this.configService.cliConfiguration;
       // First create the client and the instance synchronously
       // and notify client is ready.
       // TODO: Creation failure should probably be handled here
-      await this.reconcileClient(
-        cliConfig ? cliConfig.daemon.port : undefined
-      ).then(() => {
+      await this.reconcileClient().then(() => {
         this._created.resolve();
       });
 

--- a/arduino-ide-extension/src/node/grpc-client-provider.ts
+++ b/arduino-ide-extension/src/node/grpc-client-provider.ts
@@ -21,8 +21,7 @@ export abstract class GrpcClientProvider<C> {
   @postConstruct()
   protected init(): void {
     const updateClient = () => {
-      const cliConfig = this.configService.cliConfiguration;
-      this.reconcileClient(cliConfig ? cliConfig.daemon.port : undefined);
+      this.reconcileClient();
     };
     this.configService.onConfigChange(updateClient);
     this.daemon.ready.then(updateClient);
@@ -44,9 +43,9 @@ export abstract class GrpcClientProvider<C> {
     }
   }
 
-  protected async reconcileClient(
-    port: string | number | undefined
-  ): Promise<void> {
+  protected async reconcileClient(): Promise<void> {
+    const port = await this.daemon.getPort();
+
     if (this._port === port) {
       return; // Nothing to do.
     }

--- a/arduino-ide-extension/src/test/node/arduino-daemon-impl.test.ts
+++ b/arduino-ide-extension/src/test/node/arduino-daemon-impl.test.ts
@@ -114,18 +114,22 @@ describe('arduino-daemon-impl', () => {
   // });
 
   it('should parse the port address when the log format is json', async () => {
-    const instance = await new SilentArduinoDaemonImpl(
+    const { daemon, port } = await new SilentArduinoDaemonImpl(
       'json'
     ).spawnDaemonProcess();
-    expect(instance.port).not.to.be.undefined;
-    expect(instance.port).not.to.be.equal('0');
+
+    expect(port).not.to.be.undefined;
+    expect(port).not.to.be.equal('0');
+    daemon.kill();
   });
 
   it('should parse the port address when the log format is text', async () => {
-    const instance = await new SilentArduinoDaemonImpl(
+    const { daemon, port } = await new SilentArduinoDaemonImpl(
       'text'
     ).spawnDaemonProcess();
-    expect(instance.port).not.to.be.undefined;
-    expect(instance.port).not.to.be.equal('0');
+
+    expect(port).not.to.be.undefined;
+    expect(port).not.to.be.equal('0');
+    daemon.kill();
   });
 });


### PR DESCRIPTION
## Why
It's not possible to make assumptions on what ports are available on the different OS the IDE can be run, and the default port 50051 is already in use in some cases (such as OS Monterey).
This issue is particularly annoying for first-time users that should go into the CLI configuration and change the port manually, before running the IDE.

## How
The IDE now force the CLI daemon port to `0` (automatically assigned from the OS). This ensure an available port is always picked up and the IDE can start normally, without manual intervention of the user