### PR TITLE
workaround: stop discoveries before install/uninstall boards/libs

### DIFF
--- a/arduino-ide-extension/src/node/library-service-server-impl.ts
+++ b/arduino-ide-extension/src/node/library-service-server-impl.ts
@@ -271,6 +271,10 @@ export class LibraryServiceImpl
     req.setNoDeps(!options.installDependencies);
 
     console.info('>>> Starting library package installation...', item);
+
+    // stop the board discovery
+    await this.boardDiscovery.stopBoardListWatch(coreClient);
+
     const resp = client.libraryInstall(req);
     resp.on(
       'data',
@@ -322,6 +326,10 @@ export class LibraryServiceImpl
     if (typeof overwrite === 'boolean') {
       req.setOverwrite(overwrite);
     }
+
+    // stop the board discovery
+    await this.boardDiscovery.stopBoardListWatch(coreClient);
+
     const resp = client.zipLibraryInstall(req);
     resp.on(
       'data',
@@ -354,6 +362,10 @@ export class LibraryServiceImpl
     req.setVersion(item.installedVersion!);
 
     console.info('>>> Starting library package uninstallation...', item);
+
+    // stop the board discovery
+    await this.boardDiscovery.stopBoardListWatch(coreClient);
+
     const resp = client.libraryUninstall(req);
     resp.on(
       'data',


### PR DESCRIPTION
## Why
After installing a board/library the discoveries are be broken: plugging or unplugging a board has no effect on the UI.
This issue is 100% reproducible on windows and a minority of mac users are affected as well.

The reason is that, in some circumstances that need to be further investigated, the CLI is not sending the `quit` or `end` message when an install/uninstall action is perfomed. ( cc @silvanocerza )

This causes the IDE not to restart the watchers on the board discoveries when needed (as it's never been informed they ever stopped).

Being the watchers broken, the UI do not react to changes that communicated (correctly) from the CLI.

## How
This workaround perform a stop of the discoveries from the IDE side before any install/uninstall operation.
Calling the stop from the IDE actually fixes the problem as the CLI correctly answers with the `end` message and the IDE can be informed and hence restart the discoveries when needed.

## Note
This is a workaround as the correct way to approach the issue should be on the CLI side: there is no reason why the business logic of stopping/restarting the boards watchers shoud be on the IDE.
The IDE should be transparent to what happens on the CLI side, as the CLI should just stop sending the boardsList messages when an install/uninstall is in progress, then communicate the new state to the IDE at the end of its internal routines

fixes #671 