### PR TITLE
Correctly transform uint8array to string

### DIFF
--- a/arduino-ide-extension/src/browser/create/create-api.ts
+++ b/arduino-ide-extension/src/browser/create/create-api.ts
@@ -15,7 +15,7 @@ export namespace ResponseResultProvider {
   export const JSON: ResponseResultProvider = (response) => response.json();
 }
 
-function Utf8ArrayToStr(array: Uint8Array): string {
+export function Utf8ArrayToStr(array: Uint8Array): string {
   let out, i, c;
   let char2, char3;
 


### PR DESCRIPTION
## Why
IDE2 currently converts larger files to uint8arrays. When a file is then pushed to the cloud it needs to be conferted back to a string.

This process fails miserably, as we are trying to use `new TextDecoder().decode(content)` which is broken in the electron version used by theia (https://github.com/electron/electron/issues/18733)

## How
Replace `new TextDecoder().decode(content)` with `new util.TextDecoder().decode(content)`
