### PR TITLE
Serial monitor lines not to wrap lines

### DIFF
--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -43,6 +43,7 @@ export class SerialMonitorOutput extends React.Component<
         itemCount={this.state.lines.length}
         itemSize={18}
         width={'100%'}
+        style={{ whiteSpace: 'nowrap' }}
         ref={this.listRef}
       >
         {Row}


### PR DESCRIPTION
## Why
currently, lines plotted to the serial plotter have fixed height, as a this is required for the virtual scroll to work properly and guarantee good performance.

This causes longer lines to wrap and overflow over the line below, causing a glitch in the ui (see picture)

![image](https://user-images.githubusercontent.com/1636933/146402061-aaa64b5e-d1ab-4c97-a1a4-42ed5b0450e8.png)

## How

Setting the `white-space: nowrap;` property fixes the issue allowing the whole panel to scroll horizontally
![image](https://user-images.githubusercontent.com/1636933/146402265-e90548ba-418e-45e3-ad14-b840834ca301.png)
