### PR TITLE
Remove red squigglies and word wrap from Preferences window

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
@@ -83,6 +83,7 @@ export class SettingsComponent extends React.Component<
           <input
             className="theia-input stretch"
             type="text"
+            spellcheck={false}
             value={this.state.sketchbookPath}
             onChange={this.sketchpathDidChange}
           />
@@ -302,6 +303,7 @@ export class SettingsComponent extends React.Component<
           <input
             className="theia-input stretch with-margin"
             type="text"
+            spellCheck={false}
             value={this.state.additionalUrls.join(',')}
             onChange={this.additionalUrlsDidChange}
           />

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-dialog.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-dialog.tsx
@@ -140,7 +140,8 @@ export class AdditionalUrlsDialog extends AbstractDialog<string[]> {
       .filter((url) => url.trim())
       .filter((url) => !!url)
       .join('\n');
-    this.textArea.wrap = 'soft';
+    this.textArea.wrap = 'off';
+    this.textArea.spellcheck = false;
     this.textArea.cols = 90;
     this.textArea.rows = 5;
     this.contentNode.appendChild(this.textArea);


### PR DESCRIPTION
I've been annoyed by the red squigglies that come up in the text input fields in the Preferences window when they get focus, and this is doubly so when the Additional Boards Manager URLs dialog shows them while wrapping the lines, which (in my case at least) means that the label's claim 'one for each row' is incorrect. These edits set the `spellcheck` attribute to `false` in both places and turns off the `wrap` attribute for the textarea.

Before:
![image](https://user-images.githubusercontent.com/190127/146595215-5867340f-abed-4cb8-9d29-9b5e88ecf554.png)
![image](https://user-images.githubusercontent.com/190127/146595285-1bf83761-a279-4f51-8abd-dfb5cf46a2e4.png)
![image](https://user-images.githubusercontent.com/190127/146595349-5294afb8-2f8e-4f95-812b-0493d0ce96de.png)

After:
![image](https://user-images.githubusercontent.com/190127/146595025-ac450556-f4cf-4dbd-8bdd-7abc8bd8ad23.png)
![image](https://user-images.githubusercontent.com/190127/146594979-1fcae188-a764-460e-8fe8-139b89d54620.png)
![image](https://user-images.githubusercontent.com/190127/146594904-37aa563f-ca0c-4577-9544-b5e96c43b8ee.png)
