### PR TITLE
Splash-screen Improvements

### DIFF
--- a/arduino-ide-extension/src/electron-main/splash/splash-screen.ts
+++ b/arduino-ide-extension/src/electron-main/splash/splash-screen.ts
@@ -143,6 +143,8 @@ export const initSplashScreen = (
     slowStartup = true;
     showSplash();
   }, xConfig.delay);
+  // Splashscreen is now on top of the main browser window.
+  window.on('show', () => splashScreen?.setAlwaysOnTop(false));
   if (onCloseRequested) {
     onCloseRequested(() => closeSplashScreen(window, xConfig.minVisible));
   } else {

--- a/arduino-ide-extension/src/electron-main/splash/static/splash.html
+++ b/arduino-ide-extension/src/electron-main/splash/static/splash.html
@@ -12,6 +12,7 @@
         img {
             max-width: 95%;
             height: auto;
+            -webkit-user-drag: none;
         }
     </style>
 </head>


### PR DESCRIPTION
Fixes #324. It only disables the `alwaysOnTop` after the main window appears so the splash-screen is still on top of the main window.

Fixes #325