### PR TITLE
Update development docs for current repository

### DIFF
--- a/docs/internal/Arm.md
+++ b/docs/internal/Arm.md
@@ -42,10 +42,10 @@ Building the Pro IDE on Linux `armv7l` (aka `armhf`) and `aarch64` (aka `arm64`)
     - `libx11-dev`, and
     - `libxkbfile-dev`
 
-4. [Build it](https://github.com/bcmi-labs/arduino-editor#build-from-source) from the source:
+4. [Build it](../../BUILDING.md#build-from-source) from the source:
     ```
-    git clone https://github.com/bcmi-labs/arduino-editor.git \
-    && cd arduino-editor \
+    git clone https://github.com/arduino/arduino-ide.git \
+    && cd arduino-ide \
     && yarn \
     && yarn rebuild:electron \
     && yarn --cwd ./electron-app start

--- a/docs/internal/Ubuntu.md
+++ b/docs/internal/Ubuntu.md
@@ -1,6 +1,6 @@
 ### Building and start the app from the sources on Ubuntu Linux
 
-Tested and verified on Ubuntu 18.04.4. The source will be checked out to `~/dev/git/arduino-editor`.
+Tested and verified on Ubuntu 18.04.4. The source will be checked out to `~/dev/git/arduino-ide`.
 
 ```
 #!/bin/bash -i
@@ -25,9 +25,9 @@ sudo apt update \
 && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
 && sudo apt update && sudo apt install --no-install-recommends yarn \
 && mkdir -p ~/dev/git/ \
-&& rm -rf ~/dev/git/arduino-editor \
-&& git clone --depth 1 https://github.com/bcmi-labs/arduino-editor.git ~/dev/git/arduino-editor \
-&& yarn --cwd ~/dev/git/arduino-editor \
-&& yarn --cwd ~/dev/git/arduino-editor rebuild:electron \
-&& yarn --cwd ~/dev/git/arduino-editor/electron-app start
+&& rm -rf ~/dev/git/arduino-ide \
+&& git clone --depth 1 https://github.com/arduino/arduino-ide.git ~/dev/git/arduino-ide \
+&& yarn --cwd ~/dev/git/arduino-ide \
+&& yarn --cwd ~/dev/git/arduino-ide rebuild:electron \
+&& yarn --cwd ~/dev/git/arduino-ide/electron-app start
 ```


### PR DESCRIPTION
The original location of the project repository was `bcmi-labs/arduino-editor` and some of the internal development documentation for the project contains references to the repository.

This documentation was not updated at the time the repository was moved to the current home in `arduino/arduino-ide`.

Fixes https://github.com/arduino/arduino-ide/issues/388