### PR TITLE
Remove stray brace from compilation error output

### DIFF
--- a/arduino-ide-extension/src/node/core-service-impl.ts
+++ b/arduino-ide-extension/src/node/core-service-impl.ts
@@ -96,7 +96,7 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
         e.details
       );
       this.responseService.appendToOutput({
-        chunk: `${errorMessage}}\n`,
+        chunk: `${errorMessage}\n`,
         severity: 'error',
       });
       throw new Error(errorMessage);


### PR DESCRIPTION
An extra brace [was inadvertently introduced](https://github.com/arduino/arduino-ide/commit/5ddab1ded74a0fe74cd5350579dc60a6327f4940#diff-620225c1911f715af828b254eb226f590cea42b7787c5f5941d38f115924a3e1R95) into a template literal used to format output text in the event of an error
during compilation. This caused the text to end in a pointless `}`

For example, compiling this sketch:

```cpp
#error
void setup() {}
void loop() {}
```

Previously produced this output:

```
C:\Users\per\AppData\Local\Temp\.arduinoIDE-unsaved2022014-9692-1u5eon9.v425\sketch_jan14a\sketch_jan14a.ino:1:2: error: #error 
 #error
  ^~~~~
Compilation error: exit status 1}
```

After this change, the output text is as expected:

```
C:\Users\per\AppData\Local\Temp\.arduinoIDE-unsaved2022014-9692-1u5eon9.v425\sketch_jan14a\sketch_jan14a.ino:1:2: error: #error 
 #error
  ^~~~~
Compilation error: exit status 1
```