### PR TITLE
Add script to create historical changelog

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,20 +198,6 @@ jobs:
         run: |
           echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
 
-      - name: Create full changelog
-        id: full-changelog
-        run: |
-          mkdir "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}"
-
-          # Get the changelog file name to build
-          CHANGELOG_FILE_NAME="${{ steps.tag_name.outputs.TAG_NAME }}-${date --iso-8601=s}.md"
-
-          # Create manifest file pointing to latest changelog file name
-          echo "$CHANGELOG_FILE_NAME" >> "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}/latest.txt"
-
-          # Compose changelog
-          yarn run compose-changelog "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}/$CHANGELOG_FILE_NAME"
-
       - name: Publish Release [GitHub]
         uses: svenstaro/upload-release-action@2.2.0
         with:
@@ -221,16 +207,6 @@ jobs:
           tag: ${{ github.ref }}
           file_glob: true
           body: ${{ needs.changelog.outputs.BODY }}
-
-      - name: Publish Changelog [S3]
-        uses: docker://plugins/s3
-        env:
-          PLUGIN_SOURCE: '${{ env.CHANGELOG_ARTIFACTS }}/*'
-          PLUGIN_STRIP_PREFIX: '${{ env.CHANGELOG_ARTIFACTS }}/'
-          PLUGIN_TARGET: '/arduino-ide/changelog'
-          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Publish Release [S3]
         uses: docker://plugins/s3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,9 @@ on:
 
 env:
   JOB_TRANSFER_ARTIFACT: build-artifacts
+  CHANGELOG_ARTIFACTS: changelog
 
 jobs:
-
   build:
     if: github.repository == 'arduino/arduino-ide'
     strategy:
@@ -56,29 +56,29 @@ jobs:
           IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') }}
           IS_FORK: ${{ github.event.pull_request.head.repo.fork == true }}
         run: |
-            # See: https://www.electron.build/code-signing
-            if [ $IS_FORK = true ]; then
-              echo "Skipping the app signing: building from a fork."
-            else
-              if [ "${{ runner.OS }}" = "macOS" ]; then
-                export CSC_LINK="${{ runner.temp }}/signing_certificate.p12"
-                # APPLE_SIGNING_CERTIFICATE_P12 secret was produced by following the procedure from:
-                # https://www.kencochrane.com/2020/08/01/build-and-sign-golang-binaries-for-macos-with-github-actions/#exporting-the-developer-certificate
-                echo "${{ secrets.APPLE_SIGNING_CERTIFICATE_P12 }}" | base64 --decode > "$CSC_LINK"
+          # See: https://www.electron.build/code-signing
+          if [ $IS_FORK = true ]; then
+            echo "Skipping the app signing: building from a fork."
+          else
+            if [ "${{ runner.OS }}" = "macOS" ]; then
+              export CSC_LINK="${{ runner.temp }}/signing_certificate.p12"
+              # APPLE_SIGNING_CERTIFICATE_P12 secret was produced by following the procedure from:
+              # https://www.kencochrane.com/2020/08/01/build-and-sign-golang-binaries-for-macos-with-github-actions/#exporting-the-developer-certificate
+              echo "${{ secrets.APPLE_SIGNING_CERTIFICATE_P12 }}" | base64 --decode > "$CSC_LINK"
 
-                export CSC_KEY_PASSWORD="${{ secrets.KEYCHAIN_PASSWORD }}"
+              export CSC_KEY_PASSWORD="${{ secrets.KEYCHAIN_PASSWORD }}"
 
-              elif [ "${{ runner.OS }}" = "Windows" ]; then
-                export CSC_LINK="${{ runner.temp }}/signing_certificate.pfx"
-                npm config set msvs_version 2017 --global
-                echo "${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PFX }}" | base64 --decode > "$CSC_LINK"
+            elif [ "${{ runner.OS }}" = "Windows" ]; then
+              export CSC_LINK="${{ runner.temp }}/signing_certificate.pfx"
+              npm config set msvs_version 2017 --global
+              echo "${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PFX }}" | base64 --decode > "$CSC_LINK"
 
-                export CSC_KEY_PASSWORD="${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}"
-              fi
+              export CSC_KEY_PASSWORD="${{ secrets.WINDOWS_SIGNING_CERTIFICATE_PASSWORD }}"
             fi
+          fi
 
-            yarn --cwd ./electron/packager/
-            yarn --cwd ./electron/packager/ package
+          yarn --cwd ./electron/packager/
+          yarn --cwd ./electron/packager/ package
 
       - name: Upload [GitHub Actions]
         uses: actions/upload-artifact@v2
@@ -95,15 +95,15 @@ jobs:
     strategy:
       matrix:
         artifact:
-          - path: "*Linux_64bit.zip"
+          - path: '*Linux_64bit.zip'
             name: Linux_X86-64
-          - path: "*macOS_64bit.dmg"
+          - path: '*macOS_64bit.dmg'
             name: macOS
-          - path: "*Windows_64bit.exe"
+          - path: '*Windows_64bit.exe'
             name: Windows_X86-64_interactive_installer
-          - path: "*Windows_64bit.msi"
+          - path: '*Windows_64bit.msi'
             name: Windows_X86-64_MSI
-          - path: "*Windows_64bit.zip"
+          - path: '*Windows_64bit.zip'
             name: Windows_X86-64_zip
 
     steps:
@@ -112,7 +112,7 @@ jobs:
         with:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: ${{ env.JOB_TRANSFER_ARTIFACT }}
-      
+
       - name: Upload tester build artifact
         uses: actions/upload-artifact@v2
         with:
@@ -135,24 +135,24 @@ jobs:
         env:
           IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: |
-            export LATEST_TAG=$(git describe --abbrev=0)
-            export GIT_LOG=$(git log --pretty=" - %s [%h]" $LATEST_TAG..HEAD | sed 's/ *$//g')
-            if [ "$IS_RELEASE" = true ]; then
-              export BODY=$(echo -e "$GIT_LOG")
-            else 
-              export LATEST_TAG_WITH_LINK=$(echo "[$LATEST_TAG](https://github.com/arduino/arduino-ide/releases/tag/$LATEST_TAG)")
-              if [ -z "$GIT_LOG" ]; then
-                  export BODY="There were no changes since version $LATEST_TAG_WITH_LINK."
-              else
-                  export BODY=$(echo -e "Changes since version $LATEST_TAG_WITH_LINK:\n$GIT_LOG")
-              fi
+          export LATEST_TAG=$(git describe --abbrev=0)
+          export GIT_LOG=$(git log --pretty=" - %s [%h]" $LATEST_TAG..HEAD | sed 's/ *$//g')
+          if [ "$IS_RELEASE" = true ]; then
+            export BODY=$(echo -e "$GIT_LOG")
+          else
+            export LATEST_TAG_WITH_LINK=$(echo "[$LATEST_TAG](https://github.com/arduino/arduino-ide/releases/tag/$LATEST_TAG)")
+            if [ -z "$GIT_LOG" ]; then
+                export BODY="There were no changes since version $LATEST_TAG_WITH_LINK."
+            else
+                export BODY=$(echo -e "Changes since version $LATEST_TAG_WITH_LINK:\n$GIT_LOG")
             fi
-            echo -e "$BODY"
-            OUTPUT_SAFE_BODY="${BODY//'%'/'%25'}"
-            OUTPUT_SAFE_BODY="${OUTPUT_SAFE_BODY//$'\n'/'%0A'}"
-            OUTPUT_SAFE_BODY="${OUTPUT_SAFE_BODY//$'\r'/'%0D'}"
-            echo "::set-output name=BODY::$OUTPUT_SAFE_BODY"
-            echo "$BODY" > CHANGELOG.txt
+          fi
+          echo -e "$BODY"
+          OUTPUT_SAFE_BODY="${BODY//'%'/'%25'}"
+          OUTPUT_SAFE_BODY="${OUTPUT_SAFE_BODY//$'\n'/'%0A'}"
+          OUTPUT_SAFE_BODY="${OUTPUT_SAFE_BODY//$'\r'/'%0D'}"
+          echo "::set-output name=BODY::$OUTPUT_SAFE_BODY"
+          echo "$BODY" > CHANGELOG.txt
 
       - name: Upload Changelog [GitHub Actions]
         if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')
@@ -175,9 +175,9 @@ jobs:
       - name: Publish Nightly [S3]
         uses: docker://plugins/s3
         env:
-          PLUGIN_SOURCE: "${{ env.JOB_TRANSFER_ARTIFACT }}/*"
-          PLUGIN_STRIP_PREFIX: "${{ env.JOB_TRANSFER_ARTIFACT }}/"
-          PLUGIN_TARGET: "/arduino-ide/nightly"
+          PLUGIN_SOURCE: '${{ env.JOB_TRANSFER_ARTIFACT }}/*'
+          PLUGIN_STRIP_PREFIX: '${{ env.JOB_TRANSFER_ARTIFACT }}/'
+          PLUGIN_TARGET: '/arduino-ide/nightly'
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -198,6 +198,20 @@ jobs:
         run: |
           echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
 
+      - name: Create full changelog
+        id: full-changelog
+        run: |
+          mkdir "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}"
+
+          # Get the changelog file name to build
+          CHANGELOG_FILE_NAME="${{ steps.tag_name.outputs.TAG_NAME }}-${date --iso-8601=s}.md"
+
+          # Create manifest file pointing to latest changelog file name
+          echo "$CHANGELOG_FILE_NAME" >> "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}/latest.txt"
+
+          # Compose changelog
+          yarn run compose-changelog "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}/$CHANGELOG_FILE_NAME"
+
       - name: Publish Release [GitHub]
         uses: svenstaro/upload-release-action@2.2.0
         with:
@@ -208,12 +222,22 @@ jobs:
           file_glob: true
           body: ${{ needs.changelog.outputs.BODY }}
 
+      - name: Publish Changelog [S3]
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: '${{ env.CHANGELOG_ARTIFACTS }}/*'
+          PLUGIN_STRIP_PREFIX: '${{ env.CHANGELOG_ARTIFACTS }}/'
+          PLUGIN_TARGET: '/arduino-ide/changelog'
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Publish Release [S3]
         uses: docker://plugins/s3
         env:
-          PLUGIN_SOURCE: "${{ env.JOB_TRANSFER_ARTIFACT }}/*"
-          PLUGIN_STRIP_PREFIX: "${{ env.JOB_TRANSFER_ARTIFACT }}/"
-          PLUGIN_TARGET: "/arduino-ide"
+          PLUGIN_SOURCE: '${{ env.JOB_TRANSFER_ARTIFACT }}/*'
+          PLUGIN_STRIP_PREFIX: '${{ env.JOB_TRANSFER_ARTIFACT }}/'
+          PLUGIN_TARGET: '/arduino-ide'
           PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/compose-full-changelog.yaml
+++ b/.github/workflows/compose-full-changelog.yaml
@@ -1,0 +1,45 @@
+name: Compose full changelog
+
+on:
+  release:
+    types: [created, edited]
+
+env:
+  CHANGELOG_ARTIFACTS: changelog
+
+jobs:
+  create-changelog:
+    if: github.repository == 'arduino/arduino-ide'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get Tag
+        id: tag_name
+        run: |
+          echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
+
+      - name: Create full changelog
+        id: full-changelog
+        run: |
+          mkdir "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}"
+
+          # Get the changelog file name to build
+          CHANGELOG_FILE_NAME="${{ steps.tag_name.outputs.TAG_NAME }}-${date --iso-8601=s}.md"
+
+          # Create manifest file pointing to latest changelog file name
+          echo "$CHANGELOG_FILE_NAME" >> "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}/latest.txt"
+
+          # Compose changelog
+          yarn run compose-changelog "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}/$CHANGELOG_FILE_NAME"
+
+      - name: Publish Changelog [S3]
+        uses: docker://plugins/s3
+        env:
+          PLUGIN_SOURCE: '${{ env.CHANGELOG_ARTIFACTS }}/*'
+          PLUGIN_STRIP_PREFIX: '${{ env.CHANGELOG_ARTIFACTS }}/'
+          PLUGIN_TARGET: '/arduino-ide/changelog'
+          PLUGIN_BUCKET: ${{ secrets.DOWNLOADS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "prepare": "yarn download-cli && yarn download-fwuploader && yarn download-ls && yarn copy-serial-plotter && yarn clean && yarn download-examples && yarn build && yarn test",
     "clean": "rimraf lib",
+    "compose-changelog": "node ./scripts/compose-changelog.js",
     "download-cli": "node ./scripts/download-cli.js",
     "download-fwuploader": "node ./scripts/download-fwuploader.js",
     "copy-serial-plotter": "npx ncp ../node_modules/arduino-serial-plotter-webapp ./build/arduino-serial-plotter-webapp",

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -92,6 +92,7 @@
     "which": "^1.3.1"
   },
   "devDependencies": {
+    "@octokit/rest": "^18.12.0",
     "@types/chai": "^4.2.7",
     "@types/chai-string": "^1.4.2",
     "@types/mocha": "^5.2.7",

--- a/arduino-ide-extension/scripts/compose-changelog.js
+++ b/arduino-ide-extension/scripts/compose-changelog.js
@@ -1,7 +1,10 @@
 // @ts-check
 
+
 (async () => {
   const { Octokit } = require('@octokit/rest');
+  const fs = require("fs");
+  const path = require("path");
 
   const octokit = new Octokit({
     userAgent: 'Arduino IDE compose-changelog.js',
@@ -24,7 +27,22 @@
     return acc + `# ${item.name}\n\n${body}\n\n---\n\n`;
   }, '');
 
-  console.log(fullChangelog);
+  const changelogFile = path.resolve(process.argv[process.argv.length - 1]);
+
+  await fs.writeFile(
+    changelogFile,
+    fullChangelog,
+    {
+      flag: "w+",
+    },
+    err => {
+      if (err) {
+        console.error(err);
+        process.exit(1);
+      }
+      console.log("Changelog written to", changelogFile);
+    }
+  )
 })();
 
 

--- a/arduino-ide-extension/scripts/compose-changelog.js
+++ b/arduino-ide-extension/scripts/compose-changelog.js
@@ -1,0 +1,50 @@
+// @ts-check
+
+(async () => {
+  const { Octokit } = require('@octokit/rest');
+
+  const octokit = new Octokit({
+    userAgent: 'Arduino IDE compose-changelog.js',
+  });
+
+  const response = await octokit.rest.repos.listReleases({
+    owner: 'arduino',
+    repo: 'arduino-ide',
+  });
+
+  if (!response || response.status !== 200) {
+    console.log('fancù');
+    return;
+  }
+  const releases = response.data;
+
+  let fullChangelog = releases.reduce((acc, item) => {
+    return acc + `\n\n${item.body}`;
+  }, '');
+
+  fullChangelog = replaceIssueNumber(fullChangelog);
+  fullChangelog = replaceIssueLink(fullChangelog);
+  fullChangelog = replaceCompareLink(fullChangelog);
+
+  console.log(fullChangelog);
+})();
+
+const replaceIssueLink = (str) => {
+  const regex =
+    /(https:\/\/github\.com\/arduino\/arduino-ide\/(issues|pull)\/(\d*))/gm;
+  const substr = `[#$3]($1)`;
+  return str.replace(regex, substr);
+};
+
+const replaceIssueNumber = (str) => {
+  const regex = /#(\d+)/gm;
+  const subst = `[#$1](https://github.com/arduino/arduino-ide/pull/$1)`;
+  return str.replace(regex, subst);
+};
+
+const replaceCompareLink = (str) => {
+  const regex =
+    /(https:\/\/github.com\/arduino\/arduino-ide\/compare\/(.*))\s/gm;
+  const subst = `[\`$2\`]($1)`;
+  return str.replace(regex, subst);
+};

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "i18n:generate": "theia nls-extract -e vscode -f \"+(arduino-ide-extension|browser-app|electron|electron-app|plugins)/**/*.ts?(x)\" -o ./i18n/en.json",
     "i18n:check": "yarn i18n:generate && git add -N ./i18n && git diff --exit-code ./i18n",
     "i18n:push": "node ./scripts/i18n/transifex-push.js ./i18n/en.json",
-    "i18n:pull": "node ./scripts/i18n/transifex-pull.js ./i18n/"
+    "i18n:pull": "node ./scripts/i18n/transifex-pull.js ./i18n/",
+    "compose-changelog": "yarn --cwd ./arduino-ide-extension compose-changelog"
   },
   "lint-staged": {
     "./arduino-ide-extension/**/*.{ts,tsx}": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,6 +1824,26 @@
   dependencies:
     "@octokit/types" "^6.0.3"
 
+"@octokit/auth-token@^2.4.4":
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/@octokit/auth-token/-/auth-token-2.5.0.tgz#27c37ea26c205f28443402477ffd261311f21e36"
+  integrity sha512-r5FVUJCOLl19AxiuZD2VRZ/ORjp/4IN98Of6YJoJOkY75CIBuYfmiNHGrDwXr+aLGG55igl9QrxX3hbiXlLb+g==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+
+"@octokit/core@^3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@octokit/core/-/core-3.5.1.tgz#8601ceeb1ec0e1b1b8217b960a413ed8e947809b"
+  integrity sha512-omncwpLVxMP+GLpLPgeGJBF6IWJFjXDS5flY5VbppePYX9XehevbDykRH9PdCdvqt9TS5AOTiDide7h0qrkHjw==
+  dependencies:
+    "@octokit/auth-token" "^2.4.4"
+    "@octokit/graphql" "^4.5.8"
+    "@octokit/request" "^5.6.0"
+    "@octokit/request-error" "^2.0.5"
+    "@octokit/types" "^6.0.3"
+    before-after-hook "^2.2.0"
+    universal-user-agent "^6.0.0"
+
 "@octokit/endpoint@^6.0.1":
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/@octokit/endpoint/-/endpoint-6.0.11.tgz#082adc2aebca6dcefa1fb383f5efb3ed081949d1"
@@ -1832,6 +1852,20 @@
     "@octokit/types" "^6.0.3"
     is-plain-object "^5.0.0"
     universal-user-agent "^6.0.0"
+
+"@octokit/graphql@^4.5.8":
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/@octokit/graphql/-/graphql-4.8.0.tgz#664d9b11c0e12112cbf78e10f49a05959aa22cc3"
+  integrity sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==
+  dependencies:
+    "@octokit/request" "^5.6.0"
+    "@octokit/types" "^6.0.3"
+    universal-user-agent "^6.0.0"
+
+"@octokit/openapi-types@^11.2.0":
+  version "11.2.0"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-11.2.0.tgz#b38d7fc3736d52a1e96b230c1ccd4a58a2f400a6"
+  integrity sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA==
 
 "@octokit/openapi-types@^5.3.2":
   version "5.3.2"
@@ -1850,10 +1884,22 @@
   dependencies:
     "@octokit/types" "^2.0.1"
 
+"@octokit/plugin-paginate-rest@^2.16.8":
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz#32e9c7cab2a374421d3d0de239102287d791bce7"
+  integrity sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==
+  dependencies:
+    "@octokit/types" "^6.34.0"
+
 "@octokit/plugin-request-log@^1.0.0":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz#70a62be213e1edc04bb8897ee48c311482f9700d"
   integrity sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==
+
+"@octokit/plugin-request-log@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz#5e50ed7083a613816b1e4a28aeec5fb7f1462e85"
+  integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
 
 "@octokit/plugin-rest-endpoint-methods@2.4.0":
   version "2.4.0"
@@ -1861,6 +1907,14 @@
   integrity sha512-EZi/AWhtkdfAYi01obpX0DF7U6b1VRr30QNQ5xSFPITMdLSfhcBqjamE3F+sKcxPbD7eZuMHu3Qkk2V+JGxBDQ==
   dependencies:
     "@octokit/types" "^2.0.1"
+    deprecation "^2.3.1"
+
+"@octokit/plugin-rest-endpoint-methods@^5.12.0":
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz#8c46109021a3412233f6f50d28786f8e552427ba"
+  integrity sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==
+  dependencies:
+    "@octokit/types" "^6.34.0"
     deprecation "^2.3.1"
 
 "@octokit/request-error@^1.0.2":
@@ -1881,6 +1935,15 @@
     deprecation "^2.0.0"
     once "^1.4.0"
 
+"@octokit/request-error@^2.0.5", "@octokit/request-error@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@octokit/request-error/-/request-error-2.1.0.tgz#9e150357831bfc788d13a4fd4b1913d60c74d677"
+  integrity sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==
+  dependencies:
+    "@octokit/types" "^6.0.3"
+    deprecation "^2.0.0"
+    once "^1.4.0"
+
 "@octokit/request@^5.2.0":
   version "5.4.14"
   resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.14.tgz#ec5f96f78333bb2af390afa5ff66f114b063bc96"
@@ -1893,6 +1956,18 @@
     is-plain-object "^5.0.0"
     node-fetch "^2.6.1"
     once "^1.4.0"
+    universal-user-agent "^6.0.0"
+
+"@octokit/request@^5.6.0":
+  version "5.6.3"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.6.3.tgz#19a022515a5bba965ac06c9d1334514eb50c48b0"
+  integrity sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==
+  dependencies:
+    "@octokit/endpoint" "^6.0.1"
+    "@octokit/request-error" "^2.1.0"
+    "@octokit/types" "^6.16.1"
+    is-plain-object "^5.0.0"
+    node-fetch "^2.6.7"
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^16.28.4":
@@ -1917,6 +1992,16 @@
     once "^1.4.0"
     universal-user-agent "^4.0.0"
 
+"@octokit/rest@^18.12.0":
+  version "18.12.0"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.12.0.tgz#f06bc4952fc87130308d810ca9d00e79f6988881"
+  integrity sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==
+  dependencies:
+    "@octokit/core" "^3.5.1"
+    "@octokit/plugin-paginate-rest" "^2.16.8"
+    "@octokit/plugin-request-log" "^1.0.4"
+    "@octokit/plugin-rest-endpoint-methods" "^5.12.0"
+
 "@octokit/types@^2.0.0", "@octokit/types@^2.0.1":
   version "2.16.2"
   resolved "https://registry.yarnpkg.com/@octokit/types/-/types-2.16.2.tgz#4c5f8da3c6fecf3da1811aef678fda03edac35d2"
@@ -1930,6 +2015,13 @@
   integrity sha512-kCkiN8scbCmSq+gwdJV0iLgHc0O/GTPY1/cffo9kECu1MvatLPh9E+qFhfRIktKfHEA6ZYvv6S1B4Wnv3bi3pA==
   dependencies:
     "@octokit/openapi-types" "^5.3.2"
+
+"@octokit/types@^6.16.1", "@octokit/types@^6.34.0":
+  version "6.34.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.34.0.tgz#c6021333334d1ecfb5d370a8798162ddf1ae8218"
+  integrity sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==
+  dependencies:
+    "@octokit/openapi-types" "^11.2.0"
 
 "@phosphor/algorithm@1", "@phosphor/algorithm@^1.2.0":
   version "1.2.0"
@@ -4429,6 +4521,11 @@ before-after-hook@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.0.tgz#09c40d92e936c64777aa385c4e9b904f8147eaf0"
   integrity sha512-jH6rKQIfroBbhEXVmI7XmXe3ix5S/PgJqpzdDPnR8JGLHWNYLsYZ6tK5iWOF/Ra3oqEX0NobXGlzbiylIzVphQ==
+
+before-after-hook@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/before-after-hook/-/before-after-hook-2.2.2.tgz#a6e8ca41028d90ee2c24222f201c90956091613e"
+  integrity sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ==
 
 bent@^7.1.0:
   version "7.3.12"
@@ -10295,6 +10392,13 @@ node-fetch@^2.5.0, node-fetch@^2.6.0, node-fetch@^2.6.1:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
+node-fetch@^2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-gyp@^5.0.2:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-5.1.1.tgz#eb915f7b631c937d282e33aed44cb7a025f62a3e"
@@ -13864,6 +13968,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 trash@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/trash/-/trash-6.1.1.tgz#8fb863421b31f32571f2650b53534934d5e63025"
@@ -14494,6 +14603,11 @@ wcwidth@^1.0.0, wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
 webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
@@ -14580,6 +14694,14 @@ whatwg-mimetype@^2.1.0, whatwg-mimetype@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz#3d4b1e0312d2079879f826aff18dbeeca5960fbf"
   integrity sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^6.4.1:
   version "6.5.0"


### PR DESCRIPTION
This PR adds a `compose-changelog` script to create a changelog containing all versions of the `arduino-ide` project released on Github.

Calling this `yarn run compose-changelog changelog.md` from the project root will create a `changelog.md` file in the `arduino-ide-extension` folder since it's used as working directory.

This also updates the release process to generate the changelog and upload it to AWS S3, a manifest `latest.txt` file is also uploaded containing the name of the latest changelog available. 
The generated changelog file is formatted like so `<tag_name>-<iso-8601-date>.md`, for example `2.0.0-rc3-2022-01-26T15:55:46+01:00.md`.

Changelog and manifest are uploaded to `https://downloads.arduino.cc/arduino-ide/changelog/`.