### PR TITLE
When selecting new port that matches board type, also check match of protocol

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -230,7 +230,8 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
       )) {
         if (
           this.latestValidBoardsConfig.selectedBoard.fqbn === board.fqbn &&
-          this.latestValidBoardsConfig.selectedBoard.name === board.name
+          this.latestValidBoardsConfig.selectedBoard.name === board.name &&
+          this.latestValidBoardsConfig.selectedPort.protocol === board.port?.protocol
         ) {
           this.boardsConfig = {
             ...this.latestValidBoardsConfig,


### PR DESCRIPTION
This is the same as  #765, which was closed since it was a PR on a branch that got merged. @silvanocerza asked for this PR to get rebased on the latest main, so here it is. Please let me know if you need any changes / cleanups, etc.

The original description is:

### This is a partial-workaround for #710. 

Currently, when a user selects Board A, and Port B, when that device disconnects, the IDE searches for a 'similar' port to connect to. For reasons I don't fully appreciate [^1] some boards when they disconnect and reconnect, they reconnect on a different port. So when the IDE searches for a similar port, it first searches for an exact match. But if that fails, it then searches for a match on FQBN-name pairs only and ignores the port. 

Unfortunately, when the user selects Board A, then any port that isn't known to the IDE is listed with the name/FQBN of that selected board. So when the IDE is looking to reconnect, any unknown port will match based on name/FQBN. I think this may be a bug, but maybe it is desirable for reasons I don't understand and/or changing this would break things.

So as a mitigation, I've added a check to make sure that the protocol of the previously connected port matches the protocol of the new port. This doesn't fully address the problem in #710 since the serial protocol is used by 'unknown' ports as well as many Arduino devices and if the protocols match, this patch does nothing. But when using a different protocol it prevents the IE from (re)connecting to port that is not a match for the originally selected port.


[^1]: The code in boards-service-provider.ts on line 48  references the private url https://arduino.slack.com/archives/CJJHJCJSJ/p1568645417013000?thread_ts=1568640504.009400&cid=CJJHJCJSJ for why some boards disconnect and reconnect on a different port.
