### PR TITLE
Add gRPC user agent

### DIFF
--- a/arduino-ide-extension/src/node/grpc-client-provider.ts
+++ b/arduino-ide-extension/src/node/grpc-client-provider.ts
@@ -1,4 +1,5 @@
 import { inject, injectable, postConstruct } from 'inversify';
+import { app } from 'electron';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { ConfigServiceImpl } from './config-service-impl';
@@ -73,6 +74,7 @@ export abstract class GrpcClientProvider<C> {
     return {
       'grpc.max_send_message_length': 512 * 1024 * 1024,
       'grpc.max_receive_message_length': 512 * 1024 * 1024,
+      'grpc.primary_user_agent': `arduino-ide/${app.getVersion()}`
     };
   }
 }


### PR DESCRIPTION
This PR adds the `arduino-ide/<version>` User Agent as the primary UA when connecting to the CLI gRPC daemon.

Closes #790.