### PR TITLE
Fix version retrieval in node process

### DIFF
--- a/arduino-ide-extension/src/node/grpc-client-provider.ts
+++ b/arduino-ide-extension/src/node/grpc-client-provider.ts
@@ -1,5 +1,4 @@
 import { inject, injectable, postConstruct } from 'inversify';
-import { app } from 'electron';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { ConfigServiceImpl } from './config-service-impl';
@@ -71,10 +70,11 @@ export abstract class GrpcClientProvider<C> {
   protected abstract close(client: C): void;
 
   protected get channelOptions(): Record<string, unknown> {
+    const pjson = require('../../package.json') || { "version": "0.0.0" }
     return {
       'grpc.max_send_message_length': 512 * 1024 * 1024,
       'grpc.max_receive_message_length': 512 * 1024 * 1024,
-      'grpc.primary_user_agent': `arduino-ide/${app.getVersion()}`
+      'grpc.primary_user_agent': `arduino-ide/${pjson.version}`
     };
   }
 }


### PR DESCRIPTION
Wrong import in code run in `node` process was causing the IDE not to start.

This happened because the `node` process doesn't have access to the defines found in the `electron` process, thus we had to find a different way of getting the version information.

Fixes #836.