### PR TITLE
Splashscreen fixes

### DIFF
--- a/arduino-ide-extension/src/electron-main/splash/static/splash.html
+++ b/arduino-ide-extension/src/electron-main/splash/static/splash.html
@@ -7,6 +7,7 @@
             width: auto;
             text-align: center;
             padding: 0px;
+            pointer-events: none;
         }
 
         img {

--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -128,7 +128,7 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
         x: splashX,
         y: splashY,
         transparent: true,
-        alwaysOnTop: true,
+        alwaysOnTop: false,
         focusable: false,
         minimizable: false,
         maximizable: false,


### PR DESCRIPTION
Fixes
1. prevent splashscreen from starting alwaysOnTop
2. prevent pointer events like drag on splash screen

Note: I saw https://github.com/arduino/arduino-ide/pull/717 but the approach is different.