### PR TITLE
Avoid duplicated yaml entries

### DIFF
--- a/electron/packager/index.js
+++ b/electron/packager/index.js
@@ -416,7 +416,10 @@ ${fs.readFileSync(path('..', 'build', 'package.json')).toString()}
           const { url } = file;
           const { size } = fs.statSync(join(cwd, url));
           const newSha512 = await hashFile(join(cwd, url));
-          newFiles.push({ ...file, sha512: newSha512, size });
+
+          if (!newFiles.find((f) => f.sha512 === newSha512)) {
+            newFiles.push({ ...file, sha512: newSha512, size });
+          }
         }
         newChannelFile.files = newFiles;
       }


### PR DESCRIPTION
During the generation of the `stable-mac.yml` and `nightly-mac.yml` files, electron builder duplicates the number of entries for dmg files.

This PR fixes the issue, removing the duplicated files using the sha512 as a key.