### PR TITLE
Automatically check for updates only once

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         config:
-          - os: windows-latest
+          - os: windows-2019
           - os: ubuntu-18.04 # https://github.com/arduino/arduino-ide/issues/259
           - os: macos-latest
     runs-on: ${{ matrix.config.os }}

--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -282,7 +282,7 @@ export class ArduinoFrontendContribution
     this.updaterService.init(
       this.arduinoPreferences.get('arduino.ide.updateChannel')
     );
-    this.updater.checkForUpdates().then(async (updateInfo) => {
+    this.updater.checkForUpdates(true).then(async (updateInfo) => {
       if (!updateInfo) return;
       const versionToSkip = await this.localStorageService.getData<string>(
         SKIP_IDE_VERSION

--- a/arduino-ide-extension/src/browser/ide-updater/ide-updater-commands.ts
+++ b/arduino-ide-extension/src/browser/ide-updater/ide-updater-commands.ts
@@ -31,8 +31,8 @@ export class IDEUpdaterCommands implements CommandContribution {
     });
   }
 
-  async checkForUpdates(): Promise<UpdateInfo | void> {
-    return await this.updater.checkForUpdates();
+  async checkForUpdates(initialCheck?: boolean): Promise<UpdateInfo | void> {
+    return await this.updater.checkForUpdates(initialCheck);
   }
 
   async downloadUpdate(): Promise<void> {

--- a/arduino-ide-extension/src/common/protocol/ide-updater.ts
+++ b/arduino-ide-extension/src/common/protocol/ide-updater.ts
@@ -47,7 +47,7 @@ export const IDEUpdaterPath = '/services/ide-updater';
 export const IDEUpdater = Symbol('IDEUpdater');
 export interface IDEUpdater extends JsonRpcServer<IDEUpdaterClient> {
   init(channel: UpdateChannel): void;
-  checkForUpdates(): Promise<UpdateInfo | void>;
+  checkForUpdates(initialCheck?: boolean): Promise<UpdateInfo | void>;
   downloadUpdate(): Promise<void>;
   quitAndInstall(): void;
   stopDownload(): void;

--- a/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
+++ b/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
@@ -12,12 +12,13 @@ const IDE_DOWNLOAD_BASE_URL = 'https://downloads.arduino.cc/arduino-ide';
 
 @injectable()
 export class IDEUpdaterImpl implements IDEUpdater {
+  private isAlreadyChecked = false;
   private updater = autoUpdater;
   private cancellationToken?: CancellationToken;
   protected theiaFEClient?: IDEUpdaterClient;
   protected clients: Array<IDEUpdaterClient> = [];
 
-  init(channel: UpdateChannel) {
+  init(channel: UpdateChannel): void {
     this.updater.autoDownload = false;
     this.updater.channel = channel;
     this.updater.setFeedURL({
@@ -52,9 +53,16 @@ export class IDEUpdaterImpl implements IDEUpdater {
     if (client) this.clients.push(client);
   }
 
-  async checkForUpdates(): Promise<UpdateInfo | void> {
-    const { updateInfo, cancellationToken } =
-      await this.updater.checkForUpdates();
+  async checkForUpdates(initialCheck?: boolean): Promise<UpdateInfo | void> {
+    if (initialCheck) {
+      if (this.isAlreadyChecked) return Promise.resolve();
+      this.isAlreadyChecked = true;
+    }
+
+    const {
+      updateInfo,
+      cancellationToken,
+    } = await this.updater.checkForUpdates();
 
     this.cancellationToken = cancellationToken;
     if (this.updater.currentVersion.compare(updateInfo.version) === -1) {


### PR DESCRIPTION
### Motivation
Checking for updates should happen only once at startup.
Right now, every time a new sketch is open (that is, every time an electron renderer process is instantiated) a check for updates is performed. Since we don't want to flood the users with unnecessary dialogs, we need to show it only on the first sketch they open.

### Change description
Add a flag to check if an initial check has already been performed

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)