### PR TITLE
Add preference to set a custom update url

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -280,7 +280,8 @@ export class ArduinoFrontendContribution
     }
 
     this.updaterService.init(
-      this.arduinoPreferences.get('arduino.ide.updateChannel')
+      this.arduinoPreferences.get('arduino.ide.updateChannel'),
+      this.arduinoPreferences.get('arduino.ide.updateBaseUrl')
     );
     this.updater.checkForUpdates(true).then(async (updateInfo) => {
       if (!updateInfo) return;

--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -78,6 +78,14 @@ export const ArduinoConfigSchema: PreferenceSchema = {
         "Release channel to get updated from. 'stable' is the stable release, 'nightly' is the latest development build."
       ),
     },
+    'arduino.ide.updateBaseUrl': {
+      type: 'string',
+      default: 'https://downloads.arduino.cc/arduino-ide',
+      description: nls.localize(
+        'arduino/preferences/ide.updateBaseUrl',
+        `The base URL where to download updates from. Defaults to 'https://downloads.arduino.cc/arduino-ide'`
+      ),
+    },
     'arduino.board.certificates': {
       type: 'string',
       description: nls.localize(
@@ -178,6 +186,7 @@ export interface ArduinoConfiguration {
   'arduino.window.autoScale': boolean;
   'arduino.window.zoomLevel': number;
   'arduino.ide.updateChannel': UpdateChannel;
+  'arduino.ide.updateBaseUrl': string;
   'arduino.board.certificates': string;
   'arduino.sketchbook.showAllFiles': boolean;
   'arduino.cloud.enabled': boolean;

--- a/arduino-ide-extension/src/common/protocol/ide-updater.ts
+++ b/arduino-ide-extension/src/common/protocol/ide-updater.ts
@@ -46,7 +46,7 @@ export interface ProgressInfo {
 export const IDEUpdaterPath = '/services/ide-updater';
 export const IDEUpdater = Symbol('IDEUpdater');
 export interface IDEUpdater extends JsonRpcServer<IDEUpdaterClient> {
-  init(channel: UpdateChannel): void;
+  init(channel: UpdateChannel, baseUrl: string): void;
   checkForUpdates(initialCheck?: boolean): Promise<UpdateInfo | void>;
   downloadUpdate(): Promise<void>;
   quitAndInstall(): void;

--- a/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
+++ b/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
@@ -8,7 +8,6 @@ import {
 } from '../../common/protocol/ide-updater';
 
 const CHANGELOG_BASE_URL = 'https://downloads.arduino.cc/arduino-ide/changelog';
-const IDE_DOWNLOAD_BASE_URL = 'https://downloads.arduino.cc/arduino-ide';
 
 @injectable()
 export class IDEUpdaterImpl implements IDEUpdater {
@@ -18,14 +17,12 @@ export class IDEUpdaterImpl implements IDEUpdater {
   protected theiaFEClient?: IDEUpdaterClient;
   protected clients: Array<IDEUpdaterClient> = [];
 
-  init(channel: UpdateChannel): void {
+  init(channel: UpdateChannel, baseUrl: string): void {
     this.updater.autoDownload = false;
     this.updater.channel = channel;
     this.updater.setFeedURL({
       provider: 'generic',
-      url: `${IDE_DOWNLOAD_BASE_URL}/${
-        channel === UpdateChannel.Nightly ? 'nightly' : ''
-      }`,
+      url: `${baseUrl}/${channel === UpdateChannel.Nightly ? 'nightly' : ''}`,
       channel,
     });
 


### PR DESCRIPTION
### Motivation
We want to have a way to test the automatic update feature when downloading a build from a PR.

### Change description
Add the possibility to change the URL the updater uses to know if there are updates and to download them. This way, anyone could start a local server that serves the files needed for the automatic update and fool the updater to make them think there is a new update to download.

### Other information
This is necessary because a PR build of the Arduino IDE will generally be a newer version than the current latest version, so it's difficult to test before merging.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)