### PR TITLE
show represented file on MacOS

### DIFF
--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-service.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-service.ts
@@ -1,3 +1,4 @@
+import * as remote from '@theia/core/electron-shared/@electron/remote';
 import { injectable, inject } from 'inversify';
 import URI from '@theia/core/lib/common/uri';
 import { EditorWidget } from '@theia/editor/lib/browser';
@@ -77,7 +78,9 @@ export class WorkspaceService extends TheiaWorkspaceService {
             ),
         ]);
         // On Dindows, `getRecentWorkspaces` returns only file paths, not URIs as expected by the `isValid` method.
-        const recentWorkspaces = recentWorkspacesPaths.map(e => VSCodeUri.file(e).toString());
+        const recentWorkspaces = recentWorkspacesPaths.map((e) =>
+          VSCodeUri.file(e).toString()
+        );
         const toOpen = await new ArduinoWorkspaceRootResolver({
           isValid: this.isValid.bind(this),
         }).resolve({ hash, recentWorkspaces, recentSketches });
@@ -127,6 +130,8 @@ export class WorkspaceService extends TheiaWorkspaceService {
   }: FocusTracker.IChangedArgs<Widget>): void {
     if (newValue instanceof EditorWidget) {
       const { uri } = newValue.editor;
+      const currentWindow = remote.getCurrentWindow();
+      currentWindow.setRepresentedFilename(uri.path.toString());
       if (Sketch.isSketchFile(uri.toString())) {
         this.updateTitle();
       } else {


### PR DESCRIPTION
### Motivation
On macOS, you can [set a represented file](https://www.electronjs.org/docs/latest/tutorial/represented-file) for any window in your application. The represented file's icon will be shown in the title bar, and when users CMD/CTRL+Click, a popup with a path to the file will be shown.

<img width="334" alt="image" src="https://user-images.githubusercontent.com/6939054/155875729-15ecf162-d77f-4796-ae11-82dd15d34565.png">


### Change description
Use [BrowserWindow.setRepresentedFilename](https://www.electronjs.org/docs/latest/api/browser-window#winsetrepresentedfilenamefilename-macos) whenever the file selected in the editor changes.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)