### PR TITLE
Go to download page when automatic update fails

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -280,7 +280,8 @@ export class ArduinoFrontendContribution
     }
 
     this.updaterService.init(
-      this.arduinoPreferences.get('arduino.ide.updateChannel')
+      this.arduinoPreferences.get('arduino.ide.updateChannel'),
+      this.arduinoPreferences.get('arduino.ide.updateBaseUrl')
     );
     this.updater.checkForUpdates(true).then(async (updateInfo) => {
       if (!updateInfo) return;

--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -78,6 +78,14 @@ export const ArduinoConfigSchema: PreferenceSchema = {
         "Release channel to get updated from. 'stable' is the stable release, 'nightly' is the latest development build."
       ),
     },
+    'arduino.ide.updateBaseUrl': {
+      type: 'string',
+      default: 'https://downloads.arduino.cc/arduino-ide',
+      description: nls.localize(
+        'arduino/preferences/ide.updateBaseUrl',
+        `The base URL where to download updates from. Defaults to 'https://downloads.arduino.cc/arduino-ide'`
+      ),
+    },
     'arduino.board.certificates': {
       type: 'string',
       description: nls.localize(
@@ -178,6 +186,7 @@ export interface ArduinoConfiguration {
   'arduino.window.autoScale': boolean;
   'arduino.window.zoomLevel': number;
   'arduino.ide.updateChannel': UpdateChannel;
+  'arduino.ide.updateBaseUrl': string;
   'arduino.board.certificates': string;
   'arduino.sketchbook.showAllFiles': boolean;
   'arduino.cloud.enabled': boolean;

--- a/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-component.tsx
@@ -1,3 +1,4 @@
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { nls } from '@theia/core/lib/common';
 import { shell } from 'electron';
 import * as React from 'react';
@@ -8,6 +9,7 @@ import ProgressBar from '../../components/ProgressBar';
 
 export type IDEUpdaterComponentProps = {
   updateInfo: UpdateInfo;
+  windowService: WindowService;
   downloadFinished?: boolean;
   downloadStarted?: boolean;
   progress?: ProgressInfo;
@@ -22,6 +24,7 @@ export const IDEUpdaterComponent = ({
   updateInfo: { version, releaseNotes },
   downloadStarted = false,
   downloadFinished = false,
+  windowService,
   progress,
   error,
   onDownload,
@@ -62,98 +65,147 @@ export const IDEUpdaterComponent = ({
     </button>
   );
 
+  const DownloadCompleted: () => React.ReactElement = () => (
+    <div className="ide-updater-dialog--downloaded">
+      <div>
+        {nls.localize(
+          'arduino/ide-updater/versionDownloaded',
+          'Arduino IDE {0} has been downloaded.',
+          version
+        )}
+      </div>
+      <div>
+        {nls.localize(
+          'arduino/ide-updater/closeToInstallNotice',
+          'Close the software and install the update on your machine.'
+        )}
+      </div>
+      <div className="buttons-container">
+        {closeButton}
+        <button
+          onClick={onCloseAndInstall}
+          type="button"
+          className="theia-button close-and-install"
+        >
+          {nls.localize(
+            'arduino/ide-updater/closeAndInstallButton',
+            'Close and Install'
+          )}
+        </button>
+      </div>
+    </div>
+  );
+
+  const DownloadStarted: () => React.ReactElement = () => (
+    <div className="ide-updater-dialog--downloading">
+      <div>
+        {nls.localize(
+          'arduino/ide-updater/downloadingNotice',
+          'Downloading the latest version of the Arduino IDE.'
+        )}
+      </div>
+      <ProgressBar percent={progress?.percent} showPercentage />
+    </div>
+  );
+
+  const PreDownload: () => React.ReactElement = () => (
+    <div className="ide-updater-dialog--pre-download">
+      <div className="ide-updater-dialog--logo-container">
+        <div className="ide-updater-dialog--logo"></div>
+      </div>
+      <div className="ide-updater-dialog--new-version-text dialogSection">
+        <div className="dialogRow">
+          <div className="bold">
+            {nls.localize(
+              'arduino/ide-updater/updateAvailable',
+              'Update Available'
+            )}
+          </div>
+        </div>
+        <div className="dialogRow">
+          {nls.localize(
+            'arduino/ide-updater/newVersionAvailable',
+            'A new version of Arduino IDE ({0}) is available for download.',
+            version
+          )}
+        </div>
+        {releaseNotes && (
+          <div className="dialogRow">
+            <div className="changelog-container" ref={changelogDivRef} />
+          </div>
+        )}
+        <div className="buttons-container">
+          <button
+            onClick={onSkipVersion}
+            type="button"
+            className="theia-button secondary skip-version"
+          >
+            {nls.localize(
+              'arduino/ide-updater/skipVersionButton',
+              'Skip Version'
+            )}
+          </button>
+          <div className="push"></div>
+          {closeButton}
+          <button
+            onClick={onDownload}
+            type="button"
+            className="theia-button primary"
+          >
+            {nls.localize('arduino/ide-updater/downloadButton', 'Download')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  const onGoToDownloadClick = (
+    event: React.SyntheticEvent<HTMLAnchorElement, Event>
+  ) => {
+    const { target } = event.nativeEvent;
+    if (target instanceof HTMLAnchorElement) {
+      event.nativeEvent.preventDefault();
+      windowService.openNewWindow(target.href, { external: true });
+      onClose();
+    }
+  };
+
+  const GoToDownloadPage: () => React.ReactElement = () => (
+    <div className="ide-updater-dialog--go-to-download-page">
+      <div>
+        {nls.localize(
+          'arduino/ide-updater/goToDownloadPage',
+          "An update for the Arduino IDE is available, but we're not able to download and install it automatically. Please go to the download page and download the latest version from there."
+        )}
+      </div>
+      <div className="buttons-container">
+        {closeButton}
+        <a
+          className="theia-button primary"
+          href="https://www.arduino.cc/en/software#experimental-software"
+          onClick={onGoToDownloadClick}
+        >
+          {nls.localize(
+            'arduino/ide-updater/goToDownloadButton',
+            'Go To Download'
+          )}
+        </a>
+      </div>
+    </div>
+  );
+
   return (
     <div className="ide-updater-dialog--content">
-      {downloadFinished ? (
-        <div className="ide-updater-dialog--downloaded">
-          <div>
-            {nls.localize(
-              'arduino/ide-updater/versionDownloaded',
-              'Arduino IDE {0} has been downloaded.',
-              version
-            )}
-          </div>
-          <div>
-            {nls.localize(
-              'arduino/ide-updater/closeToInstallNotice',
-              'Close the software and install the update on your machine.'
-            )}
-          </div>
-          <div className="buttons-container">
-            {closeButton}
-            <button
-              onClick={onCloseAndInstall}
-              type="button"
-              className="theia-button close-and-install"
-            >
-              {nls.localize(
-                'arduino/ide-updater/closeAndInstallButton',
-                'Close and Install'
-              )}
-            </button>
-          </div>
-        </div>
+      {!!error ? (
+        <GoToDownloadPage />
+      ) : downloadFinished ? (
+        <DownloadCompleted />
       ) : downloadStarted ? (
-        <div className="ide-updater-dialog--downloading">
-          <div>
-            {nls.localize(
-              'arduino/ide-updater/downloadingNotice',
-              'Downloading the latest version of the Arduino IDE.'
-            )}
-          </div>
-          <ProgressBar percent={progress?.percent} showPercentage />
-        </div>
+        <DownloadStarted />
       ) : (
-        <div className="ide-updater-dialog--pre-download">
-          <div className="ide-updater-dialog--logo-container">
-            <div className="ide-updater-dialog--logo"></div>
-          </div>
-          <div className="ide-updater-dialog--new-version-text dialogSection">
-            <div className="dialogRow">
-              <div className="bold">
-                {nls.localize(
-                  'arduino/ide-updater/updateAvailable',
-                  'Update Available'
-                )}
-              </div>
-            </div>
-            <div className="dialogRow">
-              {nls.localize(
-                'arduino/ide-updater/newVersionAvailable',
-                'A new version of Arduino IDE ({0}) is available for download.',
-                version
-              )}
-            </div>
-            {releaseNotes && (
-              <div className="dialogRow">
-                <div className="changelog-container" ref={changelogDivRef} />
-              </div>
-            )}
-            <div className="buttons-container">
-              <button
-                onClick={onSkipVersion}
-                type="button"
-                className="theia-button secondary skip-version"
-              >
-                {nls.localize(
-                  'arduino/ide-updater/skipVersionButton',
-                  'Skip Version'
-                )}
-              </button>
-              <div className="push"></div>
-              {closeButton}
-              <button
-                onClick={onDownload}
-                type="button"
-                className="theia-button primary"
-              >
-                {nls.localize('arduino/ide-updater/downloadButton', 'Download')}
-              </button>
-            </div>
-          </div>
-        </div>
+        <PreDownload />
       )}
-      {!!error && <div className="error-container">{error}</div>}
+      {/* {!!error && <div className="error-container">{error}</div>} */}
     </div>
   );
 };

--- a/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-dialog.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-dialog.tsx
@@ -15,6 +15,7 @@ import {
 } from '../../../common/protocol/ide-updater';
 import { LocalStorageService } from '@theia/core/lib/browser';
 import { SKIP_IDE_VERSION } from '../../arduino-frontend-contribution';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
 
 @injectable()
 export class IDEUpdaterDialogWidget extends ReactWidget {
@@ -34,6 +35,9 @@ export class IDEUpdaterDialogWidget extends ReactWidget {
 
   @inject(LocalStorageService)
   protected readonly localStorageService: LocalStorageService;
+
+  @inject(WindowService)
+  protected windowService: WindowService;
 
   init(updateInfo: UpdateInfo, onClose: () => void): void {
     this.updateInfo = updateInfo;
@@ -92,9 +96,11 @@ export class IDEUpdaterDialogWidget extends ReactWidget {
       <form>
         <IDEUpdaterComponent
           updateInfo={this.updateInfo}
+          windowService={this.windowService}
           downloadStarted={this.downloadStarted}
           downloadFinished={this.downloadFinished}
           progress={this.progressInfo}
+          error={this.error}
           onClose={this.close.bind(this)}
           onSkipVersion={this.onSkipVersion.bind(this)}
           onDownload={this.onDownload.bind(this)}

--- a/arduino-ide-extension/src/browser/style/ide-updater-dialog.css
+++ b/arduino-ide-extension/src/browser/style/ide-updater-dialog.css
@@ -62,6 +62,17 @@
   margin-top: 28px;
 }
 
+.ide-updater-dialog .buttons-container a.theia-button {
+  text-decoration: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.ide-updater-dialog .buttons-container a.theia-button:hover {
+  color: var(--theia-button-foreground);
+}
+
 .ide-updater-dialog .buttons-container .push {
   margin-right: auto;
 }

--- a/arduino-ide-extension/src/common/protocol/ide-updater.ts
+++ b/arduino-ide-extension/src/common/protocol/ide-updater.ts
@@ -46,7 +46,7 @@ export interface ProgressInfo {
 export const IDEUpdaterPath = '/services/ide-updater';
 export const IDEUpdater = Symbol('IDEUpdater');
 export interface IDEUpdater extends JsonRpcServer<IDEUpdaterClient> {
-  init(channel: UpdateChannel): void;
+  init(channel: UpdateChannel, baseUrl: string): void;
   checkForUpdates(initialCheck?: boolean): Promise<UpdateInfo | void>;
   downloadUpdate(): Promise<void>;
   quitAndInstall(): void;

--- a/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
+++ b/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
@@ -104,7 +104,7 @@ export class IDEUpdaterImpl implements IDEUpdater {
       await this.updater.downloadUpdate(this.cancellationToken);
     } catch (e) {
       if (e.message === 'cancelled') return;
-      throw e;
+      this.clients.forEach((c) => c.notifyError(e));
     }
   }
 

--- a/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
+++ b/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
@@ -8,7 +8,6 @@ import {
 } from '../../common/protocol/ide-updater';
 
 const CHANGELOG_BASE_URL = 'https://downloads.arduino.cc/arduino-ide/changelog';
-const IDE_DOWNLOAD_BASE_URL = 'https://downloads.arduino.cc/arduino-ide';
 
 @injectable()
 export class IDEUpdaterImpl implements IDEUpdater {
@@ -18,14 +17,12 @@ export class IDEUpdaterImpl implements IDEUpdater {
   protected theiaFEClient?: IDEUpdaterClient;
   protected clients: Array<IDEUpdaterClient> = [];
 
-  init(channel: UpdateChannel): void {
+  init(channel: UpdateChannel, baseUrl: string): void {
     this.updater.autoDownload = false;
     this.updater.channel = channel;
     this.updater.setFeedURL({
       provider: 'generic',
-      url: `${IDE_DOWNLOAD_BASE_URL}/${
-        channel === UpdateChannel.Nightly ? 'nightly' : ''
-      }`,
+      url: `${baseUrl}/${channel === UpdateChannel.Nightly ? 'nightly' : ''}`,
       channel,
     });
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -264,7 +264,9 @@
             "updateAvailable": "Update Available",
             "newVersionAvailable": "A new version of Arduino IDE ({0}) is available for download.",
             "skipVersionButton": "Skip Version",
-            "downloadButton": "Download"
+            "downloadButton": "Download",
+            "goToDownloadPage": "An update for the Arduino IDE is available, but we're not able to download and install it automatically. Please go to the download page and download the latest version from there.",
+            "goToDownloadButton": "Go To Download"
         },
         "updater": {
             "ideUpdaterDialog": "Software Update"


### PR DESCRIPTION
### Motivation
Errors happening during the automatic update aren't handled properly. 

### Change description
Whenever an error happens during the automatic update occurs, show a link to the download page to let the user download the IDE by themselves.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)