### PR TITLE
fix IDE updater commands

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -291,7 +291,11 @@ export class ArduinoFrontendContribution
       })
       .catch((e) => {
         this.messageService.error(
-          `Error while checking for Arduino IDE updates. ${e}`
+          nls.localize(
+            'arduino/ide-updater/errorCheckingForUpdates',
+            'Error while checking for Arduino IDE updates.\n{0}',
+            e.message
+          )
         );
       });
 

--- a/arduino-ide-extension/src/browser/contributions/help.ts
+++ b/arduino-ide-extension/src/browser/contributions/help.ts
@@ -13,6 +13,7 @@ import {
   KeybindingRegistry,
 } from './contribution';
 import { nls } from '@theia/core/lib/common';
+import { IDEUpdaterCommands } from '../ide-updater/ide-updater-commands';
 
 @injectable()
 export class Help extends Contribution {
@@ -114,6 +115,10 @@ export class Help extends Contribution {
     registry.registerMenuAction(ArduinoMenus.HELP__FIND_GROUP, {
       commandId: Help.Commands.VISIT_ARDUINO.id,
       order: '6',
+    });
+    registry.registerMenuAction(ArduinoMenus.HELP__FIND_GROUP, {
+      commandId: IDEUpdaterCommands.CHECK_FOR_UPDATES.id,
+      order: '7',
     });
   }
 

--- a/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-component.tsx
@@ -205,7 +205,6 @@ export const IDEUpdaterComponent = ({
       ) : (
         <PreDownload />
       )}
-      {/* {!!error && <div className="error-container">{error}</div>} */}
     </div>
   );
 };

--- a/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-dialog.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-dialog.tsx
@@ -7,8 +7,9 @@ import { Message } from '@phosphor/messaging';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { nls } from '@theia/core';
 import { IDEUpdaterComponent } from './ide-updater-component';
-import { IDEUpdaterCommands } from '../../ide-updater/ide-updater-commands';
+
 import {
+  IDEUpdater,
   IDEUpdaterClient,
   ProgressInfo,
   UpdateInfo,
@@ -27,8 +28,8 @@ export class IDEUpdaterDialogWidget extends ReactWidget {
   downloadStarted: boolean;
   onClose: () => void;
 
-  @inject(IDEUpdaterCommands)
-  protected readonly updater: IDEUpdaterCommands;
+  @inject(IDEUpdater)
+  protected readonly updater: IDEUpdater;
 
   @inject(IDEUpdaterClient)
   protected readonly updaterClient: IDEUpdaterClient;

--- a/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-dialog.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-dialog.tsx
@@ -126,7 +126,7 @@ export class IDEUpdaterDialog extends AbstractDialog<UpdateInfo> {
   ) {
     super({
       title: nls.localize(
-        'arduino/updater/ideUpdaterDialog',
+        'arduino/ide-updater/ideUpdaterDialog',
         'Software Update'
       ),
     });

--- a/arduino-ide-extension/src/browser/ide-updater/ide-updater-commands.ts
+++ b/arduino-ide-extension/src/browser/ide-updater/ide-updater-commands.ts
@@ -3,6 +3,7 @@ import {
   CommandContribution,
   CommandRegistry,
   MessageService,
+  nls,
 } from '@theia/core';
 import { injectable, inject } from 'inversify';
 import { IDEUpdater, UpdateInfo } from '../../common/protocol/ide-updater';
@@ -32,13 +33,20 @@ export class IDEUpdaterCommands implements CommandContribution {
         this.updaterDialog.open(updateInfo);
       } else {
         this.messageService.info(
-          `There are no recent updates available the Arduino IDE`
+          nls.localize(
+            'arduino/ide-updater/noUpdatesAvailable',
+            'There are no recent updates available for the Arduino IDE'
+          )
         );
       }
       return updateInfo;
     } catch (e) {
       this.messageService.error(
-        `Error while checking for Arduino IDE updates. ${e.message}`
+        nls.localize(
+          'arduino/ide-updater/errorCheckingForUpdates',
+          'Error while checking for Arduino IDE updates.\n{0}',
+          e.message
+        )
       );
     }
   }

--- a/arduino-ide-extension/src/browser/ide-updater/ide-updater-commands.ts
+++ b/arduino-ide-extension/src/browser/ide-updater/ide-updater-commands.ts
@@ -38,7 +38,7 @@ export class IDEUpdaterCommands implements CommandContribution {
       return updateInfo;
     } catch (e) {
       this.messageService.error(
-        `Error while checking for Arduino IDE updates. ${e}`
+        `Error while checking for Arduino IDE updates. ${e.message}`
       );
     }
   }

--- a/arduino-ide-extension/src/common/protocol/ide-updater.ts
+++ b/arduino-ide-extension/src/common/protocol/ide-updater.ts
@@ -46,7 +46,7 @@ export interface ProgressInfo {
 export const IDEUpdaterPath = '/services/ide-updater';
 export const IDEUpdater = Symbol('IDEUpdater');
 export interface IDEUpdater extends JsonRpcServer<IDEUpdaterClient> {
-  init(channel: UpdateChannel, baseUrl: string): void;
+  init(channel: UpdateChannel, baseUrl: string): Promise<void>;
   checkForUpdates(initialCheck?: boolean): Promise<UpdateInfo | void>;
   downloadUpdate(): Promise<void>;
   quitAndInstall(): void;

--- a/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
+++ b/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
@@ -17,15 +17,7 @@ export class IDEUpdaterImpl implements IDEUpdater {
   protected theiaFEClient?: IDEUpdaterClient;
   protected clients: Array<IDEUpdaterClient> = [];
 
-  init(channel: UpdateChannel, baseUrl: string): void {
-    this.updater.autoDownload = false;
-    this.updater.channel = channel;
-    this.updater.setFeedURL({
-      provider: 'generic',
-      url: `${baseUrl}/${channel === UpdateChannel.Nightly ? 'nightly' : ''}`,
-      channel,
-    });
-
+  constructor() {
     this.updater.on('checking-for-update', (e) => {
       this.clients.forEach((c) => c.notifyCheckingForUpdate(e));
     });
@@ -43,6 +35,16 @@ export class IDEUpdaterImpl implements IDEUpdater {
     });
     this.updater.on('error', (e) => {
       this.clients.forEach((c) => c.notifyError(e));
+    });
+  }
+
+  async init(channel: UpdateChannel, baseUrl: string): Promise<void> {
+    this.updater.autoDownload = false;
+    this.updater.channel = channel;
+    this.updater.setFeedURL({
+      provider: 'generic',
+      url: `${baseUrl}/${channel === UpdateChannel.Nightly ? 'nightly' : ''}`,
+      channel,
     });
   }
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -14,6 +14,22 @@
             "saveChangesToSketch": "Do you want to save changes to this sketch before closing?",
             "loseChanges": "If you don't save, your changes will be lost."
         },
+        "ide-updater": {
+            "errorCheckingForUpdates": "Error while checking for Arduino IDE updates.\n{0}",
+            "notNowButton": "Not now",
+            "versionDownloaded": "Arduino IDE {0} has been downloaded.",
+            "closeToInstallNotice": "Close the software and install the update on your machine.",
+            "closeAndInstallButton": "Close and Install",
+            "downloadingNotice": "Downloading the latest version of the Arduino IDE.",
+            "updateAvailable": "Update Available",
+            "newVersionAvailable": "A new version of Arduino IDE ({0}) is available for download.",
+            "skipVersionButton": "Skip Version",
+            "downloadButton": "Download",
+            "goToDownloadPage": "An update for the Arduino IDE is available, but we're not able to download and install it automatically. Please go to the download page and download the latest version from there.",
+            "goToDownloadButton": "Go To Download",
+            "ideUpdaterDialog": "Software Update",
+            "noUpdatesAvailable": "There are no recent updates available for the Arduino IDE"
+        },
         "menu": {
             "sketch": "Sketch",
             "tools": "Tools"
@@ -254,22 +270,6 @@
         },
         "dialog": {
             "dontAskAgain": "Don't ask again"
-        },
-        "ide-updater": {
-            "notNowButton": "Not now",
-            "versionDownloaded": "Arduino IDE {0} has been downloaded.",
-            "closeToInstallNotice": "Close the software and install the update on your machine.",
-            "closeAndInstallButton": "Close and Install",
-            "downloadingNotice": "Downloading the latest version of the Arduino IDE.",
-            "updateAvailable": "Update Available",
-            "newVersionAvailable": "A new version of Arduino IDE ({0}) is available for download.",
-            "skipVersionButton": "Skip Version",
-            "downloadButton": "Download",
-            "goToDownloadPage": "An update for the Arduino IDE is available, but we're not able to download and install it automatically. Please go to the download page and download the latest version from there.",
-            "goToDownloadButton": "Go To Download"
-        },
-        "updater": {
-            "ideUpdaterDialog": "Software Update"
         },
         "userFields": {
             "cancel": "Cancel",


### PR DESCRIPTION
### Motivation
IDE updater commands are not working how expected. They work, but they are not giving any feedback to the user.

### Change description
Remove useless commands. Leave only the "Check for Arduino IDE updates" command. When launching this command, if there is an update available, it opens the update dialog. If there isn't any update available or some error occurs, it shows a notification message.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)