### PR TITLE
Remove dev tools menu item

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/help.ts
+++ b/arduino-ide-extension/src/browser/contributions/help.ts
@@ -14,6 +14,7 @@ import {
 } from './contribution';
 import { nls } from '@theia/core/lib/common';
 import { IDEUpdaterCommands } from '../ide-updater/ide-updater-commands';
+import { ElectronCommands } from '@theia/core/lib/electron-browser/menu/electron-menu-contribution';
 
 @injectable()
 export class Help extends Contribution {
@@ -87,6 +88,10 @@ export class Help extends Contribution {
   }
 
   registerMenus(registry: MenuModelRegistry): void {
+    registry.unregisterMenuAction({
+      commandId: ElectronCommands.TOGGLE_DEVELOPER_TOOLS.id,
+    });
+
     registry.registerMenuAction(ArduinoMenus.HELP__MAIN_GROUP, {
       commandId: Help.Commands.GETTING_STARTED.id,
       order: '0',


### PR DESCRIPTION
### Motivation
The "Help" menu contains the item "Toggle Developer Tools". In this case, "developer" is referring to the developer of the IDE itself. Those using the IDE to develop Arduino sketches will not find this to be useful in any way, so it only adds unnecessary complexity to the primary UI of the IDE.
Solves #650 

### Change description
Unregister the dev tools menu item, which is automatically registered by a Theia module.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)