### PR TITLE
Add Linux AppImage to nightly build download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ should be considered unstable:
 
 | Platform  | 32 bit                   | 64 bit                                                                                                 |
 | --------- | ------------------------ | ------------------------------------------------------------------------------------------------------ |
-| Linux     |                          | [Nightly Linux 64 bit]                                                                                 |
+| Linux     |                          | [Nightly Linux AppImage 64 bit]<br />[Nightly Linux ZIP file 64 bit]                                   |
 | Linux ARM | [🚧 Work in progress...] | [🚧 Work in progress...]                                                                               |
 | Windows   |                          | [Nightly Windows 64 bit installer]<br />[Nightly Windows 64 bit MSI]<br />[Nightly Windows 64 bit ZIP] |
 | macOS     |                          | [Nightly macOS 64 bit]                                                                                 |
 
 [🚧 work in progress...]: https://github.com/arduino/arduino-ide/issues/107
-[nightly linux 64 bit]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Linux_64bit.zip
+[nightly linux appimage 64 bit]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Linux_64bit.AppImage
+[nightly linux zip file 64 bit]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Linux_64bit.zip
 [nightly windows 64 bit installer]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Windows_64bit.exe
 [nightly windows 64 bit msi]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Windows_64bit.msi
 [nightly windows 64 bit zip]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Windows_64bit.zip


### PR DESCRIPTION
### Motivation

Linux x86-64 builds of the Arduino IDE are now available in [AppImage format](https://appimage.org/) in additional to the previous ZIP format (https://github.com/arduino/arduino-ide/pull/846).

Since only the AppImage format IDE supports auto-updates (the IDE installed from the ZIP will notify of available updates, but can't auto-update), this will be the preferred format and so good beta testing coverage of it is especially important.

### Change description

Add Linux x64-64 AppImage option to the "**Nightly builds**" download link table in the readme.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [x] PR addresses a single concern.
* [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [x] PR title and description are properly filled.
* [x] Docs have been added / updated (for bug fixes / features)