### PR TITLE
Remove irrelevant trigger from "Compose full changelog" workflow

### DIFF
--- a/.github/workflows/compose-full-changelog.yaml
+++ b/.github/workflows/compose-full-changelog.yaml
@@ -2,7 +2,8 @@ name: Compose full changelog
 
 on:
   release:
-    types: [created, edited]
+    types:
+      - edited
 
 env:
   CHANGELOG_ARTIFACTS: changelog


### PR DESCRIPTION
The "Compose full changelog" GitHub Actions workflow generates a changelog file from [the release notes](https://github.com/arduino/arduino-ide/releases/latest) and uploads this to Arduino's server for display to the user by [the IDE updater](https://github.com/arduino/arduino-ide/pull/797).

Previously, this workflow could be [triggered](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on) by either of two types of [`release` event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release):

- Release creation
- Release edit

### Motivation

To reduce the possibility of endless recursion, GitHub Actions ignores events which are triggered using the auto-generated [`GITHUB_TOKEN` access token](https://docs.github.com/en/actions/security-guides/automatic-token-authentication):

https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

All release creations are done automatically by [the "Arduino IDE" GitHub Actions workflow](https://github.com/arduino/arduino-ide/blob/e6b9d4e2aa0503a0cb99e472051e1e49f487e2c7/.github/workflows/build.yml), which [uses this token](https://github.com/arduino/arduino-ide/blob/e6b9d4e2aa0503a0cb99e472051e1e49f487e2c7/.github/workflows/build.yml#L209).

For this reason, the release creation trigger will never be used. Since the behavior of the event being ignored by GitHub Actions under these conditions is not at all obvious, having the workflow configured for such an irrelevant trigger can cause confusion.


### Change description

Remove the irrelevant trigger from the workflow.

The workflow will be triggered by the manual edit which is done on every release to format the raw release notes [auto-generated from the commit history](https://github.com/arduino/arduino-ide/blob/e6b9d4e2aa0503a0cb99e472051e1e49f487e2c7/.github/workflows/build.yml#L138). So the fact that the release creation trigger doesn't work is not a problem.

### Reviewer checklist

* [x] PR addresses a single concern.
* [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [x] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)