### PR TITLE
Remove irrelevant statement from EULA

### DIFF
--- a/electron/build/resources/eula.txt
+++ b/electron/build/resources/eula.txt
@@ -1,5 +1,3 @@
 Terms of Service
 
-By downloading the software from this page, you agree to the specified terms.
-
 The Arduino software is provided to you "as is" and we make no express or implied warranties whatsoever with respect to its functionality, operability, or use, including, without limitation, any implied warranties of merchantability, fitness for a particular purpose, or infringement. We expressly disclaim any liability whatsoever for any direct, indirect, consequential, incidental or special damages, including, without limitation, lost revenues, lost profits, losses resulting from business interruption or loss of data, regardless of the form of action or legal theory under which the liability may be asserted, even if advised of the possibility or likelihood of such damages.


### PR DESCRIPTION
### Motivation

When using the interactive installer, the user is presented with a dialog requesting they agree to this:

![image](https://user-images.githubusercontent.com/8572152/157071382-7c801ece-79c5-4739-819c-1761031923f0.png)

The previous statement about initiation of a download constituting agreement is relevant in the context of [the text's source on the arduino.cc downloads page](https://www.arduino.cc/en/software#terms-of-service), but not at all in the context of the installer dialog.

### Change description

Remove the irrelevant statement

### Reviewer checklist

* [x] PR addresses a single concern.
* [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [x] PR title and description are properly filled.
* [ ] ~~Docs have been added / updated (for bug fixes / features)~~ N/A