### PR TITLE
Install oktokit in changelog workflow

### DIFF
--- a/.github/workflows/compose-full-changelog.yaml
+++ b/.github/workflows/compose-full-changelog.yaml
@@ -32,6 +32,7 @@ jobs:
       - name: Create full changelog
         id: full-changelog
         run: |
+          yarn add @octokit/rest
           mkdir "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}"
 
           # Get the changelog file name to build

--- a/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
+++ b/arduino-ide-extension/src/electron-main/ide-updater/ide-updater-impl.ts
@@ -81,11 +81,9 @@ export class IDEUpdaterImpl implements IDEUpdater {
           ? await fetch(`${CHANGELOG_BASE_URL}/${latestChangelogFileName}`)
           : null;
         const changelog = response?.ok ? await response?.text() : null;
-
+        const currentVersionHeader = `\n\n---\n\n## ${this.updater.currentVersion}\n\n`;
         // We only want to see the release notes of newer versions
-        const currentVersionIndex = changelog?.indexOf(
-          `\r\n\r\n---\r\n\r\n## ${this.updater.currentVersion}\r\n\r\n`
-        );
+        const currentVersionIndex = changelog?.indexOf(currentVersionHeader);
         const newChangelog =
           currentVersionIndex && currentVersionIndex > 0
             ? changelog?.slice(0, currentVersionIndex)


### PR DESCRIPTION
### Motivation
The changelog in the update dialog is not displayed correctly.

### Change description
- Workflow to compose changelog is failing because `octokit` is not installed, so we just install it
- Fix the string that searches for the current version in the changelog

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)