### PR TITLE
download linux arm64 binaries for clangd and arduino-language-server

### DIFF
--- a/arduino-ide-extension/scripts/download-ls.js
+++ b/arduino-ide-extension/scripts/download-ls.js
@@ -79,6 +79,11 @@
       lsSuffix = 'Linux_64bit.tar.gz';
       clangdSuffix = 'Linux_64bit';
       break;
+    case 'linux-arm64':
+      clangdExecutablePath = path.join(build, 'clangd');
+      lsSuffix = 'Linux_ARM64.tar.gz';
+      clangdSuffix = 'Linux_ARM64';
+      break;
     case 'win32-x64':
       clangdExecutablePath = path.join(build, 'clangd.exe');
       lsSuffix = 'Windows_64bit.zip';


### PR DESCRIPTION
### Motivation
build arduino-ide on arm64 linux, e.g. raspberry pi 4.

### Change description
Needed to download linux arm64 binaries for clangd and arduino-language-server from downloads.arduino.cc

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)