### PR TITLE
Improve condition to recognise read-only sketches

### DIFF
--- a/arduino-ide-extension/src/browser/utils/constants.ts
+++ b/arduino-ide-extension/src/browser/utils/constants.ts
@@ -1,0 +1,2 @@
+export const REMOTE_SKETCHBOOK_FOLDER = 'RemoteSketchbook';
+export const ARDUINO_CLOUD_FOLDER = 'ArduinoCloud';

--- a/arduino-ide-extension/src/common/protocol/sketches-service-client-impl.ts
+++ b/arduino-ide-extension/src/common/protocol/sketches-service-client-impl.ts
@@ -11,12 +11,13 @@ import { FrontendApplicationContribution } from '@theia/core/lib/browser/fronten
 import { Sketch, SketchesService } from '../../common/protocol';
 import { ConfigService } from './config-service';
 import { SketchContainer } from './sketches-service';
+import {
+  ARDUINO_CLOUD_FOLDER,
+  REMOTE_SKETCHBOOK_FOLDER,
+} from '../../browser/utils/constants';
 
-const READ_ONLY_FILES = [
-  'thingProperties.h',
-  'thingsProperties.h',
-  'sketch.json',
-];
+const READ_ONLY_FILES = ['sketch.json'];
+const READ_ONLY_FILES_REMOTE = ['thingProperties.h', 'thingsProperties.h'];
 
 @injectable()
 export class SketchesServiceClientImpl
@@ -178,7 +179,17 @@ export class SketchesServiceClientImpl
     if (toCheck.scheme === 'user-storage') {
       return false;
     }
-    if (READ_ONLY_FILES.includes(toCheck?.path?.base)) {
+
+    const isCloudSketch = toCheck
+      .toString()
+      .includes(`${REMOTE_SKETCHBOOK_FOLDER}/${ARDUINO_CLOUD_FOLDER}`);
+
+    const filesToCheck = [
+      ...READ_ONLY_FILES,
+      ...(isCloudSketch ? READ_ONLY_FILES_REMOTE : []),
+    ];
+
+    if (filesToCheck.includes(toCheck?.path?.base)) {
       return true;
     }
     const readOnly = !this.workspaceService


### PR DESCRIPTION
### Motivation
The condition to check if a sketch must be shown in read-only mode is too mild. For example, a `thingProperties.h` file shouldn't be read-only if it's not inside an IoT sketch

### Change description
Check if it's an IoT sketch.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)