### PR TITLE
Minified browser code in the packaged final app.

### DIFF
--- a/electron/build/template-package.json
+++ b/electron/build/template-package.json
@@ -20,8 +20,7 @@
     "shelljs": "^0.8.3"
   },
   "scripts": {
-    "build": "yarn download:plugins && theia build --mode development && yarn patch",
-    "build:publish": "yarn download:plugins && theia build --mode production && yarn patch",
+    "build": "yarn download:plugins && theia build --mode production && yarn patch",
     "rebuild": "yarn theia rebuild:electron",
     "package": "cross-env DEBUG=* && electron-builder --publish=never",
     "package:publish": "cross-env DEBUG=* && electron-builder --publish=always",

--- a/electron/packager/index.js
+++ b/electron/packager/index.js
@@ -227,8 +227,7 @@ ${fs.readFileSync(path('..', 'build', 'package.json')).toString()}
     'Installing dependencies'
   );
   exec(
-    `yarn --network-timeout 1000000 --cwd ${path('..', 'build')} build${isElectronPublish ? ':publish' : ''
-    }`,
+    `yarn --network-timeout 1000000 --cwd ${path('..', 'build')} build`,
     `Building the ${productName} application`
   );
   exec(
@@ -488,7 +487,6 @@ ${fs.readFileSync(path('..', 'build', 'package.json')).toString()}
         )}.`
       );
       shell.exit(1);
-      process.exit(1);
     }
     if (expectedVersion) {
       if (!versions.has(expectedVersion)) {
@@ -497,7 +495,6 @@ ${fs.readFileSync(path('..', 'build', 'package.json')).toString()}
           }'.`
         );
         shell.exit(1);
-        process.exit(1);
       }
     }
   }


### PR DESCRIPTION
 - Also switched to minified `monaco` code,
 - Removed dead code from the packager.

Signed-off-by: Akos Kitta <kittaakos@gmail.com>

-----

### Motivation
<!-- Why this pull request? -->
To improve the IDE load time using the minified browser code + minified `monaco` code.

### Change description
<!-- What does your code do? -->

 - From now on, the packager does not distinguish between release- and non-release builds; it always minifies the frontend code,
 - Removed dead code from the packager.

### Other information

So this is a tiny improvement for the IDE load time, but I noticed, the bundled electron app does not contain minified code; it should.

Before the change load times:
<img width="730" alt="Screen Shot 2022-03-28 at 14 11 26" src="https://user-images.githubusercontent.com/1405703/160405643-d3b31dc5-60c1-423b-b3ac-e06b3bb3a03e.png">
<img width="727" alt="Screen Shot 2022-03-28 at 14 10 52" src="https://user-images.githubusercontent.com/1405703/160405654-2ea60e4b-d605-4466-ae79-60dfce8f0e54.png">
<img width="729" alt="Screen Shot 2022-03-28 at 14 10 27" src="https://user-images.githubusercontent.com/1405703/160405658-00a8657c-2abc-476d-a3a2-5baff2d1f164.png">


After change load times:
<img width="727" alt="Screen Shot 2022-03-28 at 15 08 37" src="https://user-images.githubusercontent.com/1405703/160405533-d8236251-bf61-4cfe-ac41-5257a737d279.png">
<img width="729" alt="Screen Shot 2022-03-28 at 15 08 20" src="https://user-images.githubusercontent.com/1405703/160405535-946d04b7-9381-4e32-907d-7ad383594da1.png">
<img width="728" alt="Screen Shot 2022-03-28 at 15 08 56" src="https://user-images.githubusercontent.com/1405703/160405526-fd5a0a4e-b8de-463f-98a3-ef0c6baacf43.png">

Although you cannot notice significant app startup improvements 🤦 , the size of the loaded resources shows some improved numbers: it's down from `21.2 MB` to `9.4 MB`.

There are multiple ways to verify it.
 - Open the folder where the frontend lives. (It is `cd /Applications/Arduino\ IDE.app/Contents/Resources/app/lib/` on macOS). Manually investigate the `/vs/editor/editor.main.js` file content. You can see the original `monaco` code in the latest RC build. With the proposed changes, all JS/CSS files are minified.
 - You can open the IDE, open the `DevTools` (with `cmd`+`alt`+`i` on macOS) > switch to the `Network` tab, and reload the window.

### Reviewer checklist

* [x] PR addresses a single concern.
* [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)