### PR TITLE
Allow builds on M1 Macs

### DIFF
--- a/arduino-ide-extension/scripts/download-ls.js
+++ b/arduino-ide-extension/scripts/download-ls.js
@@ -70,6 +70,7 @@
 
   switch (platformArch) {
     case 'darwin-x64':
+    case 'darwin-arm64':
       clangdExecutablePath = path.join(build, 'clangd');
       lsSuffix = 'macOS_64bit.tar.gz';
       clangdSuffix = 'macOS_64bit';


### PR DESCRIPTION
### Motivation
The only thing preventing builds on M1 macs is failure in downloading `arduino-language-server`. While other downloads do not check the arch, it is checked here. Adding case for `darwin-arm64` fixes the issue.

### Change description
Adds case for `darwin-arm64`

### Other information
None

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)