### PR TITLE
Disable widget dragging/splitting

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -39,13 +39,14 @@ import {
 import { MessageService } from '@theia/core/lib/common/message-service';
 import URI from '@theia/core/lib/common/uri';
 import {
+  EditorCommands,
   EditorMainMenu,
   EditorManager,
   EditorOpenerOptions,
 } from '@theia/editor/lib/browser';
 import { ProblemContribution } from '@theia/markers/lib/browser/problem/problem-contribution';
 import { MonacoMenus } from '@theia/monaco/lib/browser/monaco-menu';
-import { FileNavigatorContribution } from '@theia/navigator/lib/browser/navigator-contribution';
+import { FileNavigatorCommands, FileNavigatorContribution } from '@theia/navigator/lib/browser/navigator-contribution';
 import { OutlineViewContribution } from '@theia/outline-view/lib/browser/outline-view-contribution';
 import { OutputContribution } from '@theia/output/lib/browser/output-contribution';
 import { ScmContribution } from '@theia/scm/lib/browser/scm-contribution';
@@ -344,14 +345,14 @@ export class ArduinoFrontendContribution
     app.shell.leftPanelHandler.removeBottomMenu('settings-menu');
 
     this.fileSystemFrontendContribution.onDidChangeEditorFile(e => {
-        if (e.type === FileChangeType.DELETED) {
-            const editorWidget = e.editor;
-            if (SaveableWidget.is(editorWidget)) {
-                editorWidget.closeWithoutSaving();
-            } else {
-                editorWidget.close();
-            }
+      if (e.type === FileChangeType.DELETED) {
+        const editorWidget = e.editor;
+        if (SaveableWidget.is(editorWidget)) {
+          editorWidget.closeWithoutSaving();
+        } else {
+          editorWidget.close();
         }
+      }
     });
   }
 
@@ -485,6 +486,18 @@ export class ArduinoFrontendContribution
         }
       },
     });
+
+    for (const command of [
+      EditorCommands.SPLIT_EDITOR_DOWN,
+      EditorCommands.SPLIT_EDITOR_LEFT,
+      EditorCommands.SPLIT_EDITOR_RIGHT,
+      EditorCommands.SPLIT_EDITOR_UP,
+      EditorCommands.SPLIT_EDITOR_VERTICAL,
+      EditorCommands.SPLIT_EDITOR_HORIZONTAL,
+      FileNavigatorCommands.REVEAL_IN_NAVIGATOR
+    ]) {
+      registry.unregisterCommand(command);
+    }
   }
 
   registerMenus(registry: MenuModelRegistry) {

--- a/arduino-ide-extension/src/browser/theia/core/application-shell.ts
+++ b/arduino-ide-extension/src/browser/theia/core/application-shell.ts
@@ -9,6 +9,7 @@ import {
 } from '@theia/core/lib/browser/connection-status-service';
 import {
   ApplicationShell as TheiaApplicationShell,
+  DockPanel,
   Panel,
   Widget,
 } from '@theia/core/lib/browser';
@@ -74,6 +75,11 @@ export class ApplicationShell extends TheiaApplicationShell {
     return super.addWidget(widget, { ...options, ref });
   }
 
+  handleEvent(): boolean {
+    // NOOP, dragging has been disabled
+    return false
+  }
+
   // Avoid hiding top panel as we use it for arduino toolbar
   protected createTopPanel(): Panel {
     const topPanel = super.createTopPanel();
@@ -101,3 +107,16 @@ export class ApplicationShell extends TheiaApplicationShell {
     );
   }
 }
+
+const originalHandleEvent = DockPanel.prototype.handleEvent;
+
+DockPanel.prototype.handleEvent = function (event) {
+  switch (event.type) {
+      case 'p-dragenter':
+      case 'p-dragleave':
+      case 'p-dragover':
+      case 'p-drop':
+        return;
+  }
+  originalHandleEvent(event);
+};

--- a/arduino-ide-extension/src/browser/theia/core/common-frontend-contribution.ts
+++ b/arduino-ide-extension/src/browser/theia/core/common-frontend-contribution.ts
@@ -11,7 +11,15 @@ export class CommonFrontendContribution extends TheiaCommonFrontendContribution 
   registerCommands(commandRegistry: CommandRegistry): void {
     super.registerCommands(commandRegistry);
 
-    for (const command of [CommonCommands.CONFIGURE_DISPLAY_LANGUAGE]) {
+    for (const command of [
+      CommonCommands.CONFIGURE_DISPLAY_LANGUAGE,
+      CommonCommands.CLOSE_TAB,
+      CommonCommands.CLOSE_SAVED_TABS,
+      CommonCommands.CLOSE_OTHER_TABS,
+      CommonCommands.CLOSE_ALL_TABS,
+      CommonCommands.COLLAPSE_PANEL,
+      CommonCommands.TOGGLE_MAXIMIZED,
+    ]) {
       commandRegistry.unregisterCommand(command);
     }
   }
@@ -32,10 +40,6 @@ export class CommonFrontendContribution extends TheiaCommonFrontendContribution 
       CommonCommands.SELECT_ICON_THEME,
       CommonCommands.SELECT_COLOR_THEME,
       CommonCommands.ABOUT_COMMAND,
-      CommonCommands.CLOSE_TAB,
-      CommonCommands.CLOSE_OTHER_TABS,
-      CommonCommands.CLOSE_ALL_TABS,
-      CommonCommands.COLLAPSE_PANEL,
       CommonCommands.SAVE_WITHOUT_FORMATTING, // Patched for https://github.com/eclipse-theia/theia/pull/8877
     ]) {
       registry.unregisterMenuAction(command);


### PR DESCRIPTION
### Motivation

Closes https://github.com/arduino/arduino-ide/issues/552

### Change description

Removes all contributed commands which programmatically enable users to split editors. Also disables widget dragging so that it's not possible to split editors that way. I believe the dragging functionality hasn't been used anyway?

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)