### PR TITLE
Disable automatic application start after install via Windows Installer

### DIFF
--- a/electron/build/template-package.json
+++ b/electron/build/template-package.json
@@ -106,6 +106,9 @@
       "category": "Development",
       "icon": "resources/icons"
     },
+    "msi": {
+      "runAfterFinish": false
+    },
     "nsis": {
       "oneClick": false,
       "installerHeaderIcon": "resources/icon.ico",


### PR DESCRIPTION
Arduino IDE is packaged for Windows in multiple formats:

- ZIP
- [NSIS](https://en.wikipedia.org/wiki/Nullsoft_Scriptable_Install_System)
- [Windows Installer](https://en.wikipedia.org/wiki/Windows_Installer) (AKA "MSI")

The interactive installer of the NSIS package makes it the best option for installation by users.

The other use case for the installers is deployment by a system administrator. The Windows Installer package was added to offer an additional installer option for this specific use case.

Previously, the Windows Installer package was configured to start the Arduino IDE after completing the installation. That behavior is likely to be problematic for the very use case the Windows Installer package is intended for, where a "silent install" will often be required ([example](https://forum.arduino.cc/t/arduino-ide-2-0-rc-silent-install/960245/16)). That "run after finish" configuration was not intentional, but rather a result of using whatever setting [electron-builder happened to provide as a default](https://github.com/electron-userland/electron-builder/blob/v22.10.5/packages/app-builder-lib/src/targets/MsiTarget.ts#L159).

The configuration of the Windows Installer package is hereby changed to not run after installation by setting the [electron-builder `build.msi.runAfterFinish` configuration key](https://github.com/electron-userland/electron-builder/blob/v22.10.5/packages/app-builder-lib/scheme.json#L3134) to `false`. This also aligns the Windows Installer package with the behavior of [the NSIS package's silent installation (running the installer with the `/S` flag)](https://nsis.sourceforge.io/Docs/Chapter4.html#silent).

The behavior of the NSIS installer is unchanged:

- When in interactive mode: user chooses whether to start Arduino IDE
- When in silent mode: Arduino IDE does not start after installation