### PR TITLE
Correctly print backslash-escaped characters

### DIFF
--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -115,8 +115,10 @@ const _Row = ({
   return (
     (data.lines[index].lineLen && (
       <div style={style}>
-        {timestamp}
-        {data.lines[index].message}
+        <pre>
+          {timestamp}
+          {data.lines[index].message}
+        </pre>
       </div>
     )) ||
     null


### PR DESCRIPTION
### Motivation
When printing output to the serial monitor, some characters are not being rendered as expected. For example, tabs are rendered like normal whitespaces (#675). This is caused by how HTML treats these kinds of characters.

### Change description
Wrap each serial monitor message inside a `<pre>` element.

fixes #675

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)