### PR TITLE
Allow to close files in certain folders

### DIFF
--- a/arduino-ide-extension/src/browser/theia/core/application-shell.ts
+++ b/arduino-ide-extension/src/browser/theia/core/application-shell.ts
@@ -41,6 +41,14 @@ export class ApplicationShell extends TheiaApplicationShell {
       // Make the editor un-closeable asynchronously.
       this.sketchesServiceClient.currentSketch().then((sketch) => {
         if (sketch) {
+          const ignoreFolders = ['.vscode', '.theia', 'src'];
+          let editorPath = widget.editor.uri;
+          while (editorPath.toString().length > sketch.uri.length) {
+            if (ignoreFolders.includes(editorPath.path.base)) {
+              return;
+            }
+            editorPath = editorPath.parent;
+          }
           if (Sketch.isInSketch(widget.editor.uri, sketch)) {
             widget.title.closable = false;
           }

--- a/arduino-ide-extension/src/browser/theia/core/application-shell.ts
+++ b/arduino-ide-extension/src/browser/theia/core/application-shell.ts
@@ -17,6 +17,7 @@ import { Sketch } from '../../../common/protocol';
 import { SaveAsSketch } from '../../contributions/save-as-sketch';
 import { SketchesServiceClientImpl } from '../../../common/protocol/sketches-service-client-impl';
 import { nls } from '@theia/core/lib/common';
+import URI from '@theia/core/lib/common/uri';
 
 @injectable()
 export class ApplicationShell extends TheiaApplicationShell {
@@ -41,13 +42,8 @@ export class ApplicationShell extends TheiaApplicationShell {
       // Make the editor un-closeable asynchronously.
       this.sketchesServiceClient.currentSketch().then((sketch) => {
         if (sketch) {
-          const ignoreFolders = ['.vscode', '.theia', 'src'];
-          let editorPath = widget.editor.uri;
-          while (editorPath.toString().length > sketch.uri.length) {
-            if (ignoreFolders.includes(editorPath.path.base)) {
+          if (!this.isSketchFile(widget.editor.uri, sketch.uri)) {
               return;
-            }
-            editorPath = editorPath.parent;
           }
           if (Sketch.isInSketch(widget.editor.uri, sketch)) {
             widget.title.closable = false;
@@ -55,6 +51,14 @@ export class ApplicationShell extends TheiaApplicationShell {
         }
       });
     }
+  }
+
+  private isSketchFile(uri: URI, sketchUriString: string): boolean {
+      const sketchUri = new URI(sketchUriString);
+      if (uri.parent.isEqual(sketchUri)) {
+          return true;
+      }
+      return false;
   }
 
   async addWidget(


### PR DESCRIPTION
### Motivation

Closes https://github.com/arduino/arduino-ide/issues/866
Closes https://github.com/arduino/arduino-ide/issues/831

### Change description

When adding a widget to the tracker we first try to see whether it is contained in one of our `ignoreFolders` (`.vscode`, `.theia` and `src` so far). If it is, we allow it to stay closable.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)