### PR TITLE
Use electron reload command when changing language

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/settings/settings.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings.tsx
@@ -15,8 +15,9 @@ import {
   FileSystemExt,
   Network,
 } from '../../../common/protocol';
-import { nls } from '@theia/core/lib/common';
+import { CommandService, nls } from '@theia/core/lib/common';
 import { AsyncLocalizationProvider } from '@theia/core/lib/common/i18n/localization';
+import { ElectronCommands } from '@theia/core/lib/electron-browser/menu/electron-menu-contribution';
 
 export const EDITOR_SETTING = 'editor';
 export const FONT_SIZE_SETTING = `${EDITOR_SETTING}.fontSize`;
@@ -81,6 +82,9 @@ export class SettingsService {
 
   @inject(AsyncLocalizationProvider)
   protected readonly localizationProvider: AsyncLocalizationProvider;
+
+  @inject(CommandService)
+  protected commandService: CommandService;
 
   protected readonly onDidChangeEmitter = new Emitter<Readonly<Settings>>();
   readonly onDidChange = this.onDidChangeEmitter.event;
@@ -282,7 +286,7 @@ export class SettingsService {
       } else {
         window.localStorage.setItem(nls.localeId, currentLanguage);
       }
-      window.location.reload();
+      this.commandService.executeCommand(ElectronCommands.RELOAD.id);
     }
 
     return true;


### PR DESCRIPTION
### Motivation
Attempt to solve #948 

fixes #948

### Change description
Execute the command `ElectronCommands.RELOAD` instead of running calling `window.location.reload();`

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)