### PR TITLE
Fix update version script

### DIFF
--- a/scripts/update-version.js
+++ b/scripts/update-version.js
@@ -35,7 +35,7 @@ for (const toUpdate of [
     pkg.version = targetVersion;
     if ('dependencies' in pkg) {
         for (const dep of Object.keys(pkg['dependencies'])) {
-            if (dep.startsWith('arduino-')) {
+            if (dep.startsWith('arduino-ide-')) {
                 pkg['dependencies'][dep] = targetVersion;
             }
         }


### PR DESCRIPTION
### Motivation
The `update-version` script in the package.json is too approximate in determining the dependencies that will be updated.

The condition only checks if a dependency starts with `"arduino-"`, therefore dependencies like `"arduino-serial-plotter"` are affected by this script.

### Change description
Update all the dependencies that start with `"arduino-ide-"` instead of `"arduino-"`.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)