### PR TITLE
Remove useless step in changelog workflow

### DIFF
--- a/.github/workflows/compose-full-changelog.yaml
+++ b/.github/workflows/compose-full-changelog.yaml
@@ -32,7 +32,6 @@ jobs:
       - name: Create full changelog
         id: full-changelog
         run: |
-          yarn add @octokit/rest
           mkdir "${{ github.workspace }}/${{ env.CHANGELOG_ARTIFACTS }}"
 
           # Get the changelog file name to build


### PR DESCRIPTION
### Motivation
This line was making the changelog workflow fail
https://github.com/arduino/arduino-ide/compare/fix-changelog?expand=1#diff-1c6c9545ae4f7be1b70ffe6ab6a047db3a73f2053f914068cb78258a77cae818L35

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)