### PR TITLE
raspberry pi/arm64

### DIFF
--- a/arduino-ide-extension/scripts/download-ls.js
+++ b/arduino-ide-extension/scripts/download-ls.js
@@ -79,6 +79,11 @@
       lsSuffix = 'Linux_64bit.tar.gz';
       clangdSuffix = 'Linux_64bit';
       break;
+    case 'linux-arm64':
+      clangdExecutablePath = path.join(build, 'clangd');
+      lsSuffix = 'Linux_ARM64.tar.gz';
+      clangdSuffix = 'Linux_ARM64';
+      break;
     case 'win32-x64':
       clangdExecutablePath = path.join(build, 'clangd.exe');
       lsSuffix = 'Windows_64bit.zip';


### PR DESCRIPTION
### Motivation
Make build on raspberry pi easier

### Change description
Add arm64 to prebuilt binaries (clangd).

### Other information

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)