### PR TITLE
Allow flexibility in OS type selections in issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -37,11 +37,13 @@ body:
     id: os
     attributes:
       label: Operating system
-      description: Which operating system are you using on your computer?
+      description: Which operating system(s) are you using on your computer?
+      multiple: true
       options:
         - Windows
         - Linux
         - macOS
+        - N/A
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -32,11 +32,13 @@ body:
     id: os
     attributes:
       label: Operating system
-      description: Which operating system are you using on your computer?
+      description: Which operating system(s) are you using on your computer?
+      multiple: true
       options:
         - Windows
         - Linux
         - macOS
+        - N/A
     validations:
       required: true
   - type: input


### PR DESCRIPTION
### Motivation

[GitHub issue forms](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) are used in this repository to facilitate the creation of high quality issues. These provide input fields for each of the distinct classes of information which will be essential for the evaluation of the issues.

One of these fields is for the user's operating system. A dropdown menu is used for the selection of the high level operating system type. Previously this only permitted the selection of a single option. A devoted contributor might have made the effort to determine that the issue applies to multiple operating system types only to be met with the inability to provide this information via the dedicated field.

The field also did not offer an option to indicate that the operating system was irrelevant to the issue (e.g., a subject related to the repository assets).

### Change description

Those issues would be resolved by the following changes:

- Configure the field to allow multiple selections
- Add a "N/A" option to the menu

### Other information

Before:

![image](https://user-images.githubusercontent.com/8572152/166840877-d58327fa-27fd-4d84-a981-35e7f0cdc7c5.png)

After:

![image](https://user-images.githubusercontent.com/8572152/166860112-86fe7684-32fb-4f66-bfe3-aa352d1649dd.png)

### Reviewer checklist

* [x] PR addresses a single concern.
* [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [x] PR title and description are properly filled.
* [N/A] ~~Docs have been added / updated (for bug fixes / features)~~