### PR TITLE
#985: Restored the missing `inject` decorator.

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -157,6 +157,7 @@ export class ArduinoFrontendContribution
   @inject(SketchesServiceClientImpl)
   protected readonly sketchServiceClient: SketchesServiceClientImpl;
 
+  @inject(FrontendApplicationStateService)
   protected readonly appStateService: FrontendApplicationStateService;
 
   @inject(LocalStorageService)


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

This PR restores the missing `inject` decorator to
 - fix the error thrown at startup,
 - fix the editor tab open/close when sketch files are added/deleted outside from the IDE2

### Change description
<!-- What does your code do? -->

Fixes the service injection. The breaking change was [here](https://github.com/arduino/arduino-ide/commit/20f771212910cfdac4f14621b96fda6562c6afa9#diff-abca14a02be77160a86d9f4fb6eca8c18d47312d2d4be37c50de50430bbbcd07L203).

`main` with the bug:
https://user-images.githubusercontent.com/1405703/167870194-184faa67-0c11-406c-9666-3a170c335fc5.mp4

This PR with the fix (also tracks deletion):
https://user-images.githubusercontent.com/1405703/167870155-6266d690-ecca-43c5-a467-93a142e26b69.mp4

### Other information
Closes #985.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)