### PR TITLE
Can build the IDE on macOS 13.2 (Monterey).

### DIFF
--- a/electron/build/template-package.json
+++ b/electron/build/template-package.json
@@ -3,7 +3,7 @@
   "author": "Arduino SA",
   "resolutions": {
     "**/fs-extra": "^4.0.3",
-    "electron-builder": "22.10.5",
+    "electron-builder": "23.0.2",
     "find-git-exec": "0.0.4",
     "dugite-extra": "0.1.15"
   },
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@theia/cli": "1.22.1",
     "cross-env": "^7.0.2",
-    "electron-builder": "22.10.5",
+    "electron-builder": "23.0.2",
     "electron-notarize": "^1.1.1",
     "is-ci": "^2.0.0",
     "ncp": "^2.0.0",


### PR DESCRIPTION

### Motivation
<!-- Why this pull request? -->

Updated `electron-builder` version to build the IDE on macOS 13.2 (Monterey).

`/usr/bin/python` was hard-coded in the builder. `23.0.2` can handle missing `python2` on macOS.

Upstream ref: https://github.com/electron-userland/electron-builder/pull/6789

Before:

```
⏱️  >>> Packaging your Arduino IDE application...
$ cross-env DEBUG=* && electron-builder --publish=never
  • electron-builder  version=22.10.5 os=21.4.0
  • loaded configuration  file=package.json ("build" field)
  • skipped dependencies rebuild  reason=npmRebuild is set to false
  • packaging       platform=darwin arch=x64 electron=15.3.6 appOutDir=dist/mac
  • Unpacking electron zip  zipPath=undefined
  • asar usage is disabled — this is strongly not recommended  solution=enable asar and use asarUnpack to unpack files that must be externally available
  • asar usage is disabled — this is strongly not recommended  solution=enable asar and use asarUnpack to unpack files that must be externally available
  • skipped macOS application code signing  reason=cannot find valid "Developer ID Application" identity or custom non-Apple code signing certificate, see https://electron.build/code-signing allIdentities=
                                                   0 identities found
                                              
                                                Valid identities only
                                                   0 valid identities found
Skipping notarization: not on CI.
  • building        target=macOS zip arch=x64 file=dist/arduino-ide_2.0.0-rc6-snapshot-b407d0a_macOS_64bit.zip
  • building        target=DMG arch=x64 file=dist/arduino-ide_2.0.0-rc6-snapshot-b407d0a_macOS_64bit.dmg
  • building embedded block map  file=dist/arduino-ide_2.0.0-rc6-snapshot-b407d0a_macOS_64bit.zip
  ⨯ Exit code: ENOENT. spawn /usr/bin/python ENOENT  stackTrace=
                                                       Error: Exit code: ENOENT. spawn /usr/bin/python ENOENT
                                                           at /Users/a.kitta/Desktop/arduino-ide/electron/build/node_modules/builder-util/src/util.ts:129:16
                                                           at exithandler (child_process.js:390:5)
                                                           at ChildProcess.errorhandler (child_process.js:402:5)
                                                           at ChildProcess.emit (events.js:400:28)
                                                           at Process.ChildProcess._handle.onexit (internal/child_process.js:280:12)
                                                           at onErrorNT (internal/child_process.js:469:16)
                                                           at processTicksAndRejections (internal/process/task_queues.js:82:21)
```

After:

```
⏱️  >>> Packaging your Arduino IDE application...
$ cross-env DEBUG=* && electron-builder --publish=never
  • electron-builder  version=23.0.2 os=21.4.0
  • loaded configuration  file=package.json ("build" field)
  • skipped dependencies rebuild  reason=npmRebuild is set to false
  • packaging       platform=darwin arch=x64 electron=15.3.6 appOutDir=dist/mac
  • asar usage is disabled — this is strongly not recommended  solution=enable asar and use asarUnpack to unpack files that must be externally available
  • asar usage is disabled — this is strongly not recommended  solution=enable asar and use asarUnpack to unpack files that must be externally available
  • skipped macOS application code signing  reason=cannot find valid "Developer ID Application" identity or custom non-Apple code signing certificate, it could cause some undefined behaviour, e.g. macOS localized description not visible, see https://electron.build/code-signing allIdentities=     0 identities found
                                                Valid identities only
     0 valid identities found
Skipping notarization: not on CI.
  • building        target=macOS zip arch=x64 file=dist/arduino-ide_2.0.0-rc6-snapshot-bbf829b_macOS_64bit.zip
  • building        target=DMG arch=x64 file=dist/arduino-ide_2.0.0-rc6-snapshot-bbf829b_macOS_64bit.dmg
  • building block map  blockMapFile=dist/arduino-ide_2.0.0-rc6-snapshot-bbf829b_macOS_64bit.dmg.blockmap
  • building block map  blockMapFile=dist/arduino-ide_2.0.0-rc6-snapshot-bbf829b_macOS_64bit.zip.blockmap
👌  <<< Packaging your Arduino IDE application.
🎉  Success. Your application is at: /Users/a.kitta/Desktop/arduino-ide/electron/build/dist
✨  Done in 356.61s.
```

### Change description
<!-- What does your code do? -->

Updated the `electron-builder` dependency.

### Other information

The version change was in a "template" `package.json` file. I do not know if snyk.io checks this.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)