### PR TITLE
#944: Fixed auth. sessions not persistent

### DIFF
--- a/arduino-ide-extension/src/browser/auth/authentication-client-service.ts
+++ b/arduino-ide-extension/src/browser/auth/authentication-client-service.ts
@@ -49,7 +49,10 @@ export class AuthenticationClientService
     this.service
       .session()
       .then((session) => this.notifySessionDidChange(session));
+
     this.setOptions();
+    this.service.initAuthSession()
+
     this.arduinoPreferences.onPreferenceChanged((event) => {
       if (event.preferenceName.startsWith('arduino.auth.')) {
         this.setOptions();

--- a/arduino-ide-extension/src/common/protocol/authentication-service.ts
+++ b/arduino-ide-extension/src/common/protocol/authentication-service.ts
@@ -23,6 +23,7 @@ export interface AuthenticationService
   session(): Promise<AuthenticationSession | undefined>;
   disposeClient(client: AuthenticationServiceClient): void;
   setOptions(authOptions: AuthOptions): void;
+  initAuthSession(): Promise<void>;
 }
 
 export interface AuthenticationServiceClient {

--- a/arduino-ide-extension/src/node/auth/authentication-service-impl.ts
+++ b/arduino-ide-extension/src/node/auth/authentication-service-impl.ts
@@ -19,6 +19,8 @@ export class AuthenticationServiceImpl
   protected readonly delegate = new ArduinoAuthenticationProvider();
   protected readonly clients: AuthenticationServiceClient[] = [];
   protected readonly toDispose = new DisposableCollection();
+  
+  private initialized = false; 
 
   async onStart(): Promise<void> {
     this.toDispose.pushAll([
@@ -42,7 +44,13 @@ export class AuthenticationServiceImpl
         this.clients.forEach((client) => this.disposeClient(client))
       ),
     ]);
-    await this.delegate.init();
+  }
+
+  async initAuthSession(): Promise<void> {
+    if (!this.initialized) {
+      await this.delegate.init();
+      this.initialized = true
+    }
   }
 
   setOptions(authOptions: AuthOptions) {


### PR DESCRIPTION
### Motivation
To ensure login sessions to Arduino Cloud are persistent when closing and reopening the application.

### Issue
We were initialising our backend auth service and performing token refreshes without the required "authOptions" properties. These properties are set on the frontend after the backend service is initialised.

### Change description
We now perform the auth service initialisation and token refreshes on the frontend after the required "authOptions" properties are set.

> Removed initialisation from the backend service;
> Created a method on the backend service to initialise the auth service from the frontend (and added the method to the related interface);
> Created an "initialised" variable in the backend auth service to ensure initialisation does not run more than once (incase of multiple frontend instances);
> Invoked initialisation on the frontend service after setting required "authOptions" properties;

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)