### PR TITLE
Follow up 944: authentication sessions are not persistent

### DIFF
--- a/arduino-ide-extension/src/browser/auth/authentication-client-service.ts
+++ b/arduino-ide-extension/src/browser/auth/authentication-client-service.ts
@@ -43,15 +43,15 @@ export class AuthenticationClientService
 
   readonly onSessionDidChange = this.onSessionDidChangeEmitter.event;
 
-  onStart(): void {
+  async onStart(): Promise<void> {
     this.toDispose.push(this.onSessionDidChangeEmitter);
     this.service.setClient(this);
     this.service
       .session()
       .then((session) => this.notifySessionDidChange(session));
 
-    this.setOptions();
-    this.service.initAuthSession()
+    await this.setOptions();
+    this.service.initAuthSession();
 
     this.arduinoPreferences.onPreferenceChanged((event) => {
       if (event.preferenceName.startsWith('arduino.auth.')) {
@@ -60,8 +60,8 @@ export class AuthenticationClientService
     });
   }
 
-  setOptions(): void {
-    this.service.setOptions({
+  setOptions(): Promise<void> {
+    return this.service.setOptions({
       redirectUri: `http://localhost:${serverPort}/callback`,
       responseType: 'code',
       clientID: this.arduinoPreferences['arduino.auth.clientID'],

--- a/arduino-ide-extension/src/browser/auth/authentication-client-service.ts
+++ b/arduino-ide-extension/src/browser/auth/authentication-client-service.ts
@@ -49,7 +49,10 @@ export class AuthenticationClientService
     this.service
       .session()
       .then((session) => this.notifySessionDidChange(session));
+
     this.setOptions();
+    this.service.initAuthSession()
+
     this.arduinoPreferences.onPreferenceChanged((event) => {
       if (event.preferenceName.startsWith('arduino.auth.')) {
         this.setOptions();

--- a/arduino-ide-extension/src/common/protocol/authentication-service.ts
+++ b/arduino-ide-extension/src/common/protocol/authentication-service.ts
@@ -22,7 +22,7 @@ export interface AuthenticationService
   logout(): Promise<void>;
   session(): Promise<AuthenticationSession | undefined>;
   disposeClient(client: AuthenticationServiceClient): void;
-  setOptions(authOptions: AuthOptions): void;
+  setOptions(authOptions: AuthOptions): Promise<void>;
   initAuthSession(): Promise<void>;
 }
 

--- a/arduino-ide-extension/src/common/protocol/authentication-service.ts
+++ b/arduino-ide-extension/src/common/protocol/authentication-service.ts
@@ -23,6 +23,7 @@ export interface AuthenticationService
   session(): Promise<AuthenticationSession | undefined>;
   disposeClient(client: AuthenticationServiceClient): void;
   setOptions(authOptions: AuthOptions): void;
+  initAuthSession(): Promise<void>;
 }
 
 export interface AuthenticationServiceClient {

--- a/arduino-ide-extension/src/node/auth/arduino-auth-provider.ts
+++ b/arduino-ide-extension/src/node/auth/arduino-auth-provider.ts
@@ -89,7 +89,7 @@ export class ArduinoAuthenticationProvider implements AuthenticationProvider {
     setInterval(checkToken, REFRESH_INTERVAL);
   }
 
-  public setOptions(authOptions: AuthOptions) {
+  public async setOptions(authOptions: AuthOptions): Promise<void> {
     this.authOptions = authOptions;
   }
 

--- a/arduino-ide-extension/src/node/auth/authentication-service-impl.ts
+++ b/arduino-ide-extension/src/node/auth/authentication-service-impl.ts
@@ -19,8 +19,8 @@ export class AuthenticationServiceImpl
   protected readonly delegate = new ArduinoAuthenticationProvider();
   protected readonly clients: AuthenticationServiceClient[] = [];
   protected readonly toDispose = new DisposableCollection();
-  
-  private initialized = false; 
+
+  private initialized = false;
 
   async onStart(): Promise<void> {
     this.toDispose.pushAll([
@@ -49,12 +49,12 @@ export class AuthenticationServiceImpl
   async initAuthSession(): Promise<void> {
     if (!this.initialized) {
       await this.delegate.init();
-      this.initialized = true
+      this.initialized = true;
     }
   }
 
-  setOptions(authOptions: AuthOptions) {
-    this.delegate.setOptions(authOptions);
+  setOptions(authOptions: AuthOptions): Promise<void> {
+    return this.delegate.setOptions(authOptions);
   }
 
   async login(): Promise<AuthenticationSession> {

--- a/arduino-ide-extension/src/node/auth/authentication-service-impl.ts
+++ b/arduino-ide-extension/src/node/auth/authentication-service-impl.ts
@@ -19,6 +19,8 @@ export class AuthenticationServiceImpl
   protected readonly delegate = new ArduinoAuthenticationProvider();
   protected readonly clients: AuthenticationServiceClient[] = [];
   protected readonly toDispose = new DisposableCollection();
+  
+  private initialized = false; 
 
   async onStart(): Promise<void> {
     this.toDispose.pushAll([
@@ -42,7 +44,13 @@ export class AuthenticationServiceImpl
         this.clients.forEach((client) => this.disposeClient(client))
       ),
     ]);
-    await this.delegate.init();
+  }
+
+  async initAuthSession(): Promise<void> {
+    if (!this.initialized) {
+      await this.delegate.init();
+      this.initialized = true
+    }
   }
 
   setOptions(authOptions: AuthOptions) {


### PR DESCRIPTION
### Motivation
Follow up on https://github.com/arduino/arduino-ide/pull/992, ensuring we avoid race conditions when setting authOptions prior to initialising our auth service.

### Change description
Add Promise<void> return types where necessary and await setOptions before initialising our auth service.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)