### PR TITLE
Fix duplicated editor tabs

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -575,7 +575,11 @@ export class ArduinoFrontendContribution
       (widget) => widget.editor.uri.toString() === uri
     );
     if (!widget || forceOpen) {
-      return this.editorManager.open(new URI(uri), options);
+      return this.editorManager.open(new URI(uri), options ?? {
+        mode: 'reveal',
+        preview: false,
+        counter: 0
+      });
     }
   }
 

--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -275,6 +275,8 @@ import {
   IDEUpdaterDialogWidget,
 } from './dialogs/ide-updater/ide-updater-dialog';
 import { ElectronIpcConnectionProvider } from '@theia/core/lib/electron-browser/messaging/electron-ipc-connection-provider';
+import { EditorManager as TheiaEditorManager } from '@theia/editor/lib/browser/editor-manager';
+import { EditorManager } from './theia/editor/editor-manager';
 
 const ElementQueries = require('css-element-queries/src/ElementQueries');
 
@@ -507,6 +509,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
   bind(SearchInWorkspaceWidget).toSelf();
   rebind(TheiaSearchInWorkspaceWidget).toService(SearchInWorkspaceWidget);
+  
+  rebind(TheiaEditorManager).to(EditorManager);
 
   // replace search icon
   rebind(TheiaSearchInWorkspaceFactory)

--- a/arduino-ide-extension/src/browser/theia/editor/editor-manager.ts
+++ b/arduino-ide-extension/src/browser/theia/editor/editor-manager.ts
@@ -1,0 +1,9 @@
+import { EditorManager as TheiaEditorManager } from '@theia/editor/lib/browser/editor-manager';
+
+export class EditorManager extends TheiaEditorManager {
+
+  protected getOrCreateCounterForUri(): number {
+    return 0;
+  }
+
+}


### PR DESCRIPTION
### Motivation

Closes https://github.com/arduino/arduino-ide/issues/656
Closes https://github.com/arduino/arduino-ide/issues/793

### Change description

Since editor widget identity is based not only on the `URI`, but also the options, we need to pass the correct options into the `open` call. Doing that prevents Theia from opening multiple tabs of the same editor

### Other information

You might need to run the `View: reset workbench layout` command before testing this, since it modifies some state which is stored (in parts) in the browsers local storage.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)