### PR TITLE
Fixed LS stops working after OS sleep/wakeup cycle

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -277,6 +277,9 @@ import {
 import { ElectronIpcConnectionProvider } from '@theia/core/lib/electron-browser/messaging/electron-ipc-connection-provider';
 import { EditorManager as TheiaEditorManager } from '@theia/editor/lib/browser/editor-manager';
 import { EditorManager } from './theia/editor/editor-manager';
+import { HostedPluginEvents } from './hosted-plugin-events';
+import { HostedPluginSupport } from './theia/plugin-ext/hosted-plugin';
+import { HostedPluginSupport as TheiaHostedPluginSupport } from '@theia/plugin-ext/lib/hosted/browser/hosted-plugin';
 
 const ElementQueries = require('css-element-queries/src/ElementQueries');
 
@@ -805,4 +808,9 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
       );
     })
     .inSingletonScope();
+
+  bind(HostedPluginSupport).toSelf().inSingletonScope();
+  rebind(TheiaHostedPluginSupport).toService(HostedPluginSupport);
+  bind(HostedPluginEvents).toSelf().inSingletonScope();
+  bind(FrontendApplicationContribution).toService(HostedPluginEvents);
 });

--- a/arduino-ide-extension/src/browser/hosted-plugin-events.ts
+++ b/arduino-ide-extension/src/browser/hosted-plugin-events.ts
@@ -1,0 +1,74 @@
+import { DisposableCollection, Emitter, Event } from '@theia/core';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { HostedPluginSupport } from './theia/plugin-ext/hosted-plugin';
+
+/**
+ * Frontend contribution to watch VS Code extension start/stop events from Theia.
+ *
+ * In Theia, there are no events when a VS Code extension is loaded, started, unloaded, and stopped.
+ * Currently, it's possible to `@inject` the `HostedPluginSupport` service from Theia and `await`
+ * for the `didStart` promise to resolve. But if the OS goes to sleep, the VS Code extensions will
+ * be unloaded and loaded and started again when the OS awakes. Theia reloads the VS Code extensions
+ * after the OS awake event, but the `didStart` promise was already resolved, so IDE2 cannot restart the LS.
+ * This service is meant to work around the limitation of Theia and fire an event every time the VS Code extensions
+ * loaded and started.
+ */
+@injectable()
+export class HostedPluginEvents implements FrontendApplicationContribution {
+  @inject(HostedPluginSupport)
+  private readonly hostedPluginSupport: HostedPluginSupport;
+
+  private firstStart = true;
+  private readonly onPluginsDidStartEmitter = new Emitter<void>();
+  private readonly onPluginsWillUnloadEmitter = new Emitter<void>();
+  private readonly toDispose = new DisposableCollection(
+    this.onPluginsDidStartEmitter,
+    this.onPluginsWillUnloadEmitter
+  );
+
+  onStart(): void {
+    this.hostedPluginSupport.onDidLoad(() => {
+      // Fire the first event, when `didStart` resolves.
+      if (!this.firstStart) {
+        console.debug('HostedPluginEvents', "Received 'onDidLoad' event.");
+        this.onPluginsDidStartEmitter.fire();
+      } else {
+        console.debug(
+          'HostedPluginEvents',
+          "Received 'onDidLoad' event before the first start. Skipping."
+        );
+      }
+    });
+    this.hostedPluginSupport.didStart.then(() => {
+      console.debug('HostedPluginEvents', "Hosted plugins 'didStart'.");
+      if (!this.firstStart) {
+        throw new Error(
+          'Unexpectedly received a `didStart` event after the first start.'
+        );
+      }
+      this.firstStart = false;
+      this.onPluginsDidStartEmitter.fire();
+    });
+    this.hostedPluginSupport.onDidCloseConnection(() => {
+      console.debug('HostedPluginEvents', "Received 'onDidCloseConnection'.");
+      this.onPluginsWillUnloadEmitter.fire();
+    });
+  }
+
+  onStop(): void {
+    this.toDispose.dispose();
+  }
+
+  get onPluginsDidStart(): Event<void> {
+    return this.onPluginsDidStartEmitter.event;
+  }
+
+  get onPluginsWillUnload(): Event<void> {
+    return this.onPluginsWillUnloadEmitter.event;
+  }
+
+  get didStart(): Promise<void> {
+    return this.hostedPluginSupport.didStart;
+  }
+}

--- a/arduino-ide-extension/src/browser/theia/plugin-ext/hosted-plugin.ts
+++ b/arduino-ide-extension/src/browser/theia/plugin-ext/hosted-plugin.ts
@@ -1,0 +1,34 @@
+import { Emitter, Event, JsonRpcProxy } from '@theia/core';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
+import { HostedPluginServer } from '@theia/plugin-ext/lib/common/plugin-protocol';
+import { HostedPluginSupport as TheiaHostedPluginSupport } from '@theia/plugin-ext/lib/hosted/browser/hosted-plugin';
+@injectable()
+export class HostedPluginSupport extends TheiaHostedPluginSupport {
+  private readonly onDidLoadEmitter = new Emitter<void>();
+  private readonly onDidCloseConnectionEmitter = new Emitter<void>();
+
+  override onStart(container: interfaces.Container): void {
+    super.onStart(container);
+    this.hostedPluginServer.onDidCloseConnection(() =>
+      this.onDidCloseConnectionEmitter.fire()
+    );
+  }
+
+  protected override async doLoad(): Promise<void> {
+    await super.doLoad();
+    this.onDidLoadEmitter.fire(); // Unlike Theia, IDE2 fires an event after loading the VS Code extensions.
+  }
+
+  get onDidLoad(): Event<void> {
+    return this.onDidLoadEmitter.event;
+  }
+
+  get onDidCloseConnection(): Event<void> {
+    return this.onDidCloseConnectionEmitter.event;
+  }
+
+  private get hostedPluginServer(): JsonRpcProxy<HostedPluginServer> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (this as any).server;
+  }
+}


### PR DESCRIPTION
### Motivation

This PR should fix the unresponsive language feature after waking up the OS from sleep.

### Change description

Theia does not fire an event when the connection to the plugin server proxy closes. Theia also does not fire an event if the hosted plugins have been re-loaded. This PR adds hooks for such events, and wires in the lifecycle of the LS to the new events exposed from the hosted plugins.

### Other information

Steps to verify:
 - Start IDE2,
 - Verify LS is functional,
 - Put the OS into sleep (I do not know if it works on Windows/Linux, but it's reliable on macOS),
 - Wake up the OS,
 - The LS must work (try the content assist)

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)