### PR TITLE
Disabled `MenuItem` `roles` on macOS.

### DIFF
--- a/arduino-ide-extension/src/electron-browser/theia/core/electron-main-menu-factory.ts
+++ b/arduino-ide-extension/src/electron-browser/theia/core/electron-main-menu-factory.ts
@@ -8,6 +8,7 @@ import {
 } from '@theia/core/lib/common/menu';
 import {
   ElectronMainMenuFactory as TheiaElectronMainMenuFactory,
+  ElectronMenuItemRole,
   ElectronMenuOptions,
 } from '@theia/core/lib/electron-browser/menu/electron-main-menu-factory';
 import {
@@ -121,6 +122,15 @@ export class ElectronMainMenuFactory extends TheiaElectronMainMenuFactory {
       };
     }
     return { label, submenu };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected override roleFor(id: string): ElectronMenuItemRole | undefined {
+    // MenuItem `roles` are completely broken on macOS:
+    //  - https://github.com/eclipse-theia/theia/issues/11217,
+    //  - https://github.com/arduino/arduino-ide/issues/969
+    // IDE2 uses commands instead.
+    return undefined;
   }
 
   protected override handleElectronDefault(


### PR DESCRIPTION

### Motivation
<!-- Why this pull request? -->

The [`MenuItem#role`](https://www.electronjs.org/docs/latest/api/menu-item#roles) support is [broken in Theia](https://github.com/eclipse-theia/theia/issues/11217). This PR disables the `role` and falls back to the default, command-based execution on `click`.

### Change description
Disabled the `role` support on macOS.

### Other information
<!-- Any additional information that could help the review process -->

This issue must be macOS-specific and should be verified by a macOS user.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)