### PR TITLE
Fix monitor service id creation

### DIFF
--- a/arduino-ide-extension/src/node/arduino-firmware-uploader-impl.ts
+++ b/arduino-ide-extension/src/node/arduino-firmware-uploader-impl.ts
@@ -76,7 +76,7 @@ export class ArduinoFirmwareUploaderImpl implements ArduinoFirmwareUploader {
       fqbn: firmware.board_fqbn,
     };
     try {
-      this.monitorManager.notifyUploadStarted(board, port);
+      await this.monitorManager.notifyUploadStarted(board, port);
       output = await this.runCommand([
         'firmware',
         'flash',

--- a/arduino-ide-extension/src/node/monitor-manager.ts
+++ b/arduino-ide-extension/src/node/monitor-manager.ts
@@ -215,6 +215,8 @@ export class MonitorManager extends CoreClientAware {
    * @returns a unique monitor ID
    */
   private monitorID(board: Board, port: Port): MonitorID {
-    return `${board.fqbn}-${port.address}-${port.protocol}`;
+    const splitFqbn = board?.fqbn?.split(':') || [];
+    const shortenedFqbn = splitFqbn.slice(0, 3).join(':') || '';
+    return `${shortenedFqbn}-${port.address}-${port.protocol}`;
   }
 }


### PR DESCRIPTION
### Motivation
This PR solves an issue that happens when uploading a sketch to some boards when the serial port is open.

Some boards need configuration parameters to append to the fqbn during the upload:
https://github.com/arduino/arduino-ide/blob/main/arduino-ide-extension/src/browser/contributions/upload-sketch.ts#L216-L219

and this is messing up with the `MonitorManager` because when `notifyUploadStarted()` is called, the monitor ID won't match the `MonitorService` instance that handles the serial connection:
https://github.com/arduino/arduino-ide/blob/main/arduino-ide-extension/src/node/monitor-manager.ts#L114-L119



### Change description
Add some logic to make sure only the first part of an fqbn is relevant when creating a `monitorID`
https://github.com/arduino/arduino-ide/compare/fix-monitor-id?expand=1#diff-cf90510ad3f811b7073a1934f11698463693bf446a2521eb2a55f27a48328427R218-R220

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)