### PR TITLE
#1031 Restored the Settings UI. Deferred model loading.

### DIFF
--- a/arduino-ide-extension/src/browser/theia/preferences/preference-tree-generator.ts
+++ b/arduino-ide-extension/src/browser/theia/preferences/preference-tree-generator.ts
@@ -1,16 +1,43 @@
+import {
+  FrontendApplicationState,
+  FrontendApplicationStateService,
+} from '@theia/core/lib/browser/frontend-application-state';
 import { CompositeTreeNode } from '@theia/core/lib/browser/tree/tree';
-import { injectable } from '@theia/core/shared/inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { PreferenceTreeGenerator as TheiaPreferenceTreeGenerator } from '@theia/preferences/lib/browser/util/preference-tree-generator';
 
 @injectable()
 export class PreferenceTreeGenerator extends TheiaPreferenceTreeGenerator {
+  private shouldHandleChangedSchemaOnReady = false;
+  private state: FrontendApplicationState | undefined;
+
+  @inject(FrontendApplicationStateService)
+  private readonly appStateService: FrontendApplicationStateService;
+
   protected override async init(): Promise<void> {
-    // The IDE2 does not use the default Theia preferences UI.
-    // There is no need to create and keep the the tree model synchronized when there is no UI for it.
+    this.appStateService.onStateChanged((state) => {
+      this.state = state;
+      // manually trigger a model (and UI) refresh if it was requested during the startup phase.
+      if (this.state === 'ready' && this.shouldHandleChangedSchemaOnReady) {
+        this.doHandleChangedSchema();
+      }
+    });
+    return super.init();
   }
 
-  // Just returns with the empty root.
+  override doHandleChangedSchema(): void {
+    if (this.state === 'ready') {
+      super.doHandleChangedSchema();
+    }
+    // don't do anything until the app is `ready`, then invoke `doHandleChangedSchema`.
+    this.shouldHandleChangedSchemaOnReady = true;
+  }
+
   override generateTree(): CompositeTreeNode {
+    if (this.state === 'ready') {
+      return super.generateTree();
+    }
+    // always create an empty root when the app is not ready.
     this._root = this.createRootNode();
     return this._root;
   }


### PR DESCRIPTION

### Motivation
This PR will restore the (advanced) Settings UI in the IDE2. The proposed changes also defer the model (and UI) loading until the IDE2 is ready. Delaying the model load keeps the startup's performance OK and the Settings UI feature in IDE2.

### Change description
<!-- What does your code do? -->

How to verify:
 - Open the IDE2, and open the preferences as described in #1031,
 - Verify that the preferences UI is the same as before `rc7`,
 - Close the IDE2, and reopen it.
 - The widget is open, the content is unavailable, then the UI refreshes. Verify that the Settings UI feature is fully functional.


https://user-images.githubusercontent.com/1405703/173190402-f5c9c518-061a-491a-9c97-8fc2f3d4d11f.mp4




### Other information
<!-- Any additional information that could help the review process -->

Closes #1031

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)