### PR TITLE
Bound the original handler to `this`.

### DIFF
--- a/arduino-ide-extension/src/browser/theia/core/application-shell.ts
+++ b/arduino-ide-extension/src/browser/theia/core/application-shell.ts
@@ -130,5 +130,5 @@ DockPanel.prototype.handleEvent = function (event) {
       case 'p-drop':
         return;
   }
-  originalHandleEvent(event);
+  originalHandleEvent.bind(this)(event);
 };


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
To fix the error that occurred on every click in the IDE2.

### Change description
<!-- What does your code do? -->
`bind` the original function to `this`.

### Other information
<!-- Any additional information that could help the review process -->
It still should not be possible to drag and drop widgets.

How to verify the fix:
 - Start the IDE2,
 - Open dev tools (`Ctrl+Alt+I` on Windows and `Option+Cmd+I` on macOS),
 - Click in the editor, _Output_ view, anywhere. You are expected to not see the `cannot read properties of undefined (reading '_evtMouseDown') error.

Closes #977

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)