### PR TITLE
#608, #229 Reveal the error location after the failed verify

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -298,6 +298,8 @@ import {
 } from '../common/protocol/survey-service';
 import { WindowContribution } from './theia/core/window-contribution';
 import { WindowContribution as TheiaWindowContribution } from '@theia/core/lib/browser/window-contribution';
+import { CoreErrorHandler } from './contributions/core-error-handler';
+import { CompilerErrors } from './contributions/compiler-errors';
 
 MonacoThemingService.register({
   id: 'arduino-theme',
@@ -430,6 +432,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
       )
     )
     .inSingletonScope();
+  bind(CoreErrorHandler).toSelf().inSingletonScope();
 
   // Serial monitor
   bind(MonitorWidget).toSelf();
@@ -694,6 +697,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   Contribution.configure(bind, AddZipLibrary);
   Contribution.configure(bind, PlotterFrontendContribution);
   Contribution.configure(bind, Format);
+  Contribution.configure(bind, CompilerErrors);
 
   // Disabled the quick-pick customization from Theia when multiple formatters are available.
   // Use the default VS Code behavior, and pick the first one. In the IDE2, clang-format has `exclusive` selectors.

--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -13,6 +13,32 @@ export enum UpdateChannel {
   Stable = 'stable',
   Nightly = 'nightly',
 }
+export const ErrorRevealStrategyLiterals = [
+  /**
+   * Scroll vertically as necessary and reveal a line.
+   */
+  'auto',
+  /**
+   * Scroll vertically as necessary and reveal a line centered vertically.
+   */
+  'center',
+  /**
+   * Scroll vertically as necessary and reveal a line close to the top of the viewport, optimized for viewing a code definition.
+   */
+  'top',
+  /**
+   * Scroll vertically as necessary and reveal a line centered vertically only if it lies outside the viewport.
+   */
+  'centerIfOutsideViewport',
+] as const;
+export type ErrorRevealStrategy = typeof ErrorRevealStrategyLiterals[number];
+export namespace ErrorRevealStrategy {
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types, @typescript-eslint/no-explicit-any
+  export function is(arg: any): arg is ErrorRevealStrategy {
+    return !!arg && ErrorRevealStrategyLiterals.includes(arg);
+  }
+  export const Default: ErrorRevealStrategy = 'centerIfOutsideViewport';
+}
 
 export const ArduinoConfigSchema: PreferenceSchema = {
   type: 'object',
@@ -32,6 +58,23 @@ export const ArduinoConfigSchema: PreferenceSchema = {
         'True for verbose compile output. False by default'
       ),
       default: false,
+    },
+    'arduino.compile.experimental': {
+      type: 'boolean',
+      description: nls.localize(
+        'arduino/preferences/compile.experimental',
+        'True if the IDE should handle multiple compiler errors. False by default'
+      ),
+      default: false,
+    },
+    'arduino.compile.revealRange': {
+      enum: [...ErrorRevealStrategyLiterals],
+      description: nls.localize(
+        'arduino/preferences/compile.revealRange',
+        "Adjusts how compiler errors are revealed in the editor after a failed verify/upload. Possible values: 'auto': Scroll vertically as necessary and reveal a line. 'center': Scroll vertically as necessary and reveal a line centered vertically. 'top': Scroll vertically as necessary and reveal a line close to the top of the viewport, optimized for viewing a code definition. 'centerIfOutsideViewport': Scroll vertically as necessary and reveal a line centered vertically only if it lies outside the viewport. The default value is '{0}'.",
+        ErrorRevealStrategy.Default
+      ),
+      default: ErrorRevealStrategy.Default,
     },
     'arduino.compile.warnings': {
       enum: [...CompilerWarningLiterals],
@@ -196,6 +239,8 @@ export const ArduinoConfigSchema: PreferenceSchema = {
 export interface ArduinoConfiguration {
   'arduino.language.log': boolean;
   'arduino.compile.verbose': boolean;
+  'arduino.compile.experimental': boolean;
+  'arduino.compile.revealRange': ErrorRevealStrategy;
   'arduino.compile.warnings': CompilerWarnings;
   'arduino.upload.verbose': boolean;
   'arduino.upload.verify': boolean;

--- a/arduino-ide-extension/src/browser/contributions/burn-bootloader.ts
+++ b/arduino-ide-extension/src/browser/contributions/burn-bootloader.ts
@@ -1,11 +1,9 @@
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { OutputChannelManager } from '@theia/output/lib/browser/output-channel';
-import { CoreService } from '../../common/protocol';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { BoardsDataStore } from '../boards/boards-data-store';
 import { BoardsServiceProvider } from '../boards/boards-service-provider';
 import {
-  SketchContribution,
+  CoreServiceContribution,
   Command,
   CommandRegistry,
   MenuModelRegistry,
@@ -13,19 +11,12 @@ import {
 import { nls } from '@theia/core/lib/common';
 
 @injectable()
-export class BurnBootloader extends SketchContribution {
-  @inject(CoreService)
-  protected readonly coreService: CoreService;
-
-
+export class BurnBootloader extends CoreServiceContribution {
   @inject(BoardsDataStore)
   protected readonly boardsDataStore: BoardsDataStore;
 
   @inject(BoardsServiceProvider)
   protected readonly boardsServiceClientImpl: BoardsServiceProvider;
-
-  @inject(OutputChannelManager)
-  protected override readonly outputChannelManager: OutputChannelManager;
 
   override registerCommands(registry: CommandRegistry): void {
     registry.registerCommand(BurnBootloader.Commands.BURN_BOOTLOADER, {
@@ -62,7 +53,7 @@ export class BurnBootloader extends SketchContribution {
         ...boardsConfig.selectedBoard,
         name: boardsConfig.selectedBoard?.name || '',
         fqbn,
-      }
+      };
       this.outputChannelManager.getChannel('Arduino').clear();
       await this.coreService.burnBootloader({
         board,
@@ -81,13 +72,7 @@ export class BurnBootloader extends SketchContribution {
         }
       );
     } catch (e) {
-      let errorMessage = "";
-      if (typeof e === "string") {
-        errorMessage = e;
-      } else {
-        errorMessage = e.toString();
-      }
-      this.messageService.error(errorMessage);
+      this.handleError(e);
     }
   }
 }

--- a/arduino-ide-extension/src/browser/contributions/compiler-errors.ts
+++ b/arduino-ide-extension/src/browser/contributions/compiler-errors.ts
@@ -1,0 +1,656 @@
+import {
+  Command,
+  CommandRegistry,
+  Disposable,
+  DisposableCollection,
+  Emitter,
+  MaybePromise,
+  nls,
+  notEmpty,
+} from '@theia/core';
+import { ApplicationShell, FrontendApplication } from '@theia/core/lib/browser';
+import URI from '@theia/core/lib/common/uri';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import {
+  Location,
+  Range,
+} from '@theia/core/shared/vscode-languageserver-protocol';
+import {
+  EditorWidget,
+  TextDocumentChangeEvent,
+} from '@theia/editor/lib/browser';
+import {
+  EditorDecoration,
+  TrackedRangeStickiness,
+} from '@theia/editor/lib/browser/decorations/editor-decoration';
+import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
+import * as monaco from '@theia/monaco-editor-core';
+import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
+import { MonacoToProtocolConverter } from '@theia/monaco/lib/browser/monaco-to-protocol-converter';
+import { ProtocolToMonacoConverter } from '@theia/monaco/lib/browser/protocol-to-monaco-converter';
+import { CoreError } from '../../common/protocol/core-service';
+import {
+  ArduinoPreferences,
+  ErrorRevealStrategy,
+} from '../arduino-preferences';
+import { InoSelector } from '../ino-selectors';
+import { fullRange } from '../utils/monaco';
+import { Contribution } from './contribution';
+import { CoreErrorHandler } from './core-error-handler';
+
+interface ErrorDecoration {
+  /**
+   * This is the unique ID of the decoration given by `monaco`.
+   */
+  readonly id: string;
+  /**
+   * The resource this decoration belongs to.
+   */
+  readonly uri: string;
+}
+namespace ErrorDecoration {
+  export function rangeOf(
+    { id, uri }: ErrorDecoration,
+    editorProvider: (uri: string) => Promise<MonacoEditor | undefined>
+  ): Promise<monaco.Range | undefined>;
+  export function rangeOf(
+    { id, uri }: ErrorDecoration,
+    editorProvider: MonacoEditor
+  ): monaco.Range | undefined;
+  export function rangeOf(
+    { id, uri }: ErrorDecoration,
+    editorProvider:
+      | ((uri: string) => Promise<MonacoEditor | undefined>)
+      | MonacoEditor
+  ): MaybePromise<monaco.Range | undefined> {
+    if (editorProvider instanceof MonacoEditor) {
+      const control = editorProvider.getControl();
+      const model = control.getModel();
+      if (model) {
+        return control
+          .getDecorationsInRange(fullRange(model))
+          ?.find(({ id: candidateId }) => id === candidateId)?.range;
+      }
+      return undefined;
+    }
+    return editorProvider(uri).then((editor) => {
+      if (editor) {
+        return rangeOf({ id, uri }, editor);
+      }
+      return undefined;
+    });
+  }
+
+  // export async function rangeOf(
+  //   { id, uri }: ErrorDecoration,
+  //   editorProvider:
+  //     | ((uri: string) => Promise<MonacoEditor | undefined>)
+  //     | MonacoEditor
+  // ): Promise<monaco.Range | undefined> {
+  //   const editor =
+  //     editorProvider instanceof MonacoEditor
+  //       ? editorProvider
+  //       : await editorProvider(uri);
+  //   if (editor) {
+  //     const control = editor.getControl();
+  //     const model = control.getModel();
+  //     if (model) {
+  //       return control
+  //         .getDecorationsInRange(fullRange(model))
+  //         ?.find(({ id: candidateId }) => id === candidateId)?.range;
+  //     }
+  //   }
+  //   return undefined;
+  // }
+  export function sameAs(
+    left: ErrorDecoration,
+    right: ErrorDecoration
+  ): boolean {
+    return left.id === right.id && left.uri === right.uri;
+  }
+}
+
+@injectable()
+export class CompilerErrors
+  extends Contribution
+  implements monaco.languages.CodeLensProvider
+{
+  @inject(EditorManager)
+  private readonly editorManager: EditorManager;
+
+  @inject(ProtocolToMonacoConverter)
+  private readonly p2m: ProtocolToMonacoConverter;
+
+  @inject(MonacoToProtocolConverter)
+  private readonly mp2: MonacoToProtocolConverter;
+
+  @inject(CoreErrorHandler)
+  private readonly coreErrorHandler: CoreErrorHandler;
+
+  @inject(ArduinoPreferences)
+  private readonly preferences: ArduinoPreferences;
+
+  private readonly errors: ErrorDecoration[] = [];
+  private readonly onDidChangeEmitter = new monaco.Emitter<this>();
+  private readonly currentErrorDidChangEmitter = new Emitter<ErrorDecoration>();
+  private readonly onCurrentErrorDidChange =
+    this.currentErrorDidChangEmitter.event;
+  private readonly toDisposeOnCompilerErrorDidChange =
+    new DisposableCollection();
+  private shell: ApplicationShell | undefined;
+  private revealStrategy = ErrorRevealStrategy.Default;
+  private currentError: ErrorDecoration | undefined;
+  private get currentErrorIndex(): number {
+    const current = this.currentError;
+    if (!current) {
+      return -1;
+    }
+    return this.errors.findIndex((error) =>
+      ErrorDecoration.sameAs(error, current)
+    );
+  }
+
+  override onStart(app: FrontendApplication): void {
+    this.shell = app.shell;
+    monaco.languages.registerCodeLensProvider(InoSelector, this);
+    this.coreErrorHandler.onCompilerErrorsDidChange((errors) =>
+      this.filter(errors).then(this.handleCompilerErrorsDidChange.bind(this))
+    );
+    this.onCurrentErrorDidChange(async (error) => {
+      const range = await ErrorDecoration.rangeOf(error, (uri) =>
+        this.monacoEditor(uri)
+      );
+      if (!range) {
+        console.warn(
+          'compiler-errors',
+          `Could not find range of decoration: ${error.id}`
+        );
+        return;
+      }
+      const editor = await this.revealLocationInEditor({
+        uri: error.uri,
+        range: this.mp2.asRange(range),
+      });
+      if (!editor) {
+        console.warn(
+          'compiler-errors',
+          `Failed to mark error ${error.id} as the current one.`
+        );
+      }
+    });
+    this.preferences.ready.then(() => {
+      this.preferences.onPreferenceChanged(({ preferenceName, newValue }) => {
+        if (preferenceName === 'arduino.compile.revealRange') {
+          this.revealStrategy = ErrorRevealStrategy.is(newValue)
+            ? newValue
+            : ErrorRevealStrategy.Default;
+        }
+      });
+    });
+  }
+
+  override registerCommands(registry: CommandRegistry): void {
+    registry.registerCommand(CompilerErrors.Commands.NEXT_ERROR, {
+      execute: () => {
+        const index = this.currentErrorIndex;
+        if (index < 0) {
+          console.warn(
+            'compiler-errors',
+            `Could not advance to next error. Unknown current error.`
+          );
+          return;
+        }
+        const nextError =
+          this.errors[index === this.errors.length - 1 ? 0 : index + 1];
+        this.markAsCurrentError(nextError);
+      },
+      isEnabled: () => !!this.currentError && this.errors.length > 1,
+    });
+    registry.registerCommand(CompilerErrors.Commands.PREVIOUS_ERROR, {
+      execute: () => {
+        const index = this.currentErrorIndex;
+        if (index < 0) {
+          console.warn(
+            'compiler-errors',
+            `Could not advance to previous error. Unknown current error.`
+          );
+          return;
+        }
+        const previousError =
+          this.errors[index === 0 ? this.errors.length - 1 : index - 1];
+        this.markAsCurrentError(previousError);
+      },
+      isEnabled: () => !!this.currentError && this.errors.length > 1,
+    });
+  }
+
+  get onDidChange(): monaco.IEvent<this> {
+    return this.onDidChangeEmitter.event;
+  }
+
+  async provideCodeLenses(
+    model: monaco.editor.ITextModel,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _token: monaco.CancellationToken
+  ): Promise<monaco.languages.CodeLensList> {
+    const lenses: monaco.languages.CodeLens[] = [];
+    if (
+      this.currentError &&
+      this.currentError.uri === model.uri.toString() &&
+      this.errors.length > 1
+    ) {
+      const range = await ErrorDecoration.rangeOf(this.currentError, (uri) =>
+        this.monacoEditor(uri)
+      );
+      if (range) {
+        lenses.push(
+          {
+            range,
+            command: {
+              id: CompilerErrors.Commands.PREVIOUS_ERROR.id,
+              title: nls.localize(
+                'arduino/editor/previousError',
+                'Previous Error'
+              ),
+              arguments: [this.currentError],
+            },
+          },
+          {
+            range,
+            command: {
+              id: CompilerErrors.Commands.NEXT_ERROR.id,
+              title: nls.localize('arduino/editor/nextError', 'Next Error'),
+              arguments: [this.currentError],
+            },
+          }
+        );
+      }
+    }
+    return {
+      lenses,
+      dispose: () => {
+        /* NOOP */
+      },
+    };
+  }
+
+  private async handleCompilerErrorsDidChange(
+    errors: CoreError.Compiler[]
+  ): Promise<void> {
+    this.toDisposeOnCompilerErrorDidChange.dispose();
+    const compilerErrorsPerResource = this.groupByResource(
+      await this.filter(errors)
+    );
+    const decorations = await this.decorateEditors(compilerErrorsPerResource);
+    this.errors.push(...decorations.errors);
+    this.toDisposeOnCompilerErrorDidChange.pushAll([
+      Disposable.create(() => (this.errors.length = 0)),
+      Disposable.create(() => this.onDidChangeEmitter.fire(this)),
+      ...(await Promise.all([
+        decorations.dispose,
+        this.trackEditors(
+          compilerErrorsPerResource,
+          (editor) =>
+            editor.editor.onSelectionChanged((selection) =>
+              this.handleSelectionChange(editor, selection)
+            ),
+          (editor) =>
+            editor.onDidDispose(() =>
+              this.handleEditorDidDispose(editor.editor.uri.toString())
+            ),
+          (editor) =>
+            editor.editor.onDocumentContentChanged((event) =>
+              this.handleDocumentContentChange(editor, event)
+            )
+        ),
+      ])),
+    ]);
+    const currentError = this.errors[0];
+    if (currentError) {
+      await this.markAsCurrentError(currentError);
+    }
+  }
+
+  private async filter(
+    errors: CoreError.Compiler[]
+  ): Promise<CoreError.Compiler[]> {
+    if (!errors.length) {
+      return [];
+    }
+    await this.preferences.ready;
+    if (this.preferences['arduino.compile.experimental']) {
+      return errors;
+    }
+    // Always shows maximum one error; hence the code lens navigation is unavailable.
+    return [errors[0]];
+  }
+
+  private async decorateEditors(
+    errors: Map<string, CoreError.Compiler[]>
+  ): Promise<{ dispose: Disposable; errors: ErrorDecoration[] }> {
+    const composite = await Promise.all(
+      [...errors.entries()].map(([uri, errors]) =>
+        this.decorateEditor(uri, errors)
+      )
+    );
+    return {
+      dispose: new DisposableCollection(
+        ...composite.map(({ dispose }) => dispose)
+      ),
+      errors: composite.reduce(
+        (acc, { errors }) => acc.concat(errors),
+        [] as ErrorDecoration[]
+      ),
+    };
+  }
+
+  private async decorateEditor(
+    uri: string,
+    errors: CoreError.Compiler[]
+  ): Promise<{ dispose: Disposable; errors: ErrorDecoration[] }> {
+    const editor = await this.editorManager.getByUri(new URI(uri));
+    if (!editor) {
+      return { dispose: Disposable.NULL, errors: [] };
+    }
+    const oldDecorations = editor.editor.deltaDecorations({
+      oldDecorations: [],
+      newDecorations: errors.map((error) =>
+        this.compilerErrorDecoration(error.location.range)
+      ),
+    });
+    return {
+      dispose: Disposable.create(() => {
+        if (editor) {
+          editor.editor.deltaDecorations({
+            oldDecorations,
+            newDecorations: [],
+          });
+        }
+      }),
+      errors: oldDecorations.map((id) => ({ id, uri })),
+    };
+  }
+
+  private compilerErrorDecoration(range: Range): EditorDecoration {
+    return {
+      range,
+      options: {
+        isWholeLine: true,
+        className: 'compiler-error',
+        stickiness: TrackedRangeStickiness.AlwaysGrowsWhenTypingAtEdges,
+      },
+    };
+  }
+
+  /**
+   * Tracks the selection in all editors that have an error. If the editor selection overlaps one of the compiler error's range, mark as current error.
+   */
+  private handleSelectionChange(editor: EditorWidget, selection: Range): void {
+    const monacoEditor = this.monacoEditor(editor);
+    if (!monacoEditor) {
+      return;
+    }
+    const uri = monacoEditor.uri.toString();
+    const monacoSelection = this.p2m.asRange(selection);
+    console.log(
+      'compiler-errors',
+      `Handling selection change in editor ${uri}. New (monaco) selection: ${monacoSelection.toJSON()}`
+    );
+    const calculatePriority = (
+      candidateErrorRange: monaco.Range,
+      currentSelection: monaco.Range
+    ) => {
+      console.trace(
+        'compiler-errors',
+        `Candidate error range: ${candidateErrorRange.toJSON()}`
+      );
+      console.trace(
+        'compiler-errors',
+        `Current selection range: ${currentSelection.toJSON()}`
+      );
+      if (candidateErrorRange.intersectRanges(currentSelection)) {
+        console.trace('Intersects.');
+        return { score: 2 };
+      }
+      if (
+        candidateErrorRange.startLineNumber <=
+          currentSelection.startLineNumber &&
+        candidateErrorRange.endLineNumber >= currentSelection.endLineNumber
+      ) {
+        console.trace('Same line.');
+        return { score: 1 };
+      }
+
+      console.trace('No match');
+      return undefined;
+    };
+    const error = this.errors
+      .filter((error) => error.uri === uri)
+      .map((error) => ({
+        error,
+        range: ErrorDecoration.rangeOf(error, monacoEditor),
+      }))
+      .map(({ error, range }) => {
+        if (range) {
+          const priority = calculatePriority(range, monacoSelection);
+          if (priority) {
+            return { ...priority, error };
+          }
+        }
+        return undefined;
+      })
+      .filter(notEmpty)
+      .sort((left, right) => right.score - left.score) // highest first
+      .map(({ error }) => error)
+      .shift();
+    if (error) {
+      this.markAsCurrentError(error);
+    } else {
+      console.info(
+        'compiler-errors',
+        `New (monaco) selection ${monacoSelection.toJSON()} does not intersect any error locations. Skipping.`
+      );
+    }
+  }
+
+  /**
+   * This code does not deal with resource deletion, but tracks editor dispose events. It does not matter what was the cause of the editor disposal.
+   * If editor closes, delete the decorators.
+   */
+  private handleEditorDidDispose(uri: string): void {
+    let i = this.errors.length;
+    // `splice` re-indexes the array. It's better to "iterate and modify" from the last element.
+    while (i--) {
+      const error = this.errors[i];
+      if (error.uri === uri) {
+        this.errors.splice(i, 1);
+      }
+    }
+    this.onDidChangeEmitter.fire(this);
+  }
+
+  /**
+   * If a document change "destroys" the range of the decoration, the decoration must be removed.
+   */
+  private handleDocumentContentChange(
+    editor: EditorWidget,
+    event: TextDocumentChangeEvent
+  ): void {
+    const monacoEditor = this.monacoEditor(editor);
+    if (!monacoEditor) {
+      return;
+    }
+    // A decoration location can be "destroyed", hence should be deleted when:
+    // - deleting range (start != end AND text is empty)
+    // - inserting text into range (start != end AND text is not empty)
+    // Filter unrelated delta changes to spare the CPU.
+    const relevantChanges = event.contentChanges.filter(
+      ({ range: { start, end } }) =>
+        start.line !== end.line || start.character !== end.character
+    );
+    if (!relevantChanges.length) {
+      return;
+    }
+
+    const resolvedMarkers = this.errors
+      .filter((error) => error.uri === event.document.uri)
+      .map((error, index) => {
+        const range = ErrorDecoration.rangeOf(error, monacoEditor);
+        if (range) {
+          return { error, range, index };
+        }
+        return undefined;
+      })
+      .filter(notEmpty);
+
+    const decorationIdsToRemove = relevantChanges
+      .map(({ range }) => this.p2m.asRange(range))
+      .map((changeRange) =>
+        resolvedMarkers.filter(({ range: decorationRange }) =>
+          changeRange.containsRange(decorationRange)
+        )
+      )
+      .reduce((acc, curr) => acc.concat(curr), [])
+      .map(({ error, index }) => {
+        this.errors.splice(index, 1);
+        return error.id;
+      });
+    if (!decorationIdsToRemove.length) {
+      return;
+    }
+    monacoEditor.getControl().deltaDecorations(decorationIdsToRemove, []);
+    this.onDidChangeEmitter.fire(this);
+  }
+
+  private async trackEditors(
+    errors: Map<string, CoreError.Compiler[]>,
+    ...track: ((editor: EditorWidget) => Disposable)[]
+  ): Promise<Disposable> {
+    return new DisposableCollection(
+      ...(await Promise.all(
+        Array.from(errors.keys()).map(async (uri) => {
+          const editor = await this.editorManager.getByUri(new URI(uri));
+          if (!editor) {
+            return Disposable.NULL;
+          }
+          return new DisposableCollection(...track.map((t) => t(editor)));
+        })
+      ))
+    );
+  }
+
+  private async markAsCurrentError(error: ErrorDecoration): Promise<void> {
+    const index = this.errors.findIndex((candidate) =>
+      ErrorDecoration.sameAs(candidate, error)
+    );
+    if (index < 0) {
+      console.warn(
+        'compiler-errors',
+        `Failed to mark error ${
+          error.id
+        } as the current one. Error is unknown. Known errors are: ${this.errors.map(
+          ({ id }) => id
+        )}`
+      );
+      return;
+    }
+    const newError = this.errors[index];
+    if (
+      !this.currentError ||
+      !ErrorDecoration.sameAs(this.currentError, newError)
+    ) {
+      this.currentError = this.errors[index];
+      console.log(
+        'compiler-errors',
+        `Current error changed to ${this.currentError.id}`
+      );
+      this.currentErrorDidChangEmitter.fire(this.currentError);
+      this.onDidChangeEmitter.fire(this);
+    }
+  }
+
+  // The double editor activation logic is required: https://github.com/eclipse-theia/theia/issues/11284
+  private async revealLocationInEditor(
+    location: Location
+  ): Promise<EditorWidget | undefined> {
+    const { uri, range } = location;
+    const editor = await this.editorManager.getByUri(new URI(uri), {
+      mode: 'activate',
+    });
+    if (editor && this.shell) {
+      // to avoid flickering, reveal the range here and not with `getByUri`, because it uses `at: 'center'` for the reveal option.
+      // TODO: check the community reaction whether it is better to set the focus at the error marker. it might cause flickering even if errors are close to each other
+      editor.editor.revealRange(range, { at: this.revealStrategy });
+      const activeWidget = await this.shell.activateWidget(editor.id);
+      if (!activeWidget) {
+        console.warn(
+          'compiler-errors',
+          `editor widget activation has failed. editor widget ${editor.id} expected to be the active one.`
+        );
+        return editor;
+      }
+      if (editor !== activeWidget) {
+        console.warn(
+          'compiler-errors',
+          `active widget was not the same as previously activated editor. editor widget ID ${editor.id}, active widget ID: ${activeWidget.id}`
+        );
+      }
+      return editor;
+    }
+    console.warn(
+      'compiler-errors',
+      `could not found editor widget for URI: ${uri}`
+    );
+    return undefined;
+  }
+
+  private groupByResource(
+    errors: CoreError.Compiler[]
+  ): Map<string, CoreError.Compiler[]> {
+    return errors.reduce((acc, curr) => {
+      const {
+        location: { uri },
+      } = curr;
+      let errors = acc.get(uri);
+      if (!errors) {
+        errors = [];
+        acc.set(uri, errors);
+      }
+      errors.push(curr);
+      return acc;
+    }, new Map<string, CoreError.Compiler[]>());
+  }
+
+  private monacoEditor(widget: EditorWidget): MonacoEditor | undefined;
+  private monacoEditor(uri: string): Promise<MonacoEditor | undefined>;
+  private monacoEditor(
+    uriOrWidget: string | EditorWidget
+  ): MaybePromise<MonacoEditor | undefined> {
+    if (uriOrWidget instanceof EditorWidget) {
+      const editor = uriOrWidget.editor;
+      if (editor instanceof MonacoEditor) {
+        return editor;
+      }
+      return undefined;
+    } else {
+      return this.editorManager
+        .getByUri(new URI(uriOrWidget))
+        .then((editor) => {
+          if (editor) {
+            return this.monacoEditor(editor);
+          }
+          return undefined;
+        });
+    }
+  }
+}
+export namespace CompilerErrors {
+  export namespace Commands {
+    export const NEXT_ERROR: Command = {
+      id: 'arduino-editor-next-error',
+    };
+    export const PREVIOUS_ERROR: Command = {
+      id: 'arduino-editor-previous-error',
+    };
+  }
+}

--- a/arduino-ide-extension/src/browser/contributions/core-error-handler.ts
+++ b/arduino-ide-extension/src/browser/contributions/core-error-handler.ts
@@ -1,0 +1,32 @@
+import { Emitter, Event } from '@theia/core';
+import { injectable } from '@theia/core/shared/inversify';
+import { CoreError } from '../../common/protocol/core-service';
+
+@injectable()
+export class CoreErrorHandler {
+  private readonly compilerErrors: CoreError.Compiler[] = [];
+  private readonly compilerErrorsDidChangeEmitter = new Emitter<
+    CoreError.Compiler[]
+  >();
+
+  tryHandle(error: unknown): void {
+    if (CoreError.is(error)) {
+      this.compilerErrors.length = 0;
+      this.compilerErrors.push(...error.data.filter(CoreError.Compiler.is));
+      this.fireCompilerErrorsDidChange();
+    }
+  }
+
+  reset(): void {
+    this.compilerErrors.length = 0;
+    this.fireCompilerErrorsDidChange();
+  }
+
+  get onCompilerErrorsDidChange(): Event<CoreError.Compiler[]> {
+    return this.compilerErrorsDidChangeEmitter.event;
+  }
+
+  private fireCompilerErrorsDidChange(): void {
+    this.compilerErrorsDidChangeEmitter.fire(this.compilerErrors.slice());
+  }
+}

--- a/arduino-ide-extension/src/browser/contributions/format.ts
+++ b/arduino-ide-extension/src/browser/contributions/format.ts
@@ -2,6 +2,8 @@ import { MaybePromise } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import { Formatter } from '../../common/protocol/formatter';
+import { InoSelector } from '../ino-selectors';
+import { fullRange } from '../utils/monaco';
 import { Contribution, URI } from './contribution';
 
 @injectable()
@@ -15,12 +17,11 @@ export class Format
   private readonly formatter: Formatter;
 
   override onStart(): MaybePromise<void> {
-    const selector = this.selectorOf('ino', 'c', 'cpp', 'h', 'hpp', 'pde');
     monaco.languages.registerDocumentRangeFormattingEditProvider(
-      selector,
+      InoSelector,
       this
     );
-    monaco.languages.registerDocumentFormattingEditProvider(selector, this);
+    monaco.languages.registerDocumentFormattingEditProvider(InoSelector, this);
   }
   async provideDocumentRangeFormattingEdits(
     model: monaco.editor.ITextModel,
@@ -39,16 +40,9 @@ export class Format
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _token: monaco.CancellationToken
   ): Promise<monaco.languages.TextEdit[]> {
-    const range = this.fullRange(model);
+    const range = fullRange(model);
     const text = await this.format(model, range, options);
     return [{ range, text }];
-  }
-
-  private fullRange(model: monaco.editor.ITextModel): monaco.Range {
-    const lastLine = model.getLineCount();
-    const lastLineMaxColumn = model.getLineMaxColumn(lastLine);
-    const end = new monaco.Position(lastLine, lastLineMaxColumn);
-    return monaco.Range.fromPositions(new monaco.Position(1, 1), end);
   }
 
   /**
@@ -81,14 +75,5 @@ export class Format
       formatterConfigFolderUris,
       options,
     });
-  }
-
-  private selectorOf(
-    ...languageId: string[]
-  ): monaco.languages.LanguageSelector {
-    return languageId.map((language) => ({
-      language,
-      exclusive: true, // <-- this should make sure the custom formatter has higher precedence over the LS formatter.
-    }));
   }
 }

--- a/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
@@ -1,12 +1,11 @@
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { Emitter } from '@theia/core/lib/common/event';
-import { CoreService } from '../../common/protocol';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { ArduinoToolbar } from '../toolbar/arduino-toolbar';
 import { BoardsDataStore } from '../boards/boards-data-store';
 import { BoardsServiceProvider } from '../boards/boards-service-provider';
 import {
-  SketchContribution,
+  CoreServiceContribution,
   Command,
   CommandRegistry,
   MenuModelRegistry,
@@ -17,10 +16,7 @@ import { nls } from '@theia/core/lib/common';
 import { CurrentSketch } from '../../common/protocol/sketches-service-client-impl';
 
 @injectable()
-export class VerifySketch extends SketchContribution {
-  @inject(CoreService)
-  protected readonly coreService: CoreService;
-
+export class VerifySketch extends CoreServiceContribution {
   @inject(BoardsDataStore)
   protected readonly boardsDataStore: BoardsDataStore;
 
@@ -96,14 +92,14 @@ export class VerifySketch extends SketchContribution {
 
     // toggle the toolbar button and menu item state.
     // verifyInProgress will be set to false whether the compilation fails or not
-    this.verifyInProgress = true;
-    this.onDidChangeEmitter.fire();
     const sketch = await this.sketchServiceClient.currentSketch();
-
     if (!CurrentSketch.isValid(sketch)) {
       return;
     }
     try {
+      this.verifyInProgress = true;
+      this.coreErrorHandler.reset();
+      this.onDidChangeEmitter.fire();
       const { boardsConfig } = this.boardsServiceClientImpl;
       const [fqbn, sourceOverride] = await Promise.all([
         this.boardsDataStore.appendConfigToFqbn(
@@ -115,12 +111,12 @@ export class VerifySketch extends SketchContribution {
         ...boardsConfig.selectedBoard,
         name: boardsConfig.selectedBoard?.name || '',
         fqbn,
-      }
+      };
       const verbose = this.preferences.get('arduino.compile.verbose');
       const compilerWarnings = this.preferences.get('arduino.compile.warnings');
       this.outputChannelManager.getChannel('Arduino').clear();
       await this.coreService.compile({
-        sketchUri: sketch.uri,
+        sketch,
         board,
         optimizeForDebug: this.editorMode.compileForDebug,
         verbose,
@@ -133,13 +129,7 @@ export class VerifySketch extends SketchContribution {
         { timeout: 3000 }
       );
     } catch (e) {
-      let errorMessage = "";
-      if (typeof e === "string") {
-        errorMessage = e;
-      } else {
-        errorMessage = e.toString();
-      }
-      this.messageService.error(errorMessage);
+      this.handleError(e);
     } finally {
       this.verifyInProgress = false;
       this.onDidChangeEmitter.fire();

--- a/arduino-ide-extension/src/browser/ino-selectors.ts
+++ b/arduino-ide-extension/src/browser/ino-selectors.ts
@@ -1,0 +1,13 @@
+import * as monaco from '@theia/monaco-editor-core';
+/**
+ * Exclusive "ino" document selector for monaco.
+ */
+export const InoSelector = selectorOf('ino', 'c', 'cpp', 'h', 'hpp', 'pde');
+function selectorOf(
+  ...languageId: string[]
+): monaco.languages.LanguageSelector {
+  return languageId.map((language) => ({
+    language,
+    exclusive: true, // <-- this should make sure the custom formatter has higher precedence over the LS formatter.
+  }));
+}

--- a/arduino-ide-extension/src/browser/style/editor.css
+++ b/arduino-ide-extension/src/browser/style/editor.css
@@ -8,3 +8,8 @@
 .monaco-list-row.show-file-icons.focused {
     background-color: #d6ebff;
 }
+
+.monaco-editor .view-overlays .compiler-error {
+    background-color: var(--theia-inputValidation-errorBackground);
+    opacity: 0.4 !important;
+}

--- a/arduino-ide-extension/src/browser/theia/output/output-channel.ts
+++ b/arduino-ide-extension/src/browser/theia/output/output-channel.ts
@@ -40,6 +40,14 @@ export class OutputChannelManager extends TheiaOutputChannelManager {
     }
     return channel;
   }
+
+  async contentOfChannel(name: string): Promise<string | undefined> {
+    const resource = this.resources.get(name);
+    if (resource) {
+      return resource.readContents();
+    }
+    return undefined;
+  }
 }
 
 export class OutputChannel extends TheiaOutputChannel {

--- a/arduino-ide-extension/src/browser/utils/monaco.ts
+++ b/arduino-ide-extension/src/browser/utils/monaco.ts
@@ -1,0 +1,8 @@
+import * as monaco from '@theia/monaco-editor-core';
+
+export function fullRange(model: monaco.editor.ITextModel): monaco.Range {
+  const lastLine = model.getLineCount();
+  const lastLineMaxColumn = model.getLineMaxColumn(lastLine);
+  const end = new monaco.Position(lastLine, lastLineMaxColumn);
+  return monaco.Range.fromPositions(new monaco.Position(1, 1), end);
+}

--- a/arduino-ide-extension/src/common/protocol/response-service.ts
+++ b/arduino-ide-extension/src/common/protocol/response-service.ts
@@ -2,7 +2,14 @@ import { Event } from '@theia/core/lib/common/event';
 
 export interface OutputMessage {
   readonly chunk: string;
-  readonly severity?: 'error' | 'warning' | 'info'; // Currently not used!
+  readonly severity?: OutputMessage.Severity;
+}
+export namespace OutputMessage {
+  export enum Severity {
+    Error,
+    Warning,
+    Info,
+  }
 }
 
 export interface ProgressMessage {

--- a/arduino-ide-extension/src/common/protocol/sketches-service.ts
+++ b/arduino-ide-extension/src/common/protocol/sketches-service.ts
@@ -127,11 +127,8 @@ export namespace Sketch {
     export const ALL = Array.from(new Set([...MAIN, ...SOURCE, ...ADDITIONAL]));
   }
   export function isInSketch(uri: string | URI, sketch: Sketch): boolean {
-    const { mainFileUri, otherSketchFileUris, additionalFileUris } = sketch;
-    return (
-      [mainFileUri, ...otherSketchFileUris, ...additionalFileUris].indexOf(
-        uri.toString()
-      ) !== -1
+    return uris(sketch).includes(
+      typeof uri === 'string' ? uri : uri.toString()
     );
   }
   export function isSketchFile(arg: string | URI): boolean {
@@ -139,6 +136,10 @@ export namespace Sketch {
       return isSketchFile(arg.toString());
     }
     return Extensions.MAIN.some((ext) => arg.endsWith(ext));
+  }
+  export function uris(sketch: Sketch): string[] {
+    const { mainFileUri, otherSketchFileUris, additionalFileUris } = sketch;
+    return [mainFileUri, ...otherSketchFileUris, ...additionalFileUris];
   }
 }
 

--- a/arduino-ide-extension/src/node/cli-error-parser.ts
+++ b/arduino-ide-extension/src/node/cli-error-parser.ts
@@ -1,0 +1,234 @@
+import { notEmpty } from '@theia/core';
+import { nls } from '@theia/core/lib/common/nls';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import {
+  Location,
+  Range,
+  Position,
+} from '@theia/core/shared/vscode-languageserver-protocol';
+import { Sketch } from '../common/protocol';
+
+export interface ErrorInfo {
+  readonly message?: string;
+  readonly location?: Location;
+  readonly details?: string;
+}
+export interface ErrorSource {
+  readonly content: string | ReadonlyArray<Uint8Array>;
+  readonly sketch?: Sketch;
+}
+
+export function tryParseError(source: ErrorSource): ErrorInfo[] {
+  const { content, sketch } = source;
+  const err =
+    typeof content === 'string'
+      ? content
+      : Buffer.concat(content).toString('utf8');
+  if (sketch) {
+    return tryParse(err)
+      .map(remapErrorMessages)
+      .filter(isLocationInSketch(sketch))
+      .map(errorInfo());
+  }
+  return [];
+}
+
+interface ParseResult {
+  readonly path: string;
+  readonly line: number;
+  readonly column?: number;
+  readonly errorPrefix: string;
+  readonly error: string;
+  readonly message?: string;
+}
+namespace ParseResult {
+  export function keyOf(result: ParseResult): string {
+    /**
+     * The CLI compiler might return with the same error multiple times. This is the key function for the distinct set calculation.
+     */
+    return JSON.stringify(result);
+  }
+}
+
+function isLocationInSketch(
+  sketch: Sketch
+): (value: ParseResult, index: number, array: ParseResult[]) => unknown {
+  return (result) => {
+    const uri = FileUri.create(result.path).toString();
+    if (!Sketch.isInSketch(uri, sketch)) {
+      console.warn(
+        `URI <${uri}> is not contained in sketch: <${JSON.stringify(sketch)}>`
+      );
+      return false;
+    }
+    return true;
+  };
+}
+
+function errorInfo(): (value: ParseResult) => ErrorInfo {
+  return ({ error, message, path, line, column }) => ({
+    message: error,
+    details: message,
+    location: {
+      uri: FileUri.create(path).toString(),
+      range: range(line, column),
+    },
+  });
+}
+
+function range(line: number, column?: number): Range {
+  const start = Position.create(
+    line - 1,
+    typeof column === 'number' ? column - 1 : 0
+  );
+  return {
+    start,
+    end: start,
+  };
+}
+
+export function tryParse(raw: string): ParseResult[] {
+  // Shamelessly stolen from the Java IDE: https://github.com/arduino/Arduino/blob/43b0818f7fa8073301db1b80ac832b7b7596b828/arduino-core/src/cc/arduino/Compiler.java#L137
+  const re = new RegExp(
+    '(.+\\.\\w+):(\\d+)(:\\d+)*:\\s*((fatal)?\\s*error:\\s*)(.*)\\s*',
+    'gm'
+  );
+  return [
+    ...new Map(
+      Array.from(raw.matchAll(re) ?? [])
+        .map((match) => {
+          const [, path, rawLine, rawColumn, errorPrefix, , error] = match.map(
+            (match) => (match ? match.trim() : match)
+          );
+          const line = Number.parseInt(rawLine, 10);
+          if (!Number.isInteger(line)) {
+            console.warn(
+              `Could not parse line number. Raw input: <${rawLine}>, parsed integer: <${line}>.`
+            );
+            return undefined;
+          }
+          let column: number | undefined = undefined;
+          if (rawColumn) {
+            const normalizedRawColumn = rawColumn.slice(-1); // trims the leading colon => `:3` will be `3`
+            column = Number.parseInt(normalizedRawColumn, 10);
+            if (!Number.isInteger(column)) {
+              console.warn(
+                `Could not parse column number. Raw input: <${normalizedRawColumn}>, parsed integer: <${column}>.`
+              );
+            }
+          }
+          return {
+            path,
+            line,
+            column,
+            errorPrefix,
+            error,
+          };
+        })
+        .filter(notEmpty)
+        .map((result) => [ParseResult.keyOf(result), result])
+    ).values(),
+  ];
+}
+
+/**
+ * Converts cryptic and legacy error messages to nice ones. Taken from the Java IDE.
+ */
+function remapErrorMessages(result: ParseResult): ParseResult {
+  const knownError = KnownErrors[result.error];
+  if (!knownError) {
+    return result;
+  }
+  const { message, error } = knownError;
+  return {
+    ...result,
+    ...(message && { message }),
+    ...(error && { error }),
+  };
+}
+
+// Based on the Java IDE: https://github.com/arduino/Arduino/blob/43b0818f7fa8073301db1b80ac832b7b7596b828/arduino-core/src/cc/arduino/Compiler.java#L528-L578
+const KnownErrors: Record<string, { error: string; message?: string }> = {
+  'SPI.h: No such file or directory': {
+    error: nls.localize(
+      'arduino/cli-error-parser/spiError',
+      'Please import the SPI library from the Sketch > Import Library menu.'
+    ),
+    message: nls.localize(
+      'arduino/cli-error-parser/spiMessage',
+      'As of Arduino 0019, the Ethernet library depends on the SPI library.\nYou appear to be using it or another library that depends on the SPI library.'
+    ),
+  },
+  "'BYTE' was not declared in this scope": {
+    error: nls.localize(
+      'arduino/cli-error-parser/byteError',
+      "The 'BYTE' keyword is no longer supported."
+    ),
+    message: nls.localize(
+      'arduino/cli-error-parser/byteMessage',
+      "As of Arduino 1.0, the 'BYTE' keyword is no longer supported.\nPlease use Serial.write() instead."
+    ),
+  },
+  "no matching function for call to 'Server::Server(int)'": {
+    error: nls.localize(
+      'arduino/cli-error-parser/serverError',
+      'The Server class has been renamed EthernetServer.'
+    ),
+    message: nls.localize(
+      'arduino/cli-error-parser/serverMessage',
+      'As of Arduino 1.0, the Server class in the Ethernet library has been renamed to EthernetServer.'
+    ),
+  },
+  "no matching function for call to 'Client::Client(byte [4], int)'": {
+    error: nls.localize(
+      'arduino/cli-error-parser/clientError',
+      'The Client class has been renamed EthernetClient.'
+    ),
+    message: nls.localize(
+      'arduino/cli-error-parser/clientMessage',
+      'As of Arduino 1.0, the Client class in the Ethernet library has been renamed to EthernetClient.'
+    ),
+  },
+  "'Udp' was not declared in this scope": {
+    error: nls.localize(
+      'arduino/cli-error-parser/udpError',
+      'The Udp class has been renamed EthernetUdp.'
+    ),
+    message: nls.localize(
+      'arduino/cli-error-parser/udpMessage',
+      'As of Arduino 1.0, the Udp class in the Ethernet library has been renamed to EthernetUdp.'
+    ),
+  },
+  "'class TwoWire' has no member named 'send'": {
+    error: nls.localize(
+      'arduino/cli-error-parser/sendError',
+      'Wire.send() has been renamed Wire.write().'
+    ),
+    message: nls.localize(
+      'arduino/cli-error-parser/sendMessage',
+      'As of Arduino 1.0, the Wire.send() function was renamed to Wire.write() for consistency with other libraries.'
+    ),
+  },
+  "'class TwoWire' has no member named 'receive'": {
+    error: nls.localize(
+      'arduino/cli-error-parser/receiveError',
+      'Wire.receive() has been renamed Wire.read().'
+    ),
+    message: nls.localize(
+      'arduino/cli-error-parser/receiveMessage',
+      'As of Arduino 1.0, the Wire.receive() function was renamed to Wire.read() for consistency with other libraries.'
+    ),
+  },
+  "'Mouse' was not declared in this scope": {
+    error: nls.localize(
+      'arduino/cli-error-parser/mouseError',
+      "'Mouse' not found. Does your sketch include the line '#include <Mouse.h>'?"
+    ),
+  },
+  "'Keyboard' was not declared in this scope": {
+    error: nls.localize(
+      'arduino/cli-error-parser/keyboardError',
+      "'Keyboard' not found. Does your sketch include the line '#include <Keyboard.h>'?"
+    ),
+  },
+};

--- a/arduino-ide-extension/src/node/core-service-impl.ts
+++ b/arduino-ide-extension/src/node/core-service-impl.ts
@@ -4,7 +4,11 @@ import { relative } from 'path';
 import * as jspb from 'google-protobuf';
 import { BoolValue } from 'google-protobuf/google/protobuf/wrappers_pb';
 import { ClientReadableStream } from '@grpc/grpc-js';
-import { CompilerWarnings, CoreService } from '../common/protocol/core-service';
+import {
+  CompilerWarnings,
+  CoreService,
+  CoreError,
+} from '../common/protocol/core-service';
 import {
   CompileRequest,
   CompileResponse,
@@ -19,27 +23,24 @@ import {
   UploadUsingProgrammerResponse,
 } from './cli-protocol/cc/arduino/cli/commands/v1/upload_pb';
 import { ResponseService } from '../common/protocol/response-service';
-import { NotificationServiceServer } from '../common/protocol';
+import { Board, OutputMessage, Port, Status } from '../common/protocol';
 import { ArduinoCoreServiceClient } from './cli-protocol/cc/arduino/cli/commands/v1/commands_grpc_pb';
-import { firstToUpperCase, firstToLowerCase } from '../common/utils';
-import { Port } from './cli-protocol/cc/arduino/cli/commands/v1/port_pb';
-import { nls } from '@theia/core';
+import { Port as GrpcPort } from './cli-protocol/cc/arduino/cli/commands/v1/port_pb';
+import { ApplicationError, Disposable, nls } from '@theia/core';
 import { MonitorManager } from './monitor-manager';
 import { SimpleBuffer } from './utils/simple-buffer';
+import { tryParseError } from './cli-error-parser';
+import { Instance } from './cli-protocol/cc/arduino/cli/commands/v1/common_pb';
+import { firstToUpperCase, notEmpty } from '../common/utils';
+import { ServiceError } from './service-error';
 
-const FLUSH_OUTPUT_MESSAGES_TIMEOUT_MS = 32;
 @injectable()
 export class CoreServiceImpl extends CoreClientAware implements CoreService {
   @inject(ResponseService)
-  protected readonly responseService: ResponseService;
-
-  @inject(NotificationServiceServer)
-  protected readonly notificationService: NotificationServiceServer;
+  private readonly responseService: ResponseService;
 
   @inject(MonitorManager)
-  protected readonly monitorManager: MonitorManager;
-
-  protected uploading = false;
+  private readonly monitorManager: MonitorManager;
 
   async compile(
     options: CoreService.Compile.Options & {
@@ -47,254 +48,298 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
       compilerWarnings?: CompilerWarnings;
     }
   ): Promise<void> {
-    const { sketchUri, board, compilerWarnings } = options;
-    const sketchPath = FileUri.fsPath(sketchUri);
-
-    await this.coreClientProvider.initialized;
     const coreClient = await this.coreClient();
     const { client, instance } = coreClient;
+    const handler = this.createOnDataHandler();
+    const request = this.compileRequest(options, instance);
+    return new Promise<void>((resolve, reject) => {
+      client
+        .compile(request)
+        .on('data', handler.onData)
+        .on('error', (error) => {
+          if (!ServiceError.is(error)) {
+            console.error(
+              'Unexpected error occurred while compiling the sketch.',
+              error
+            );
+            reject(error);
+          } else {
+            const compilerErrors = tryParseError({
+              content: handler.stderr,
+              sketch: options.sketch,
+            });
+            const message = nls.localize(
+              'arduino/compile/error',
+              'Compilation error: {0}',
+              compilerErrors
+                .map(({ message }) => message)
+                .filter(notEmpty)
+                .shift() ?? error.details
+            );
+            this.sendResponse(
+              error.details + '\n\n' + message,
+              OutputMessage.Severity.Error
+            );
+            reject(CoreError.VerifyFailed(message, compilerErrors));
+          }
+        })
+        .on('end', resolve);
+    }).finally(() => handler.dispose());
+  }
 
-    const compileReq = new CompileRequest();
-    compileReq.setInstance(instance);
-    compileReq.setSketchPath(sketchPath);
+  private compileRequest(
+    options: CoreService.Compile.Options & {
+      exportBinaries?: boolean;
+      compilerWarnings?: CompilerWarnings;
+    },
+    instance: Instance
+  ): CompileRequest {
+    const { sketch, board, compilerWarnings } = options;
+    const sketchUri = sketch.uri;
+    const sketchPath = FileUri.fsPath(sketchUri);
+    const request = new CompileRequest();
+    request.setInstance(instance);
+    request.setSketchPath(sketchPath);
     if (board?.fqbn) {
-      compileReq.setFqbn(board.fqbn);
+      request.setFqbn(board.fqbn);
     }
     if (compilerWarnings) {
-      compileReq.setWarnings(compilerWarnings.toLowerCase());
+      request.setWarnings(compilerWarnings.toLowerCase());
     }
-    compileReq.setOptimizeForDebug(options.optimizeForDebug);
-    compileReq.setPreprocess(false);
-    compileReq.setVerbose(options.verbose);
-    compileReq.setQuiet(false);
+    request.setOptimizeForDebug(options.optimizeForDebug);
+    request.setPreprocess(false);
+    request.setVerbose(options.verbose);
+    request.setQuiet(false);
     if (typeof options.exportBinaries === 'boolean') {
       const exportBinaries = new BoolValue();
       exportBinaries.setValue(options.exportBinaries);
-      compileReq.setExportBinaries(exportBinaries);
+      request.setExportBinaries(exportBinaries);
     }
-    this.mergeSourceOverrides(compileReq, options);
-
-    const result = client.compile(compileReq);
-
-    const compileBuffer = new SimpleBuffer(
-      this.flushOutputPanelMessages.bind(this),
-      FLUSH_OUTPUT_MESSAGES_TIMEOUT_MS
-    );
-    try {
-      await new Promise<void>((resolve, reject) => {
-        result.on('data', (cr: CompileResponse) => {
-          compileBuffer.addChunk(cr.getOutStream_asU8());
-          compileBuffer.addChunk(cr.getErrStream_asU8());
-        });
-        result.on('error', (error) => {
-          compileBuffer.clearFlushInterval();
-          reject(error);
-        });
-        result.on('end', () => {
-          compileBuffer.clearFlushInterval();
-          resolve();
-        });
-      });
-      this.responseService.appendToOutput({
-        chunk: '\n--------------------------\nCompilation complete.\n',
-      });
-    } catch (e) {
-      const errorMessage = nls.localize(
-        'arduino/compile/error',
-        'Compilation error: {0}',
-        e.details
-      );
-      this.responseService.appendToOutput({
-        chunk: `${errorMessage}\n`,
-        severity: 'error',
-      });
-      throw new Error(errorMessage);
-    }
+    this.mergeSourceOverrides(request, options);
+    return request;
   }
 
   async upload(options: CoreService.Upload.Options): Promise<void> {
-    await this.doUpload(
+    return this.doUpload(
       options,
       () => new UploadRequest(),
-      (client, req) => client.upload(req)
+      (client, req) => client.upload(req),
+      (message: string, info: CoreError.ErrorInfo[]) =>
+        CoreError.UploadFailed(message, info),
+      'upload'
     );
   }
 
   async uploadUsingProgrammer(
     options: CoreService.Upload.Options
   ): Promise<void> {
-    await this.doUpload(
+    return this.doUpload(
       options,
       () => new UploadUsingProgrammerRequest(),
       (client, req) => client.uploadUsingProgrammer(req),
+      (message: string, info: CoreError.ErrorInfo[]) =>
+        CoreError.UploadUsingProgrammerFailed(message, info),
       'upload using programmer'
     );
   }
 
-  isUploading(): Promise<boolean> {
-    return Promise.resolve(this.uploading);
-  }
-
   protected async doUpload(
     options: CoreService.Upload.Options,
-    requestProvider: () => UploadRequest | UploadUsingProgrammerRequest,
-    // tslint:disable-next-line:max-line-length
+    requestFactory: () => UploadRequest | UploadUsingProgrammerRequest,
     responseHandler: (
       client: ArduinoCoreServiceClient,
-      req: UploadRequest | UploadUsingProgrammerRequest
+      request: UploadRequest | UploadUsingProgrammerRequest
     ) => ClientReadableStream<UploadResponse | UploadUsingProgrammerResponse>,
-    task = 'upload'
+    errorHandler: (
+      message: string,
+      info: CoreError.ErrorInfo[]
+    ) => ApplicationError<number, CoreError.ErrorInfo[]>,
+    task: string
   ): Promise<void> {
     await this.compile(Object.assign(options, { exportBinaries: false }));
 
-    this.uploading = true;
-    const { sketchUri, board, port, programmer } = options;
-    await this.monitorManager.notifyUploadStarted(board, port);
-
-    const sketchPath = FileUri.fsPath(sketchUri);
-
-    await this.coreClientProvider.initialized;
     const coreClient = await this.coreClient();
     const { client, instance } = coreClient;
+    const request = this.uploadOrUploadUsingProgrammerRequest(
+      options,
+      instance,
+      requestFactory
+    );
+    const handler = this.createOnDataHandler();
+    return this.notifyUploadWillStart(options).then(() =>
+      new Promise<void>((resolve, reject) => {
+        responseHandler(client, request)
+          .on('data', handler.onData)
+          .on('error', (error) => {
+            if (!ServiceError.is(error)) {
+              console.error(`Unexpected error occurred while ${task}.`, error);
+              reject(error);
+            } else {
+              const message = nls.localize(
+                'arduino/upload/error',
+                '{0} error: {1}',
+                firstToUpperCase(task),
+                error.details
+              );
+              this.sendResponse(error.details, OutputMessage.Severity.Error);
+              reject(
+                errorHandler(
+                  message,
+                  tryParseError({
+                    content: handler.stderr,
+                    sketch: options.sketch,
+                  })
+                )
+              );
+            }
+          })
+          .on('end', resolve);
+      }).finally(async () => {
+        handler.dispose();
+        await this.notifyUploadDidFinish(options);
+      })
+    );
+  }
 
-    const req = requestProvider();
-    req.setInstance(instance);
-    req.setSketchPath(sketchPath);
+  private uploadOrUploadUsingProgrammerRequest(
+    options: CoreService.Upload.Options,
+    instance: Instance,
+    requestFactory: () => UploadRequest | UploadUsingProgrammerRequest
+  ): UploadRequest | UploadUsingProgrammerRequest {
+    const { sketch, board, port, programmer } = options;
+    const sketchPath = FileUri.fsPath(sketch.uri);
+    const request = requestFactory();
+    request.setInstance(instance);
+    request.setSketchPath(sketchPath);
     if (board?.fqbn) {
-      req.setFqbn(board.fqbn);
+      request.setFqbn(board.fqbn);
     }
-    const p = new Port();
-    if (port) {
-      p.setAddress(port.address);
-      p.setLabel(port.addressLabel);
-      p.setProtocol(port.protocol);
-      p.setProtocolLabel(port.protocolLabel);
-    }
-    req.setPort(p);
+    request.setPort(this.createPort(port));
     if (programmer) {
-      req.setProgrammer(programmer.id);
+      request.setProgrammer(programmer.id);
     }
-    req.setVerbose(options.verbose);
-    req.setVerify(options.verify);
+    request.setVerbose(options.verbose);
+    request.setVerify(options.verify);
 
     options.userFields.forEach((e) => {
-      req.getUserFieldsMap().set(e.name, e.value);
+      request.getUserFieldsMap().set(e.name, e.value);
     });
-
-    const result = responseHandler(client, req);
-
-    const uploadBuffer = new SimpleBuffer(
-      this.flushOutputPanelMessages.bind(this),
-      FLUSH_OUTPUT_MESSAGES_TIMEOUT_MS
-    );
-    try {
-      await new Promise<void>((resolve, reject) => {
-        result.on('data', (resp: UploadResponse) => {
-          uploadBuffer.addChunk(resp.getOutStream_asU8());
-          uploadBuffer.addChunk(resp.getErrStream_asU8());
-        });
-        result.on('error', (error) => {
-          uploadBuffer.clearFlushInterval();
-          reject(error);
-        });
-        result.on('end', () => {
-          uploadBuffer.clearFlushInterval();
-          resolve();
-        });
-      });
-      this.responseService.appendToOutput({
-        chunk:
-          '\n--------------------------\n' +
-          firstToLowerCase(task) +
-          ' complete.\n',
-      });
-    } catch (e) {
-      const errorMessage = nls.localize(
-        'arduino/upload/error',
-        '{0} error: {1}',
-        firstToUpperCase(task),
-        e.details
-      );
-      this.responseService.appendToOutput({
-        chunk: `${errorMessage}\n`,
-        severity: 'error',
-      });
-      throw new Error(errorMessage);
-    } finally {
-      this.uploading = false;
-      this.monitorManager.notifyUploadFinished(board, port);
-    }
+    return request;
   }
 
   async burnBootloader(options: CoreService.Bootloader.Options): Promise<void> {
-    this.uploading = true;
-    const { board, port, programmer } = options;
-    await this.monitorManager.notifyUploadStarted(board, port);
-
-    await this.coreClientProvider.initialized;
     const coreClient = await this.coreClient();
     const { client, instance } = coreClient;
-    const burnReq = new BurnBootloaderRequest();
-    burnReq.setInstance(instance);
-    if (board?.fqbn) {
-      burnReq.setFqbn(board.fqbn);
-    }
-    const p = new Port();
-    if (port) {
-      p.setAddress(port.address);
-      p.setLabel(port.addressLabel);
-      p.setProtocol(port.protocol);
-      p.setProtocolLabel(port.protocolLabel);
-    }
-    burnReq.setPort(p);
-    if (programmer) {
-      burnReq.setProgrammer(programmer.id);
-    }
-    burnReq.setVerify(options.verify);
-    burnReq.setVerbose(options.verbose);
-    const result = client.burnBootloader(burnReq);
-
-    const bootloaderBuffer = new SimpleBuffer(
-      this.flushOutputPanelMessages.bind(this),
-      FLUSH_OUTPUT_MESSAGES_TIMEOUT_MS
+    const handler = this.createOnDataHandler();
+    const request = this.burnBootloaderRequest(options, instance);
+    return this.notifyUploadWillStart(options).then(() =>
+      new Promise<void>((resolve, reject) => {
+        client
+          .burnBootloader(request)
+          .on('data', handler.onData)
+          .on('error', (error) => {
+            if (!ServiceError.is(error)) {
+              console.error(
+                'Unexpected error occurred while burning the bootloader.',
+                error
+              );
+              reject(error);
+            } else {
+              this.sendResponse(error.details, OutputMessage.Severity.Error);
+              reject(
+                CoreError.BurnBootloaderFailed(
+                  nls.localize(
+                    'arduino/burnBootloader/error',
+                    'Error while burning the bootloader: {0}',
+                    error.details
+                  ),
+                  tryParseError({ content: handler.stderr })
+                )
+              );
+            }
+          })
+          .on('end', resolve);
+      }).finally(async () => {
+        handler.dispose();
+        await this.notifyUploadDidFinish(options);
+      })
     );
-    try {
-      await new Promise<void>((resolve, reject) => {
-        result.on('data', (resp: BurnBootloaderResponse) => {
-          bootloaderBuffer.addChunk(resp.getOutStream_asU8());
-          bootloaderBuffer.addChunk(resp.getErrStream_asU8());
-        });
-        result.on('error', (error) => {
-          bootloaderBuffer.clearFlushInterval();
-          reject(error);
-        });
-        result.on('end', () => {
-          bootloaderBuffer.clearFlushInterval();
-          resolve();
-        });
-      });
-    } catch (e) {
-      const errorMessage = nls.localize(
-        'arduino/burnBootloader/error',
-        'Error while burning the bootloader: {0}',
-        e.details
-      );
-      this.responseService.appendToOutput({
-        chunk: `${errorMessage}\n`,
-        severity: 'error',
-      });
-      throw new Error(errorMessage);
-    } finally {
-      this.uploading = false;
-      await this.monitorManager.notifyUploadFinished(board, port);
+  }
+
+  private burnBootloaderRequest(
+    options: CoreService.Bootloader.Options,
+    instance: Instance
+  ): BurnBootloaderRequest {
+    const { board, port, programmer } = options;
+    const request = new BurnBootloaderRequest();
+    request.setInstance(instance);
+    if (board?.fqbn) {
+      request.setFqbn(board.fqbn);
     }
+    request.setPort(this.createPort(port));
+    if (programmer) {
+      request.setProgrammer(programmer.id);
+    }
+    request.setVerify(options.verify);
+    request.setVerbose(options.verbose);
+    return request;
+  }
+
+  private createOnDataHandler<R extends StreamingResponse>(): Disposable & {
+    stderr: Buffer[];
+    onData: (response: R) => void;
+  } {
+    const stderr: Buffer[] = [];
+    const buffer = new SimpleBuffer((chunks) => {
+      Array.from(chunks.entries()).forEach(([severity, chunk]) => {
+        if (chunk) {
+          this.sendResponse(chunk, severity);
+        }
+      });
+    });
+    const onData = StreamingResponse.createOnDataHandler(stderr, (out, err) => {
+      buffer.addChunk(out);
+      buffer.addChunk(err, OutputMessage.Severity.Error);
+    });
+    return {
+      dispose: () => buffer.dispose(),
+      stderr,
+      onData,
+    };
+  }
+
+  private sendResponse(
+    chunk: string,
+    severity: OutputMessage.Severity = OutputMessage.Severity.Info
+  ): void {
+    this.responseService.appendToOutput({ chunk, severity });
+  }
+
+  private async notifyUploadWillStart({
+    board,
+    port,
+  }: {
+    board?: Board | undefined;
+    port?: Port | undefined;
+  }): Promise<void> {
+    return this.monitorManager.notifyUploadStarted(board, port);
+  }
+
+  private async notifyUploadDidFinish({
+    board,
+    port,
+  }: {
+    board?: Board | undefined;
+    port?: Port | undefined;
+  }): Promise<Status> {
+    return this.monitorManager.notifyUploadFinished(board, port);
   }
 
   private mergeSourceOverrides(
     req: { getSourceOverrideMap(): jspb.Map<string, string> },
     options: CoreService.Compile.Options
   ): void {
-    const sketchPath = FileUri.fsPath(options.sketchUri);
+    const sketchPath = FileUri.fsPath(options.sketch.uri);
     for (const uri of Object.keys(options.sourceOverride)) {
       const content = options.sourceOverride[uri];
       if (content) {
@@ -304,9 +349,33 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
     }
   }
 
-  private flushOutputPanelMessages(chunk: string): void {
-    this.responseService.appendToOutput({
-      chunk,
-    });
+  private createPort(port: Port | undefined): GrpcPort {
+    const grpcPort = new GrpcPort();
+    if (port) {
+      grpcPort.setAddress(port.address);
+      grpcPort.setLabel(port.addressLabel);
+      grpcPort.setProtocol(port.protocol);
+      grpcPort.setProtocolLabel(port.protocolLabel);
+    }
+    return grpcPort;
+  }
+}
+type StreamingResponse =
+  | CompileResponse
+  | UploadResponse
+  | UploadUsingProgrammerResponse
+  | BurnBootloaderResponse;
+namespace StreamingResponse {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  export function createOnDataHandler<R extends StreamingResponse>(
+    stderr: Uint8Array[],
+    onData: (out: Uint8Array, err: Uint8Array) => void
+  ): (response: R) => void {
+    return (response: R) => {
+      const out = response.getOutStream_asU8();
+      const err = response.getErrStream_asU8();
+      stderr.push(err);
+      onData(out, err);
+    };
   }
 }

--- a/arduino-ide-extension/src/node/service-error.ts
+++ b/arduino-ide-extension/src/node/service-error.ts
@@ -1,0 +1,23 @@
+import { Metadata, StatusObject } from '@grpc/grpc-js';
+
+export type ServiceError = StatusObject & Error;
+export namespace ServiceError {
+  export function is(arg: unknown): arg is ServiceError {
+    return arg instanceof Error && isStatusObjet(arg);
+  }
+  function isStatusObjet(arg: unknown): arg is StatusObject {
+    if (typeof arg === 'object') {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const any = arg as any;
+      return (
+        !!arg &&
+        'code' in arg &&
+        'details' in arg &&
+        typeof any.details === 'string' &&
+        'metadata' in arg &&
+        any.metadata instanceof Metadata
+      );
+    }
+    return false;
+  }
+}

--- a/arduino-ide-extension/src/node/utils/simple-buffer.ts
+++ b/arduino-ide-extension/src/node/utils/simple-buffer.ts
@@ -1,17 +1,19 @@
-export class SimpleBuffer {
-  private chunks: Uint8Array[] = [];
+import { Disposable } from '@theia/core/shared/vscode-languageserver-protocol';
+import { OutputMessage } from '../../common/protocol';
 
+const DEFAULT_FLUS_TIMEOUT_MS = 32;
+
+export class SimpleBuffer implements Disposable {
+  private readonly flush: () => void;
+  private readonly chunks = Chunks.create();
   private flushInterval?: NodeJS.Timeout;
-
-  private flush: () => void;
 
   constructor(onFlush: (chunk: string) => void, flushTimeout: number) {
     const flush = () => {
       if (this.chunks.length > 0) {
         const chunkString = Buffer.concat(this.chunks).toString();
         this.clearChunks();
-
-        onFlush(chunkString);
+        onFlush(chunks);
       }
     };
 
@@ -19,12 +21,15 @@ export class SimpleBuffer {
     this.flushInterval = setInterval(flush, flushTimeout);
   }
 
-  public addChunk(chunk: Uint8Array): void {
-    this.chunks.push(chunk);
+  public addChunk(
+    chunk: Uint8Array,
+    severity: OutputMessage.Severity = OutputMessage.Severity.Info
+  ): void {
+    this.chunks.get(severity)?.push(chunk);
   }
 
   private clearChunks(): void {
-    this.chunks = [];
+    Chunks.clear(this.chunks);
   }
 
   public clearFlushInterval(): void {
@@ -32,6 +37,37 @@ export class SimpleBuffer {
     this.clearChunks();
 
     clearInterval(this.flushInterval);
+    this.clearChunks();
     this.flushInterval = undefined;
+  }
+}
+
+type Chunks = Map<OutputMessage.Severity, Uint8Array[]>;
+namespace Chunks {
+  export function create(): Chunks {
+    return new Map([
+      [OutputMessage.Severity.Error, []],
+      [OutputMessage.Severity.Warning, []],
+      [OutputMessage.Severity.Info, []],
+    ]);
+  }
+  export function clear(chunks: Chunks): Chunks {
+    for (const chunk of chunks.values()) {
+      chunk.length = 0;
+    }
+    return chunks;
+  }
+  export function isEmpty(chunks: Chunks): boolean {
+    return ![...chunks.values()].some((chunk) => Boolean(chunk.length));
+  }
+  export function toString(
+    chunks: Chunks
+  ): Map<OutputMessage.Severity, string | undefined> {
+    return new Map(
+      Array.from(chunks.entries()).map(([severity, buffers]) => [
+        severity,
+        buffers.length ? Buffer.concat(buffers).toString() : undefined,
+      ])
+    );
   }
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -56,6 +56,24 @@
       "uploadRootCertificates": "Upload SSL Root Certificates",
       "uploadingCertificates": "Uploading certificates."
     },
+    "cli-error-parser": {
+      "byteError": "The 'BYTE' keyword is no longer supported.",
+      "byteMessage": "As of Arduino 1.0, the 'BYTE' keyword is no longer supported.\nPlease use Serial.write() instead.",
+      "clientError": "The Client class has been renamed EthernetClient.",
+      "clientMessage": "As of Arduino 1.0, the Client class in the Ethernet library has been renamed to EthernetClient.",
+      "keyboardError": "'Keyboard' not found. Does your sketch include the line '#include <Keyboard.h>'?",
+      "mouseError": "'Mouse' not found. Does your sketch include the line '#include <Mouse.h>'?",
+      "receiveError": "Wire.receive() has been renamed Wire.read().",
+      "receiveMessage": "As of Arduino 1.0, the Wire.receive() function was renamed to Wire.read() for consistency with other libraries.",
+      "sendError": "Wire.send() has been renamed Wire.write().",
+      "sendMessage": "As of Arduino 1.0, the Wire.send() function was renamed to Wire.write() for consistency with other libraries.",
+      "serverError": "The Server class has been renamed EthernetServer.",
+      "serverMessage": "As of Arduino 1.0, the Server class in the Ethernet library has been renamed to EthernetServer.",
+      "spiError": "Please import the SPI library from the Sketch > Import Library menu.",
+      "spiMessage": "As of Arduino 0019, the Ethernet library depends on the SPI library.\nYou appear to be using it or another library that depends on the SPI library.",
+      "udpError": "The Udp class has been renamed EthernetUdp.",
+      "udpMessage": "As of Arduino 1.0, the Udp class in the Ethernet library has been renamed to EthernetUdp."
+    },
     "cloud": {
       "chooseSketchVisibility": "Choose visibility of your Sketch:",
       "cloudSketchbook": "Cloud Sketchbook",
@@ -120,6 +138,9 @@
       "fileAdded": "One file added to the sketch.",
       "replaceTitle": "Replace"
     },
+    "coreContribution": {
+      "copyError": "Copy error messages"
+    },
     "debug": {
       "debugWithMessage": "Debug - {0}",
       "debuggingNotSupported": "Debugging is not supported by '{0}'",
@@ -136,7 +157,9 @@
       "decreaseFontSize": "Decrease Font Size",
       "decreaseIndent": "Decrease Indent",
       "increaseFontSize": "Increase Font Size",
-      "increaseIndent": "Increase Indent"
+      "increaseIndent": "Increase Indent",
+      "nextError": "Next Error",
+      "previousError": "Previous Error"
     },
     "electron": {
       "couldNotSave": "Could not save the sketch. Please copy your unsaved work into your favorite text editor, and restart the IDE.",
@@ -236,6 +259,8 @@
       "cloud.pushpublic.warn": "True if users should be warned before pushing a public sketch to the cloud. Defaults to true.",
       "cloud.sketchSyncEnpoint": "The endpoint used to push and pull sketches from a backend. By default it points to Arduino Cloud API.",
       "compile": "compile",
+      "compile.experimental": "True if the IDE should handle multiple compiler errors. False by default",
+      "compile.revealRange": "Adjusts how compiler errors are revealed in the editor after a failed verify/upload. Possible values: 'auto': Scroll vertically as necessary and reveal a line. 'center': Scroll vertically as necessary and reveal a line centered vertically. 'top': Scroll vertically as necessary and reveal a line close to the top of the viewport, optimized for viewing a code definition. 'centerIfOutsideViewport': Scroll vertically as necessary and reveal a line centered vertically only if it lies outside the viewport. The default value is '{0}'.",
       "compile.verbose": "True for verbose compile output. False by default",
       "compile.warnings": "Tells gcc which warning level to use. It's 'None' by default",
       "compilerWarnings": "Compiler warnings",


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

 - To reveal the compilation error location in the editor after a failed verify. The first compiler error is extracted from the CLI output and the IDE2 reveals it. (#608)

https://user-images.githubusercontent.com/1405703/173849256-bd6e6797-15a5-474d-b93e-6e58282c67e6.mp4

 - Show the errors with error color in the _Output_ view (https://github.com/arduino/arduino-ide/issues/229).

<img width="1068" alt="Screen Shot 2022-06-15 at 16 15 54" src="https://user-images.githubusercontent.com/1405703/173849532-73eaf376-0a70-448d-aecd-e7e43b0cde7c.png">

 - Show the first compilation error in the notification center.
<img width="518" alt="Screen Shot 2022-06-15 at 16 17 01" src="https://user-images.githubusercontent.com/1405703/173849776-ab516f79-865c-4fcf-8894-80c052d1f396.png">

 - Can copy the _Output_ content from the error notification:

https://user-images.githubusercontent.com/1405703/173850735-bb65386b-51d2-4dab-b1fd-c95d65c0b389.mp4

### Experimental
You need to enable the experimental features from the `settings.json` if you want to see "more errors" 😉:
 - Open the _Command Palette_ with <kbd>F1</kbd>,
 - Type and `Preferences: Open Settings (JSON)` and press <kbd>Enter</kbd>,
 - Add `"arduino.compile.experimental": true` to the JSON, save the file if you do not have auto-save enabled, and close the `settings.json` editor.
 - Compile a sketch with multiple errors. Here is an example sketch:
[Errors.zip](https://github.com/arduino/arduino-ide/files/8911126/Errors.zip)

It should be possible to navigate between the errors.

https://user-images.githubusercontent.com/1405703/173874548-c6a8ed04-4952-4077-b64a-67b8c0515a00.mp4

Expected behavior:
 - The order of the compiler errors is given by the CLI (https://github.com/arduino/arduino-cli/issues/1760),
 - The `Next Error` and the `Previous Error` navigation depend on the order of the compiler errors,
 - The error parsing logic in IDE2 is [expected to be identical](https://github.com/arduino/arduino-ide/pull/1064/files#diff-f189f49a2c2650a5e2c1fc3c37e3993e049c3db6a9fa7b83ecdac4a988b65026R91-R95) as in the Java IDE.
 - If the experimental features are enabled, but there is one compiler error, navigation is not available.
 - If the cursor location intersects the location of the compiler error, or in the same line, the error under the cursor will be the current error and will have the previous/next action. (~There is an issue when there are multiple errors in the same line or location. I am working on this. 🚧 https://github.com/arduino/arduino-ide/pull/1064#discussion_r898193686~ Fixed: https://github.com/arduino/arduino-ide/pull/1064/commits/4f486cb4a2c2cdfc388d167ea3c6f5b5ed684300)
 - The error decoration (red line) must be sticky. It means, that editing the file should move the markers around.
 - If a code is deleted from an error decoration location, or text is inserted into an error decoration location, the error decoration will be removed.

https://user-images.githubusercontent.com/1405703/173877180-104d6456-ce7e-4ac8-9fe4-a2227646bffd.mp4

Known issues:
 - When deleting code from a location with the error decoration.

https://user-images.githubusercontent.com/1405703/173877699-6bd92a9c-2585-4cbd-bf32-a6026f67a751.mp4
 - TBD,

Open questions:
 - As noted [in the code](https://github.com/arduino/arduino-ide/pull/1064/files#diff-5cf4185feeb098a1b6102d6443d9aa3885075289fac0d3b2bd12557897287b78R420-R422), I do not know which focusing logic prefers the community the best. So I would like to hear feedback. ~I will add a preference for this soon.~ I added a preference: https://github.com/arduino/arduino-ide/pull/1064/commits/54e60f6e111d53e969fb08bf4c30f9ae5db3cbce


### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->


Closes #608
Closes #229

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)