### PR TITLE
Can enable debug logging of the gRPC calls.

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -182,6 +182,14 @@ export const ArduinoConfigSchema: PreferenceSchema = {
       ),
       default: true,
     },
+    'arduino.cli.daemon.debug': {
+      type: 'boolean',
+      description: nls.localize(
+        'arduino/preferences/cli.daemonDebug',
+        "Enable debug logging of the gRPC calls to the Arduino CLI. A restart of the IDE is needed for this setting to take effect. It's false by default."
+      ),
+      default: false,
+    },
   },
 };
 
@@ -207,6 +215,7 @@ export interface ArduinoConfiguration {
   'arduino.auth.audience': string;
   'arduino.auth.registerUri': string;
   'arduino.survey.notification': boolean;
+  'arduino.cli.daemon.debug': boolean;
 }
 
 export const ArduinoPreferences = Symbol('ArduinoPreferences');

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -229,6 +229,7 @@
       "board.certificates": "List of certificates that can be uploaded to boards",
       "browse": "Browse",
       "choose": "Choose",
+      "cli.daemonDebug": "Enable debug logging of the gRPC calls to the Arduino CLI. A restart of the IDE is needed for this setting to take effect. It's false by default.",
       "cloud.enabled": "True if the sketch sync functions are enabled. Defaults to true.",
       "cloud.pull.warn": "True if users should be warned before pulling a cloud sketch. Defaults to true.",
       "cloud.push.warn": "True if users should be warned before pushing a cloud sketch. Defaults to true.",


### PR DESCRIPTION
### Motivation
Can enable the debug logging of the gRPC call to the Arduino CLI.

### Change description
How to test:
 - Open the `~/.arduinoIDE/settings.json`, you can use IDE2 or your favorite text editor,
 - Add `"arduino.cli.daemon.debug": true` to the `settings.json` file and save it,
 - Start the IDE2 from a terminal, see that debug calls, such as:
```
daemon INFO 3 |  RESP: {
3 |    "download_progress": {
3 |      "url": "https://downloads.arduino.cc/packages/package_index.tar.bz2",
3 |      "file": "Downloading index: package_index.tar.bz2",
3 |      "total_size": 41847
3 |    }
3 |  }
3 |  RESP: {
3 |    "download_progress": {
3 |      "downloaded": 41847
3 |    }
3 |  }
3 |  RESP: {
3 |    "download_progress": {
3 |      "completed": true
3 |    }
3 |  }
```

### Other information

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)