### PR TITLE
IDE updater dialog colors fix

### DIFF
--- a/arduino-ide-extension/src/browser/style/ide-updater-dialog.css
+++ b/arduino-ide-extension/src/browser/style/ide-updater-dialog.css
@@ -27,8 +27,9 @@
 }
 
 .ide-updater-dialog .changelog-container {
-  background: white;
-  border: 1px solid #dae3e3;
+  color: var(--theia-dropdown-foreground);
+  background-color: var(--theia-dropdown-background);
+  border: 1px solid var(--theia-tree-indentGuidesStroke);
   border-radius: 2px;
   font-size: 12px;
   height: 180px;


### PR DESCRIPTION
### Motivation
The changelog box of the IDE updater dialog is not visible using the "High Contrast (Theia)" theme and has low contrast using the "Dark (Arduino)" and "Dark (Theia)" themes.

### Change description
Set the correct `background-color`, `color` and `border` of the IDE updater dialog.

### Other information
The correct variables for this dialog are not yet available. To work around this, variables with the same values (for both dark and light themes) has been used.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)