### PR TITLE
Sketchbook tree indentation

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
@@ -1,5 +1,9 @@
 import * as React from '@theia/core/shared/react';
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import {
+  inject,
+  injectable,
+  postConstruct,
+} from '@theia/core/shared/inversify';
 import { TreeNode } from '@theia/core/lib/browser/tree/tree';
 import { CommandRegistry } from '@theia/core/lib/common/command';
 import {
@@ -21,6 +25,11 @@ import {
 import { SelectableTreeNode } from '@theia/core/lib/browser/tree/tree-selection';
 import { Sketch } from '../../contributions/contribution';
 import { nls } from '@theia/core/lib/common';
+
+const customTreeProps: TreeProps = {
+  leftPadding: 20,
+  expansionTogglePadding: 6,
+};
 
 @injectable()
 export class SketchbookTreeWidget extends FileTreeWidget {
@@ -57,10 +66,14 @@ export class SketchbookTreeWidget extends FileTreeWidget {
     super.init();
     // cache the current open sketch uri
     const currentSketch = await this.sketchServiceClient.currentSketch();
-    this.currentSketchUri = (CurrentSketch.isValid(currentSketch) && currentSketch.uri) || '';
+    this.currentSketchUri =
+      (CurrentSketch.isValid(currentSketch) && currentSketch.uri) || '';
   }
 
-  protected override createNodeClassNames(node: TreeNode, props: NodeProps): string[] {
+  protected override createNodeClassNames(
+    node: TreeNode,
+    props: NodeProps
+  ): string[] {
     const classNames = super.createNodeClassNames(node, props);
 
     if (
@@ -73,7 +86,10 @@ export class SketchbookTreeWidget extends FileTreeWidget {
     return classNames;
   }
 
-  protected override renderIcon(node: TreeNode, props: NodeProps): React.ReactNode {
+  protected override renderIcon(
+    node: TreeNode,
+    props: NodeProps
+  ): React.ReactNode {
     if (SketchbookTree.SketchDirNode.is(node) || Sketch.isSketchFile(node.id)) {
       return <div className="sketch-folder-icon file-icon"></div>;
     }
@@ -198,5 +214,14 @@ export class SketchbookTreeWidget extends FileTreeWidget {
       }
     }
     event.stopPropagation();
+  }
+
+  protected override getPaddingLeft(node: TreeNode, props: NodeProps): number {
+    return (
+      props.depth * customTreeProps.leftPadding +
+      (this.needsExpansionTogglePadding(node)
+        ? customTreeProps.expansionTogglePadding
+        : 0)
+    );
   }
 }


### PR DESCRIPTION
### Motivation

- The indent size of the folders in the sketchbook is too small

The sketchbook structure:
```
Arduino/
├── Foo/
│   └── Bar/
│       └── Sketch/
│       └── Sketch_old/
```

was rendered:

![folders_before](https://user-images.githubusercontent.com/94986937/175019466-bba33adf-4ee1-4e1e-8581-308863c20b2e.png)

after the changes:

![folders_after](https://user-images.githubusercontent.com/94986937/175021165-e0557286-981d-4981-acf0-7048d5d61909.png)


- The sketches have an inappropriate indentation level

The sketchbook structure:
```
Arduino/
├── Foo/
│   └── Bar/
│   └── sketch_jun14a/
```

was rendered:

![sketch_before](https://user-images.githubusercontent.com/94986937/175019645-37095836-0aee-45f6-aa93-0f4f3d627a4e.png)

after the changes:

![sketch_after](https://user-images.githubusercontent.com/94986937/175020512-93ce3b16-3579-4246-be9b-b248611d9ba7.png)


### Change description
Updated the left padding of the icons in the sketchbook

### Other information
Fix for:

- https://github.com/arduino/arduino-ide/issues/1049
- https://github.com/arduino/arduino-ide/issues/1050

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)