### PR TITLE
reference cli rc1 0.24 in package.json

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -156,11 +156,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": {
-        "owner": "arduino",
-        "repo": "arduino-cli",
-        "commitish": "c1b10f562f1e1a112e215a69b84e2f2b69e3af2d"  
-      }
+      "version": "0.24.0-rc1"
     },
     "fwuploader": {
       "version": "2.2.0"


### PR DESCRIPTION
### Motivation
To use the cli version 0.24.0-rc1 in the IDE.

### Change description
Modifies the package.json cli version reference.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)