### PR TITLE
Fix cloud sketchbook widget rendering empty

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-composite-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-composite-widget.tsx
@@ -58,6 +58,20 @@ export class CloudSketchbookCompositeWidget extends BaseWidget {
     );
   }
 
+  protected override onActivateRequest(msg: Message): void {
+    super.onActivateRequest(msg);
+    this.cloudSketchbookTreeWidget.activate();
+
+    /* 
+      Sending a resize message is needed because otherwise the cloudSketchbookTreeWidget
+      would render empty
+    */
+    MessageLoop.sendMessage(
+      this.cloudSketchbookTreeWidget,
+      Widget.ResizeMessage.UnknownSize
+    );
+  }
+
   protected override onResize(message: Widget.ResizeMessage): void {
     super.onResize(message);
     MessageLoop.sendMessage(


### PR DESCRIPTION
### Motivation
Sometimes, the Remote Sketchbook content is empty. Clicking inside the widget content or resizing the sidebar will make the content appear.

### Change description
Send a "fake" resize message to the cloud sketchbook tree to trigger a correct render.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)