### PR TITLE
Sketchbook sidebar state

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -832,6 +832,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
   bind(CloudSketchbookWidget).toSelf();
   rebind(SketchbookWidget).toService(CloudSketchbookWidget);
+  bind(CommandContribution).toService(CloudSketchbookWidget);
   bind(CloudSketchbookTreeWidget).toDynamicValue(({ container }) =>
     createCloudSketchbookTreeWidget(container)
   );

--- a/arduino-ide-extension/src/browser/contributions/sketch-control.ts
+++ b/arduino-ide-extension/src/browser/contributions/sketch-control.ts
@@ -250,7 +250,7 @@ export class SketchControl extends SketchContribution {
     });
   }
 
-  protected isCloudSketch(uri: string): boolean {
+  isCloudSketch(uri: string): boolean {
     try {
       const cloudCacheLocation = this.localCacheFsProvider.from(new URI(uri));
 

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-contributions.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-contributions.ts
@@ -23,7 +23,10 @@ import {
 } from '@theia/core/lib/browser/preferences/preference-service';
 import { ArduinoMenus, PlaceholderMenuNode } from '../../menu/arduino-menus';
 import { SketchbookCommands } from '../sketchbook/sketchbook-commands';
-import { CurrentSketch, SketchesServiceClientImpl } from '../../../common/protocol/sketches-service-client-impl';
+import {
+  CurrentSketch,
+  SketchesServiceClientImpl,
+} from '../../../common/protocol/sketches-service-client-impl';
 import { Contribution } from '../../contributions/contribution';
 import { ArduinoPreferences } from '../../arduino-preferences';
 import { MainMenuManager } from '../../../common/main-menu-manager';
@@ -60,6 +63,14 @@ export namespace CloudSketchbookCommands {
       );
     }
   }
+
+  export const SHOW_CLOUD_SKETCHBOOK_WIDGET = Command.toLocalizedCommand(
+    {
+      id: 'arduino-cloud-sketchbook--show-cloud-sketchbook-widget',
+      label: 'Show Cloud Sketchbook Widget',
+    },
+    'arduino/sketch/showCloudSketchbookWidget'
+  );
 
   export const TOGGLE_CLOUD_SKETCHBOOK = Command.toLocalizedCommand(
     {

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-widget.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-widget.ts
@@ -6,16 +6,10 @@ import {
 import { CloudSketchbookCompositeWidget } from './cloud-sketchbook-composite-widget';
 import { SketchbookWidget } from '../sketchbook/sketchbook-widget';
 import { ArduinoPreferences } from '../../arduino-preferences';
-import { Command, CommandContribution, CommandRegistry } from '@theia/core';
+import { CommandContribution, CommandRegistry } from '@theia/core';
 import { ApplicationShell } from '@theia/core/lib/browser';
-
-export const SHOW_CLOUD_SKETCHBOOK_WIDGET = Command.toLocalizedCommand(
-  {
-    id: 'arduino-sketchbook--show-cloud-sketchbook-widget',
-    label: 'Show Cloud Sketchbook Widget',
-  },
-  'arduino/sketch/showCloudSketchbookWidget'
-);
+import { CloudSketchbookCommands } from './cloud-sketchbook-contributions';
+import { EditorManager } from '@theia/editor/lib/browser';
 
 @injectable()
 export class CloudSketchbookWidget
@@ -30,6 +24,9 @@ export class CloudSketchbookWidget
 
   @inject(ApplicationShell)
   protected readonly shell: ApplicationShell;
+
+  @inject(EditorManager)
+  protected readonly editorManager: EditorManager;
 
   @postConstruct()
   protected override init(): void {
@@ -83,9 +80,12 @@ export class CloudSketchbookWidget
     this.sketchbookTreesContainer.addWidget(
       this.cloudSketchbookCompositeWidget
     );
-    registry.registerCommand(SHOW_CLOUD_SKETCHBOOK_WIDGET, {
-      execute: this.showCloudSketchbookWidget.bind(this),
-    });
+    registry.registerCommand(
+      CloudSketchbookCommands.SHOW_CLOUD_SKETCHBOOK_WIDGET,
+      {
+        execute: () => this.showCloudSketchbookWidget(),
+      }
+    );
   }
 
   showCloudSketchbookWidget(): void {
@@ -94,6 +94,8 @@ export class CloudSketchbookWidget
         if (widget instanceof CloudSketchbookWidget) {
           widget.activateTreeWidget(this.cloudSketchbookCompositeWidget.id);
         }
+        if (this.editorManager.currentEditor)
+          this.shell.activateWidget(this.editorManager.currentEditor.id);
       });
     }
   }

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-commands.ts
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-commands.ts
@@ -1,6 +1,18 @@
 import { Command } from '@theia/core/lib/common/command';
 
 export namespace SketchbookCommands {
+  export const TOGGLE_SKETCHBOOK_WIDGET: Command = {
+    id: 'arduino-sketchbook-widget:toggle',
+  };
+
+  export const SHOW_SKETCHBOOK_WIDGET = Command.toLocalizedCommand(
+    {
+      id: 'arduino-sketchbook--show-sketchbook-widget',
+      label: 'Show Sketchbook Widget',
+    },
+    'arduino/sketch/showSketchbookWidget'
+  );
+
   export const OPEN_NEW_WINDOW = Command.toLocalizedCommand(
     {
       id: 'arduino-sketchbook--open-sketch-new-window',

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget-contribution.ts
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget-contribution.ts
@@ -77,7 +77,7 @@ export class SketchbookWidgetContribution
         area: 'left',
         rank: 1,
       },
-      toggleCommandId: 'arduino-sketchbook-widget:toggle',
+      toggleCommandId: SketchbookCommands.TOGGLE_SKETCHBOOK_WIDGET.id,
       toggleKeybinding: 'CtrlCmd+Shift+B',
     });
   }
@@ -100,7 +100,9 @@ export class SketchbookWidgetContribution
 
   override registerCommands(registry: CommandRegistry): void {
     super.registerCommands(registry);
-
+    registry.registerCommand(SketchbookCommands.SHOW_SKETCHBOOK_WIDGET, {
+      execute: () => this.showSketchbookWidget(),
+    });
     registry.registerCommand(SketchbookCommands.OPEN_NEW_WINDOW, {
       execute: async (arg) => {
         return this.workspaceService.open(arg.node.uri);
@@ -197,7 +199,7 @@ export class SketchbookWidgetContribution
 
     // unregister main menu action
     registry.unregisterMenuAction({
-      commandId: 'arduino-sketchbook-widget:toggle',
+      commandId: SketchbookCommands.TOGGLE_SKETCHBOOK_WIDGET.id,
     });
 
     registry.registerMenuAction(SKETCHBOOK__CONTEXT__MAIN_GROUP, {
@@ -229,5 +231,11 @@ export class SketchbookWidgetContribution
 
   protected onCurrentWidgetChangedHandler(): void {
     this.selectWidgetFileNode(this.shell.currentWidget);
+  }
+
+  protected async showSketchbookWidget(): Promise<void> {
+    const widget = await this.widget;
+    await this.shell.activateWidget(widget.id);
+    widget.activateTreeWidget(widget.getTreeWidget().id);
   }
 }

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget.tsx
@@ -1,4 +1,8 @@
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import {
+  inject,
+  injectable,
+  postConstruct,
+} from '@theia/core/shared/inversify';
 import { toArray } from '@theia/core/shared/@phosphor/algorithm';
 import { IDragEvent } from '@theia/core/shared/@phosphor/dragdrop';
 import { DockPanel, Widget } from '@theia/core/shared/@phosphor/widgets';
@@ -43,6 +47,16 @@ export class SketchbookWidget extends BaseWidget {
 
   getTreeWidget(): SketchbookTreeWidget {
     return this.localSketchbookTreeWidget;
+  }
+
+  activateTreeWidget(treeWidgetId: string): boolean {
+    for (const widget of toArray(this.sketchbookTreesContainer.widgets())) {
+      if (widget.id === treeWidgetId) {
+        this.sketchbookTreesContainer.activateWidget(widget);
+        return true;
+      }
+    }
+    return false;
   }
 
   protected override onActivateRequest(message: Message): void {


### PR DESCRIPTION
### Motivation
When opening a sketch from the sketchbook sidebar, the new IDE window should open with the sketchbook sidebar open. This should also happen when opening a sketch from the Remote Sketchbook (and of course in this case the Remote Sketchbook will be automatically open).

#### Expected Behavior
**Local Sketchbook:**
1. launch IDE
2. expand the Sketchbook sidebar
3. select the Local Sketchbook
4. double-click a Sketch that is not open
5. 😄 it will open to another window and the Local Sketchbook sidebar will be open

**Remote Sketchbook:**
1. launch IDE
2. expand the Sketchbook sidebar
3. select the Remote Sketchbook (sign in if necessary)
4. double-click a Sketch that is not open
5. 😄 it will open to another window and the Remote Sketchbook sidebar will be open


### Change description
- Added two commands to open the local and the remote sketchbook respectively.
- Added a way to pass an array of commands to the `WorkspaceService` when opening a new sketch. Those commands will be subsequently run when the front-end is ready.

### Other information
Fixes https://github.com/arduino/arduino-ide/issues/442

Replaces #912 

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)