### PR TITLE
Add missing 'Advanced' string

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/settings.ts
+++ b/arduino-ide-extension/src/browser/contributions/settings.ts
@@ -49,7 +49,10 @@ export class Settings extends SketchContribution {
         ) + '...',
       order: '0',
     });
-    registry.registerSubmenu(ArduinoMenus.FILE__ADVANCED_SUBMENU, 'Advanced');
+    registry.registerSubmenu(
+      ArduinoMenus.FILE__ADVANCED_SUBMENU,
+      nls.localize('arduino/menu/advanced', 'Advanced')
+    );
   }
 
   override registerKeybindings(registry: KeybindingRegistry): void {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -237,6 +237,7 @@
       "zipLibrary": "Library"
     },
     "menu": {
+      "advanced": "Advanced",
       "sketch": "Sketch",
       "tools": "Tools"
     },


### PR DESCRIPTION
### Motivation
The localization of the string "Advanced" was missing.

### Change description
Added localization for "Advanced" string.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)