### PR TITLE
#714: Use the build cache to speed up the LS

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -155,7 +155,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.24.0"
+      "version": "0.25.0-rc1"
     },
     "fwuploader": {
       "version": "2.2.0"
@@ -164,7 +164,7 @@
       "version": "14.0.0"
     },
     "languageServer": {
-      "version": "0.6.0"
+      "version": "0.7.0"
     }
   }
 }

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -164,11 +164,7 @@
       "version": "14.0.0"
     },
     "languageServer": {
-      "version": {
-        "owner": "arduino",
-        "repo": "arduino-language-server",
-        "commitish": "flag_to_disable_real_time_errors"
-      }
+      "version": "0.7.1"
     }
   }
 }

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -164,7 +164,11 @@
       "version": "14.0.0"
     },
     "languageServer": {
-      "version": "0.7.0"
+      "version": {
+        "owner": "arduino",
+        "repo": "arduino-language-server",
+        "commitish": "flag_to_disable_real_time_errors"
+      }
     }
   }
 }

--- a/arduino-ide-extension/scripts/download-cli.js
+++ b/arduino-ide-extension/scripts/download-cli.js
@@ -1,141 +1,87 @@
 // @ts-check
 
 (async () => {
+  const path = require('path');
+  const shell = require('shelljs');
+  const semver = require('semver');
+  const moment = require('moment');
+  const downloader = require('./downloader');
+  const { goBuildFromGit } = require('./utils');
 
-    const fs = require('fs');
-    const path = require('path');
-    const temp = require('temp');
-    const shell = require('shelljs');
-    const semver = require('semver');
-    const moment = require('moment');
-    const downloader = require('./downloader');
+  const version = (() => {
+    const pkg = require(path.join(__dirname, '..', 'package.json'));
+    if (!pkg) {
+      return undefined;
+    }
 
-    const version = (() => {
-        const pkg = require(path.join(__dirname, '..', 'package.json'));
-        if (!pkg) {
-            return undefined;
+    const { arduino } = pkg;
+    if (!arduino) {
+      return undefined;
+    }
+
+    const { cli } = arduino;
+    if (!cli) {
+      return undefined;
+    }
+
+    const { version } = cli;
+    return version;
+  })();
+
+  if (!version) {
+    shell.echo(`Could not retrieve CLI version info from the 'package.json'.`);
+    shell.exit(1);
+  }
+
+  const { platform, arch } = process;
+  const buildFolder = path.join(__dirname, '..', 'build');
+  const cliName = `arduino-cli${platform === 'win32' ? '.exe' : ''}`;
+  const destinationPath = path.join(buildFolder, cliName);
+
+  if (typeof version === 'string') {
+    const suffix = (() => {
+      switch (platform) {
+        case 'darwin':
+          return 'macOS_64bit.tar.gz';
+        case 'win32':
+          return 'Windows_64bit.zip';
+        case 'linux': {
+          switch (arch) {
+            case 'arm':
+              return 'Linux_ARMv7.tar.gz';
+            case 'arm64':
+              return 'Linux_ARM64.tar.gz';
+            case 'x64':
+              return 'Linux_64bit.tar.gz';
+            default:
+              return undefined;
+          }
         }
-
-        const { arduino } = pkg;
-        if (!arduino) {
-            return undefined;
-        }
-
-        const { cli } = arduino;
-        if (!cli) {
-            return undefined;
-        }
-
-        const { version } = cli;
-        return version;
+        default:
+          return undefined;
+      }
     })();
-
-    if (!version) {
-        shell.echo(`Could not retrieve CLI version info from the 'package.json'.`);
-        shell.exit(1);
+    if (!suffix) {
+      shell.echo(`The CLI is not available for ${platform} ${arch}.`);
+      shell.exit(1);
     }
-
-    const { platform, arch } = process;
-    const buildFolder = path.join(__dirname, '..', 'build');
-    const cliName = `arduino-cli${platform === 'win32' ? '.exe' : ''}`;
-    const destinationPath = path.join(buildFolder, cliName);
-
-    if (typeof version === 'string') {
-        const suffix = (() => {
-            switch (platform) {
-                case 'darwin': return 'macOS_64bit.tar.gz';
-                case 'win32': return 'Windows_64bit.zip';
-                case 'linux': {
-                    switch (arch) {
-                        case 'arm': return 'Linux_ARMv7.tar.gz';
-                        case 'arm64': return 'Linux_ARM64.tar.gz';
-                        case 'x64': return 'Linux_64bit.tar.gz';
-                        default: return undefined;
-                    }
-                }
-                default: return undefined;
-            }
-        })();
-        if (!suffix) {
-            shell.echo(`The CLI is not available for ${platform} ${arch}.`);
-            shell.exit(1);
-        }
-        if (semver.valid(version)) {
-            const url = `https://downloads.arduino.cc/arduino-cli/arduino-cli_${version}_${suffix}`;
-            shell.echo(`📦  Identified released version of the CLI. Downloading version ${version} from '${url}'`);
-            await downloader.downloadUnzipFile(url, destinationPath, 'arduino-cli');
-        } else if (moment(version, 'YYYYMMDD', true).isValid()) {
-            const url = `https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-${version}_${suffix}`;
-            shell.echo(`🌙  Identified nightly version of the CLI. Downloading version ${version} from '${url}'`);
-            await downloader.downloadUnzipFile(url, destinationPath, 'arduino-cli');
-        } else {
-            shell.echo(`🔥  Could not interpret 'version': ${version}`);
-            shell.exit(1);
-        }
+    if (semver.valid(version)) {
+      const url = `https://downloads.arduino.cc/arduino-cli/arduino-cli_${version}_${suffix}`;
+      shell.echo(
+        `📦  Identified released version of the CLI. Downloading version ${version} from '${url}'`
+      );
+      await downloader.downloadUnzipFile(url, destinationPath, 'arduino-cli');
+    } else if (moment(version, 'YYYYMMDD', true).isValid()) {
+      const url = `https://downloads.arduino.cc/arduino-cli/nightly/arduino-cli_nightly-${version}_${suffix}`;
+      shell.echo(
+        `🌙  Identified nightly version of the CLI. Downloading version ${version} from '${url}'`
+      );
+      await downloader.downloadUnzipFile(url, destinationPath, 'arduino-cli');
     } else {
-
-        // We assume an object with `owner`, `repo`, commitish?` properties.
-        const { owner, repo, commitish } = version;
-        if (!owner) {
-            shell.echo(`Could not retrieve 'owner' from ${JSON.stringify(version)}`);
-            shell.exit(1);
-        }
-        if (!repo) {
-            shell.echo(`Could not retrieve 'repo' from ${JSON.stringify(version)}`);
-            shell.exit(1);
-        }
-        const url = `https://github.com/${owner}/${repo}.git`;
-        shell.echo(`Building CLI from ${url}. Commitish: ${commitish ? commitish : 'HEAD'}`);
-
-        if (fs.existsSync(destinationPath)) {
-            shell.echo(`Skipping the CLI build because it already exists: ${destinationPath}`);
-            return;
-        }
-
-        if (shell.mkdir('-p', buildFolder).code !== 0) {
-            shell.echo('Could not create build folder.');
-            shell.exit(1);
-        }
-
-        const tempRepoPath = temp.mkdirSync();
-        shell.echo(`>>> Cloning CLI source to ${tempRepoPath}...`);
-        if (shell.exec(`git clone ${url} ${tempRepoPath}`).code !== 0) {
-            shell.exit(1);
-        }
-        shell.echo('<<< Cloned CLI repo.')
-
-        if (commitish) {
-            shell.echo(`>>> Checking out ${commitish}...`);
-            if (shell.exec(`git -C ${tempRepoPath} checkout ${commitish}`).code !== 0) {
-                shell.exit(1);
-            }
-            shell.echo(`<<< Checked out ${commitish}.`);
-        }
-
-        shell.echo(`>>> Building the CLI...`);
-        if (shell.exec('go build', { cwd: tempRepoPath }).code !== 0) {
-            shell.exit(1);
-        }
-        shell.echo('<<< CLI build done.')
-
-        if (!fs.existsSync(path.join(tempRepoPath, cliName))) {
-            shell.echo(`Could not find the CLI at ${path.join(tempRepoPath, cliName)}.`);
-            shell.exit(1);
-        }
-
-        const builtCliPath = path.join(tempRepoPath, cliName);
-        shell.echo(`>>> Copying CLI from ${builtCliPath} to ${destinationPath}...`);
-        if (shell.cp(builtCliPath, destinationPath).code !== 0) {
-            shell.exit(1);
-        }
-        shell.echo(`<<< Copied the CLI.`);
-
-        shell.echo('<<< Verifying CLI...');
-        if (!fs.existsSync(destinationPath)) {
-            shell.exit(1);
-        }
-        shell.echo('>>> Verified CLI.');
-
+      shell.echo(`🔥  Could not interpret 'version': ${version}`);
+      shell.exit(1);
     }
-
+  } else {
+    goBuildFromGit(version, destinationPath, 'CLI');
+  }
 })();

--- a/arduino-ide-extension/scripts/downloader.js
+++ b/arduino-ide-extension/scripts/downloader.js
@@ -86,6 +86,7 @@ exports.downloadUnzipFile = async (
  * @param targetDir {string}  Directory into which to decompress the archive
  * @param targetFile {string} Path to the main file expected after decompressing
  * @param force {boolean}     Whether to download even if the target file exists
+ * @param decompressOptions {import('decompress').DecompressOptions}
  */
 exports.downloadUnzipAll = async (
   url,

--- a/arduino-ide-extension/scripts/utils.js
+++ b/arduino-ide-extension/scripts/utils.js
@@ -1,0 +1,92 @@
+/**
+ * Clones something from GitHub and builds it with `Golang`.
+ *
+ * @param version {object} the version object.
+ * @param destinationPath {string} the absolute path of the output binary. For example, `C:\\folder\\arduino-cli.exe` or `/path/to/arduino-language-server`
+ * @param taskName {string} for the CLI logging . Can be `'CLI'` or `'language-server'`, etc.
+ */
+exports.goBuildFromGit = (version, destinationPath, taskName) => {
+  const fs = require('fs');
+  const path = require('path');
+  const temp = require('temp');
+  const shell = require('shelljs');
+
+  // We assume an object with `owner`, `repo`, commitish?` properties.
+  if (typeof version !== 'object') {
+    shell.echo(
+      `Expected a \`{ owner, repo, commitish }\` object. Got <${version}> instead.`
+    );
+  }
+  const { owner, repo, commitish } = version;
+  if (!owner) {
+    shell.echo(`Could not retrieve 'owner' from ${JSON.stringify(version)}`);
+    shell.exit(1);
+  }
+  if (!repo) {
+    shell.echo(`Could not retrieve 'repo' from ${JSON.stringify(version)}`);
+    shell.exit(1);
+  }
+  const url = `https://github.com/${owner}/${repo}.git`;
+  shell.echo(
+    `Building ${taskName} from ${url}. Commitish: ${
+      commitish ? commitish : 'HEAD'
+    }`
+  );
+
+  if (fs.existsSync(destinationPath)) {
+    shell.echo(
+      `Skipping the ${taskName} build because it already exists: ${destinationPath}`
+    );
+    return;
+  }
+
+  const buildFolder = path.join(__dirname, '..', 'build');
+  if (shell.mkdir('-p', buildFolder).code !== 0) {
+    shell.echo('Could not create build folder.');
+    shell.exit(1);
+  }
+
+  const tempRepoPath = temp.mkdirSync();
+  shell.echo(`>>> Cloning ${taskName} source to ${tempRepoPath}...`);
+  if (shell.exec(`git clone ${url} ${tempRepoPath}`).code !== 0) {
+    shell.exit(1);
+  }
+  shell.echo(`<<< Cloned ${taskName} repo.`);
+
+  if (commitish) {
+    shell.echo(`>>> Checking out ${commitish}...`);
+    if (shell.exec(`git -C ${tempRepoPath} checkout ${commitish}`).code !== 0) {
+      shell.exit(1);
+    }
+    shell.echo(`<<< Checked out ${commitish}.`);
+  }
+
+  shell.echo(`>>> Building the ${taskName}...`);
+  if (shell.exec('go build', { cwd: tempRepoPath }).code !== 0) {
+    shell.exit(1);
+  }
+  shell.echo(`<<< Done ${taskName} build.`);
+
+  const binName = path.basename(destinationPath);
+  if (!fs.existsSync(path.join(tempRepoPath, binName))) {
+    shell.echo(
+      `Could not find the ${taskName} at ${path.join(tempRepoPath, binName)}.`
+    );
+    shell.exit(1);
+  }
+
+  const binPath = path.join(tempRepoPath, binName);
+  shell.echo(
+    `>>> Copying ${taskName} from ${binPath} to ${destinationPath}...`
+  );
+  if (shell.cp(binPath, destinationPath).code !== 0) {
+    shell.exit(1);
+  }
+  shell.echo(`<<< Copied the ${taskName}.`);
+
+  shell.echo(`<<< Verifying ${taskName}...`);
+  if (!fs.existsSync(destinationPath)) {
+    shell.exit(1);
+  }
+  shell.echo(`>>> Verified ${taskName}.`);
+};

--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -277,11 +277,14 @@ export class ArduinoFrontendContribution
         );
       });
 
-    const start = async ({ selectedBoard }: BoardsConfig.Config) => {
+    const start = async (
+      { selectedBoard }: BoardsConfig.Config,
+      forceStart = false
+    ) => {
       if (selectedBoard) {
         const { name, fqbn } = selectedBoard;
         if (fqbn) {
-          this.startLanguageServer(fqbn, name);
+          this.startLanguageServer(fqbn, name, forceStart);
         }
       }
     };
@@ -296,7 +299,8 @@ export class ArduinoFrontendContribution
       if (event.newValue !== event.oldValue) {
         switch (event.preferenceName) {
           case 'arduino.language.log':
-            start(this.boardsServiceClientImpl.boardsConfig);
+          case 'arduino.language.realTimeDiagnostics':
+            start(this.boardsServiceClientImpl.boardsConfig, true);
             break;
           case 'arduino.window.zoomLevel':
             if (typeof event.newValue === 'number') {
@@ -344,7 +348,8 @@ export class ArduinoFrontendContribution
   protected languageServerStartMutex = new Mutex();
   protected async startLanguageServer(
     fqbn: string,
-    name: string | undefined
+    name: string | undefined,
+    forceStart = false
   ): Promise<void> {
     const port = await this.daemon.tryGetPort();
     if (!port) {
@@ -378,12 +383,15 @@ export class ArduinoFrontendContribution
         }
         return;
       }
-      if (fqbn === this.languageServerFqbn) {
+      if (!forceStart && fqbn === this.languageServerFqbn) {
         // NOOP
         return;
       }
       this.logger.info(`Starting language server: ${fqbn}`);
       const log = this.arduinoPreferences.get('arduino.language.log');
+      const realTimeDiagnostics = this.arduinoPreferences.get(
+        'arduino.language.realTimeDiagnostics'
+      );
       let currentSketchPath: string | undefined = undefined;
       if (log) {
         const currentSketch = await this.sketchServiceClient.currentSketch();
@@ -414,6 +422,7 @@ export class ArduinoFrontendContribution
             clangdPath,
             log: currentSketchPath ? currentSketchPath : log,
             cliDaemonInstance: '1',
+            realTimeDiagnostics,
             board: {
               fqbn,
               name: name ? `"${name}"` : undefined,

--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -51,6 +51,14 @@ export const ArduinoConfigSchema: PreferenceSchema = {
       ),
       default: false,
     },
+    'arduino.language.realTimeDiagnostics': {
+      type: 'boolean',
+      description: nls.localize(
+        'arduino/preferences/language.realTimeDiagnostics',
+        "If true, the language server provides real-time diagnostics when typing in the editor. It's false by default."
+      ),
+      default: false,
+    },
     'arduino.compile.verbose': {
       type: 'boolean',
       description: nls.localize(
@@ -238,6 +246,7 @@ export const ArduinoConfigSchema: PreferenceSchema = {
 
 export interface ArduinoConfiguration {
   'arduino.language.log': boolean;
+  'arduino.language.realTimeDiagnostics': boolean;
   'arduino.compile.verbose': boolean;
   'arduino.compile.experimental': boolean;
   'arduino.compile.revealRange': ErrorRevealStrategy;

--- a/arduino-ide-extension/src/browser/contributions/compiler-errors.ts
+++ b/arduino-ide-extension/src/browser/contributions/compiler-errors.ts
@@ -275,7 +275,7 @@ export class CompilerErrors
   }
 
   private async handleCompilerErrorsDidChange(
-    errors: CoreError.Compiler[]
+    errors: CoreError.ErrorLocation[]
   ): Promise<void> {
     this.toDisposeOnCompilerErrorDidChange.dispose();
     const compilerErrorsPerResource = this.groupByResource(
@@ -312,8 +312,8 @@ export class CompilerErrors
   }
 
   private async filter(
-    errors: CoreError.Compiler[]
-  ): Promise<CoreError.Compiler[]> {
+    errors: CoreError.ErrorLocation[]
+  ): Promise<CoreError.ErrorLocation[]> {
     if (!errors.length) {
       return [];
     }
@@ -326,7 +326,7 @@ export class CompilerErrors
   }
 
   private async decorateEditors(
-    errors: Map<string, CoreError.Compiler[]>
+    errors: Map<string, CoreError.ErrorLocation[]>
   ): Promise<{ dispose: Disposable; errors: ErrorDecoration[] }> {
     const composite = await Promise.all(
       [...errors.entries()].map(([uri, errors]) =>
@@ -346,7 +346,7 @@ export class CompilerErrors
 
   private async decorateEditor(
     uri: string,
-    errors: CoreError.Compiler[]
+    errors: CoreError.ErrorLocation[]
   ): Promise<{ dispose: Disposable; errors: ErrorDecoration[] }> {
     const editor = await this.editorManager.getByUri(new URI(uri));
     if (!editor) {
@@ -523,7 +523,7 @@ export class CompilerErrors
   }
 
   private async trackEditors(
-    errors: Map<string, CoreError.Compiler[]>,
+    errors: Map<string, CoreError.ErrorLocation[]>,
     ...track: ((editor: EditorWidget) => Disposable)[]
   ): Promise<Disposable> {
     return new DisposableCollection(
@@ -605,8 +605,8 @@ export class CompilerErrors
   }
 
   private groupByResource(
-    errors: CoreError.Compiler[]
-  ): Map<string, CoreError.Compiler[]> {
+    errors: CoreError.ErrorLocation[]
+  ): Map<string, CoreError.ErrorLocation[]> {
     return errors.reduce((acc, curr) => {
       const {
         location: { uri },
@@ -618,7 +618,7 @@ export class CompilerErrors
       }
       errors.push(curr);
       return acc;
-    }, new Map<string, CoreError.Compiler[]>());
+    }, new Map<string, CoreError.ErrorLocation[]>());
   }
 
   private monacoEditor(widget: EditorWidget): MonacoEditor | undefined;

--- a/arduino-ide-extension/src/browser/contributions/core-error-handler.ts
+++ b/arduino-ide-extension/src/browser/contributions/core-error-handler.ts
@@ -4,29 +4,29 @@ import { CoreError } from '../../common/protocol/core-service';
 
 @injectable()
 export class CoreErrorHandler {
-  private readonly compilerErrors: CoreError.Compiler[] = [];
+  private readonly errors: CoreError.ErrorLocation[] = [];
   private readonly compilerErrorsDidChangeEmitter = new Emitter<
-    CoreError.Compiler[]
+    CoreError.ErrorLocation[]
   >();
 
   tryHandle(error: unknown): void {
     if (CoreError.is(error)) {
-      this.compilerErrors.length = 0;
-      this.compilerErrors.push(...error.data.filter(CoreError.Compiler.is));
+      this.errors.length = 0;
+      this.errors.push(...error.data);
       this.fireCompilerErrorsDidChange();
     }
   }
 
   reset(): void {
-    this.compilerErrors.length = 0;
+    this.errors.length = 0;
     this.fireCompilerErrorsDidChange();
   }
 
-  get onCompilerErrorsDidChange(): Event<CoreError.Compiler[]> {
+  get onCompilerErrorsDidChange(): Event<CoreError.ErrorLocation[]> {
     return this.compilerErrorsDidChangeEmitter.event;
   }
 
   private fireCompilerErrorsDidChange(): void {
-    this.compilerErrorsDidChangeEmitter.fire(this.compilerErrors.slice());
+    this.compilerErrorsDidChangeEmitter.fire(this.errors.slice());
   }
 }

--- a/arduino-ide-extension/src/common/protocol/core-service.ts
+++ b/arduino-ide-extension/src/common/protocol/core-service.ts
@@ -5,7 +5,6 @@ import type {
   BoardUserField,
   Port,
 } from '../../common/protocol/boards-service';
-import type { ErrorInfo as CliErrorInfo } from '../../node/cli-error-parser';
 import type { Programmer } from './boards-service';
 import type { Sketch } from './sketches-service';
 
@@ -17,16 +16,10 @@ export const CompilerWarningLiterals = [
 ] as const;
 export type CompilerWarnings = typeof CompilerWarningLiterals[number];
 export namespace CoreError {
-  export type ErrorInfo = CliErrorInfo;
-  export interface Compiler extends ErrorInfo {
+  export interface ErrorLocation {
     readonly message: string;
     readonly location: Location;
-  }
-  export namespace Compiler {
-    export function is(error: ErrorInfo): error is Compiler {
-      const { message, location } = error;
-      return !!message && !!location;
-    }
+    readonly details?: string;
   }
   export const Codes = {
     Verify: 4001,
@@ -42,7 +35,7 @@ export namespace CoreError {
   export const BurnBootloaderFailed = create(Codes.BurnBootloader);
   export function is(
     error: unknown
-  ): error is ApplicationError<number, ErrorInfo[]> {
+  ): error is ApplicationError<number, ErrorLocation[]> {
     return (
       error instanceof Error &&
       ApplicationError.is(error) &&
@@ -51,10 +44,10 @@ export namespace CoreError {
   }
   function create(
     code: number
-  ): ApplicationError.Constructor<number, ErrorInfo[]> {
+  ): ApplicationError.Constructor<number, ErrorLocation[]> {
     return ApplicationError.declare(
       code,
-      (message: string, data: ErrorInfo[]) => {
+      (message: string, data: ErrorLocation[]) => {
         return {
           data,
           message,

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.d.ts
@@ -95,6 +95,9 @@ export class CompileRequest extends jspb.Message {
     getEncryptKey(): string;
     setEncryptKey(value: string): CompileRequest;
 
+    getSkipLibrariesDiscovery(): boolean;
+    setSkipLibrariesDiscovery(value: boolean): CompileRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): CompileRequest.AsObject;
@@ -133,6 +136,7 @@ export namespace CompileRequest {
         keysKeychain: string,
         signKey: string,
         encryptKey: string,
+        skipLibrariesDiscovery: boolean,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.js
@@ -149,7 +149,8 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.toObject = function(includeInsta
     libraryList: (f = jspb.Message.getRepeatedField(msg, 24)) == null ? undefined : f,
     keysKeychain: jspb.Message.getFieldWithDefault(msg, 25, ""),
     signKey: jspb.Message.getFieldWithDefault(msg, 26, ""),
-    encryptKey: jspb.Message.getFieldWithDefault(msg, 27, "")
+    encryptKey: jspb.Message.getFieldWithDefault(msg, 27, ""),
+    skipLibrariesDiscovery: jspb.Message.getBooleanFieldWithDefault(msg, 28, false)
   };
 
   if (includeInstance) {
@@ -285,6 +286,10 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.deserializeBinaryFromReader = fu
     case 27:
       var value = /** @type {string} */ (reader.readString());
       msg.setEncryptKey(value);
+      break;
+    case 28:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setSkipLibrariesDiscovery(value);
       break;
     default:
       reader.skipField();
@@ -479,6 +484,13 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.serializeBinaryToWriter = functi
   if (f.length > 0) {
     writer.writeString(
       27,
+      f
+    );
+  }
+  f = message.getSkipLibrariesDiscovery();
+  if (f) {
+    writer.writeBool(
+      28,
       f
     );
   }
@@ -1013,6 +1025,24 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.getEncryptKey = functi
  */
 proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.setEncryptKey = function(value) {
   return jspb.Message.setProto3StringField(this, 27, value);
+};
+
+
+/**
+ * optional bool skip_libraries_discovery = 28;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.getSkipLibrariesDiscovery = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 28, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.CompileRequest} returns this
+ */
+proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.setSkipLibrariesDiscovery = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 28, value);
 };
 
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.d.ts
@@ -26,6 +26,9 @@ export class PlatformInstallRequest extends jspb.Message {
     getSkipPostInstall(): boolean;
     setSkipPostInstall(value: boolean): PlatformInstallRequest;
 
+    getNoOverwrite(): boolean;
+    setNoOverwrite(value: boolean): PlatformInstallRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): PlatformInstallRequest.AsObject;
@@ -44,6 +47,7 @@ export namespace PlatformInstallRequest {
         architecture: string,
         version: string,
         skipPostInstall: boolean,
+        noOverwrite: boolean,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.js
@@ -339,7 +339,8 @@ proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.toObject = function(incl
     platformPackage: jspb.Message.getFieldWithDefault(msg, 2, ""),
     architecture: jspb.Message.getFieldWithDefault(msg, 3, ""),
     version: jspb.Message.getFieldWithDefault(msg, 4, ""),
-    skipPostInstall: jspb.Message.getBooleanFieldWithDefault(msg, 5, false)
+    skipPostInstall: jspb.Message.getBooleanFieldWithDefault(msg, 5, false),
+    noOverwrite: jspb.Message.getBooleanFieldWithDefault(msg, 6, false)
   };
 
   if (includeInstance) {
@@ -396,6 +397,10 @@ proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.deserializeBinaryFromRea
     case 5:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setSkipPostInstall(value);
+      break;
+    case 6:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setNoOverwrite(value);
       break;
     default:
       reader.skipField();
@@ -459,6 +464,13 @@ proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.serializeBinaryToWriter 
   if (f) {
     writer.writeBool(
       5,
+      f
+    );
+  }
+  f = message.getNoOverwrite();
+  if (f) {
+    writer.writeBool(
+      6,
       f
     );
   }
@@ -571,6 +583,24 @@ proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.prototype.getSkipPostIns
  */
 proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.prototype.setSkipPostInstall = function(value) {
   return jspb.Message.setProto3BooleanField(this, 5, value);
+};
+
+
+/**
+ * optional bool no_overwrite = 6;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.prototype.getNoOverwrite = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 6, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.PlatformInstallRequest} returns this
+ */
+proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.prototype.setNoOverwrite = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 6, value);
 };
 
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.d.ts
@@ -79,6 +79,9 @@ export class LibraryInstallRequest extends jspb.Message {
     getNoDeps(): boolean;
     setNoDeps(value: boolean): LibraryInstallRequest;
 
+    getNoOverwrite(): boolean;
+    setNoOverwrite(value: boolean): LibraryInstallRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): LibraryInstallRequest.AsObject;
@@ -96,6 +99,7 @@ export namespace LibraryInstallRequest {
         name: string,
         version: string,
         noDeps: boolean,
+        noOverwrite: boolean,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.js
@@ -967,7 +967,8 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.toObject = function(inclu
     instance: (f = msg.getInstance()) && cc_arduino_cli_commands_v1_common_pb.Instance.toObject(includeInstance, f),
     name: jspb.Message.getFieldWithDefault(msg, 2, ""),
     version: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    noDeps: jspb.Message.getBooleanFieldWithDefault(msg, 4, false)
+    noDeps: jspb.Message.getBooleanFieldWithDefault(msg, 4, false),
+    noOverwrite: jspb.Message.getBooleanFieldWithDefault(msg, 5, false)
   };
 
   if (includeInstance) {
@@ -1020,6 +1021,10 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.deserializeBinaryFromRead
     case 4:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setNoDeps(value);
+      break;
+    case 5:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setNoOverwrite(value);
       break;
     default:
       reader.skipField();
@@ -1076,6 +1081,13 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.serializeBinaryToWriter =
   if (f) {
     writer.writeBool(
       4,
+      f
+    );
+  }
+  f = message.getNoOverwrite();
+  if (f) {
+    writer.writeBool(
+      5,
       f
     );
   }
@@ -1170,6 +1182,24 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.getNoDeps = fun
  */
 proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.setNoDeps = function(value) {
   return jspb.Message.setProto3BooleanField(this, 4, value);
+};
+
+
+/**
+ * optional bool no_overwrite = 5;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.getNoOverwrite = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 5, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.LibraryInstallRequest} returns this
+ */
+proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.setNoOverwrite = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 5, value);
 };
 
 

--- a/electron/build/template-package.json
+++ b/electron/build/template-package.json
@@ -141,7 +141,7 @@
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
     "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.52.1/file/vscode.cpp-1.52.1.vsix",
-    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.0.2-beta.3.vsix",
+    "vscode-arduino-tools": "https://github.com/kittaakos/vscode-arduino-tools/raw/realTimeDiagnostics/build-artifacts/vscode-arduino-tools-0.0.2-beta.3.vsix",
     "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.46.1/file/vscode.json-1.46.1.vsix",
     "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "cortex-debug": "https://open-vsx.org/api/marus25/cortex-debug/0.3.10/file/marus25.cortex-debug-0.3.10.vsix",

--- a/electron/build/template-package.json
+++ b/electron/build/template-package.json
@@ -141,7 +141,7 @@
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
     "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.52.1/file/vscode.cpp-1.52.1.vsix",
-    "vscode-arduino-tools": "https://github.com/kittaakos/vscode-arduino-tools/raw/realTimeDiagnostics/build-artifacts/vscode-arduino-tools-0.0.2-beta.3.vsix",
+    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.0.2-beta.4.vsix",
     "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.46.1/file/vscode.json-1.46.1.vsix",
     "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "cortex-debug": "https://open-vsx.org/api/marus25/cortex-debug/0.3.10/file/marus25.cortex-debug-0.3.10.vsix",

--- a/electron/build/template-package.json
+++ b/electron/build/template-package.json
@@ -141,7 +141,7 @@
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
     "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.52.1/file/vscode.cpp-1.52.1.vsix",
-    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.0.2-beta.2.vsix",
+    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.0.2-beta.3.vsix",
     "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.46.1/file/vscode.json-1.46.1.vsix",
     "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "cortex-debug": "https://open-vsx.org/api/marus25/cortex-debug/0.3.10/file/marus25.cortex-debug-0.3.10.vsix",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -269,6 +269,7 @@
       "invalid.sketchbook.location": "Invalid sketchbook location: {0}",
       "invalid.theme": "Invalid theme.",
       "language.log": "True if the Arduino Language Server should generate log files into the sketch folder. Otherwise, false. It's false by default.",
+      "language.realTimeDiagnostics": "If true, the language server provides real-time diagnostics when typing in the editor. It's false by default.",
       "manualProxy": "Manual proxy configuration",
       "network": "Network",
       "newSketchbookLocation": "Select new sketchbook location",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
     "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.52.1/file/vscode.cpp-1.52.1.vsix",
-    "vscode-arduino-tools": "https://github.com/kittaakos/vscode-arduino-tools/raw/realTimeDiagnostics/build-artifacts/vscode-arduino-tools-0.0.2-beta.3.vsix",
+    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.0.2-beta.4.vsix",
     "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.46.1/file/vscode.json-1.46.1.vsix",
     "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "cortex-debug": "https://open-vsx.org/api/marus25/cortex-debug/0.3.10/file/marus25.cortex-debug-0.3.10.vsix",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
     "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.52.1/file/vscode.cpp-1.52.1.vsix",
-    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.0.2-beta.2.vsix",
+    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.0.2-beta.3.vsix",
     "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.46.1/file/vscode.json-1.46.1.vsix",
     "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "cortex-debug": "https://open-vsx.org/api/marus25/cortex-debug/0.3.10/file/marus25.cortex-debug-0.3.10.vsix",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
     "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.52.1/file/vscode.cpp-1.52.1.vsix",
-    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.0.2-beta.3.vsix",
+    "vscode-arduino-tools": "https://github.com/kittaakos/vscode-arduino-tools/raw/realTimeDiagnostics/build-artifacts/vscode-arduino-tools-0.0.2-beta.3.vsix",
     "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.46.1/file/vscode.json-1.46.1.vsix",
     "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "cortex-debug": "https://open-vsx.org/api/marus25/cortex-debug/0.3.10/file/marus25.cortex-debug-0.3.10.vsix",


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
Avoid reindexing libraries on every single text document change event.

### Change description
<!-- What does your code do? -->

After a verify (both success and failure), the IDE2 calls the `arduino.languageserver.notifyBuildDidComplete` command (exposed by the VS Code extension) and pushes the most recent [`build_path`](https://github.com/arduino/arduino-cli/blob/63b53c0fa6830ce77cfb5508f06b2b4e601c90b5/rpc/cc/arduino/cli/commands/v1/compile.proto#L44) to the LS via the custom `ino/buildDidComplete` JSON-RPC.

 - Use `0.25.0-rc1` CLI,
 - Use `0.0.2-beta.4` VS Code extension, and
 - Use `0.7.1` Arduino LS

Dev:
 - Updated the build scripts; can build the LS from sources besides downloading it from S3 or GH.

### Other information
<!-- Any additional information that could help the review process -->

#714 

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)