### PR TITLE
Only run "Arduino IDE" workflow on relevant changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,10 +4,26 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '.github/**'
+      - '!.github/workflows/build.yml'
+      - '.vscode/**'
+      - 'docs/**'
+      - 'scripts/**'
+      - 'static/**'
+      - '*.md'
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - '.github/**'
+      - '!.github/workflows/build.yml'
+      - '.vscode/**'
+      - 'docs/**'
+      - 'scripts/**'
+      - 'static/**'
+      - '*.md'
   schedule:
     - cron: '0 3 * * *' # run every day at 3AM (https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
 


### PR DESCRIPTION
### Note to reviewers

I have added filters for the irrelevant paths I am aware of. Since I am not deeply familiar with the internal workings of the project, it is possible other paths in the repository could also be filtered to achieve even higher levels of efficiency. If you have any suggestions, I would be happy to add them.

---

The ["Arduino IDE" workflow](https://github.com/arduino/arduino-ide/actions/workflows/build.yml) performs the following operations when triggered on push and pull request [events](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows):

- Build application
- Lint code
- Run tests
- Produce tester packages

All of these operations are specific to the TypeScript/JavaScript code base and its infrastructure.

Previously, the workflow ran whenever any file in the repository was changed. This includes files that have no relevance to the operations performed, meaning the workflow runs triggered by changes to those files alone were pointless. In addition to general inefficiency, these lengthy and sometimes spuriously failing unnecessary workflow runs might cause delay or confusion to both the contributors and maintainers for what would otherwise be a simple process.

GitHub Actions provides the ability to configure path [filters](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-filters) for the workflow triggers. The workflow will only run on events that change files satisfying these path filters. [This is "AND"ed with the `branches` filters](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore), meaning the existing restrictions on which branches produce a run remain unchanged. The `tags` filter is independent from the `paths` and `branches` filters, meaning the added path filters don't make any change to which tag push events will trigger the workflow.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)