### PR TITLE
Run "Arduino IDE" workflow on pull requests with any base branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
   pull_request:
-    branches:
-      - main
   schedule:
     - cron: '0 3 * * *' # run every day at 3AM (https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
 


### PR DESCRIPTION
Contributors may submit pull requests against development branches in the repository for either of the following valid reasons:

- Propose changes to a previous proposal, either while it is still in development, or else in the case where the changes are more complex/extensive than can be efficiently proposed via the PR review framework.
- The proposal is dependent on work from an unmerged PR.

Previously, [the "Arduino IDE" GitHub Actions workflow](https://github.com/arduino/arduino-ide/actions/workflows/build.yml) was unnecessarily [configured](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpull_requestpull_request_targetbranchesbranches-ignore) to only run for PRs based on the `main` branch. This meant that validation and tester builds were not provided for the PRs based on other branches.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)