### PR TITLE
Remove tabs context menu

### DIFF
--- a/arduino-ide-extension/src/browser/theia/core/tab-bars.ts
+++ b/arduino-ide-extension/src/browser/theia/core/tab-bars.ts
@@ -10,4 +10,9 @@ export class TabBarRenderer extends TheiaTabBarRenderer {
     }
     return className;
   }
+
+  protected override handleContextMenuEvent = (): void => {
+    // NOOP
+    // Context menus are empty, so they have been removed
+  };
 }


### PR DESCRIPTION
### Motivation
Editor tabs context menus are empty and, as reported in #1127, they should be removed.

### Change description
No operation is performed by right-clicking a tab in the editor.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)