### PR TITLE
#1015: Sketchbook handles more than two tree levels.

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -49,7 +49,8 @@
             "strings": false
           },
           "breadcrumbs.enabled": false,
-          "workbench.tree.renderIndentGuides": "none" 
+          "workbench.tree.renderIndentGuides": "none",
+          "explorer.compactFolders": false
         }
       }
     },


### PR DESCRIPTION
### Motivation
IDE2 should show nested sketches.

### Change description
Use a default `false` value for the `explorer.compactFolders` preference.
Ref: https://code.visualstudio.com/updates/v1_41#_compact-folders-in-explorer

### Other information

In action:

https://user-images.githubusercontent.com/1405703/177181877-1c2c23e1-2cba-4963-92c0-96be72be8a47.mp4




Closes #1015.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)