### PR TITLE
Increase sketchbook tree indentation to reflect design system

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
@@ -28,7 +28,7 @@ import { nls } from '@theia/core/lib/common';
 
 const customTreeProps: TreeProps = {
   leftPadding: 20,
-  expansionTogglePadding: 6,
+  expansionTogglePadding: 12,
 };
 
 @injectable()

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
@@ -27,8 +27,8 @@ import { Sketch } from '../../contributions/contribution';
 import { nls } from '@theia/core/lib/common';
 
 const customTreeProps: TreeProps = {
-  leftPadding: 20,
-  expansionTogglePadding: 12,
+  leftPadding: 26,
+  expansionTogglePadding: 6,
 };
 
 @injectable()


### PR DESCRIPTION
### Motivation
The indentation of the sketchbook tree must be increased even more in order to reflect the design system.

### Change description
Increase the padding.

Before:
![Screenshot 2022-07-05 110725](https://user-images.githubusercontent.com/94986937/177293378-e684da6a-7243-401b-be92-16d4a4d1991f.png)

After:
![Screenshot 2022-07-05 111227](https://user-images.githubusercontent.com/94986937/177294015-7f515f39-4745-46be-8b10-2d625e830fd1.png)


### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)