### PR TITLE
Increase space between input and controls in dialogs

### DIFF
--- a/arduino-ide-extension/src/browser/style/dialogs.css
+++ b/arduino-ide-extension/src/browser/style/dialogs.css
@@ -30,7 +30,7 @@
     padding: 0;
 }
 
-.p-Widget.dialogOverlay .dialogBlock .dialogContent input {
+.p-Widget.dialogOverlay .dialogBlock .dialogContent > input {
     margin-bottom: 28px;
 }
 


### PR DESCRIPTION
### Motivation
In dialogs with input the controls are not far enough from the input bar.

![Screenshot 2022-07-08 131417](https://user-images.githubusercontent.com/94986937/177981938-94f3ca21-0ff9-4110-ad64-b8c04e47c90f.png)

### Change description
Bottom margin of the input increased.

![Screenshot 2022-07-08 131243](https://user-images.githubusercontent.com/94986937/177982086-9fe83cd5-e610-4040-9171-1adab42563e8.png)

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)