### PR TITLE
#1161: Fixed missing core client in the monitor service.

### DIFF
--- a/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
+++ b/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
@@ -245,7 +245,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
         const webSocketProvider =
           container.get<WebSocketProvider>(WebSocketProvider);
 
-        const { board, port, monitorID } = options;
+        const { board, port, coreClientProvider, monitorID } = options;
 
         return new MonitorService(
           logger,
@@ -253,6 +253,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
           webSocketProvider,
           board,
           port,
+          coreClientProvider,
           monitorID
         );
       }

--- a/arduino-ide-extension/src/node/core-client-provider.ts
+++ b/arduino-ide-extension/src/node/core-client-provider.ts
@@ -397,7 +397,7 @@ export namespace CoreClientProvider {
 @injectable()
 export abstract class CoreClientAware {
   @inject(CoreClientProvider)
-  private readonly coreClientProvider: CoreClientProvider;
+  protected readonly coreClientProvider: CoreClientProvider; // TODO: should be `private`, fix injection in subclasses. (https://github.com/arduino/arduino-ide/issues/1161)
   /**
    * Returns with a promise that resolves when the core client is initialized and ready.
    */

--- a/arduino-ide-extension/src/node/monitor-manager.ts
+++ b/arduino-ide-extension/src/node/monitor-manager.ts
@@ -55,7 +55,7 @@ export class MonitorManager extends CoreClientAware {
    * @param board board connected to port
    * @param port port to monitor
    * @returns true if the monitor is currently monitoring the board/port
-   * combination specifed, false in all other cases.
+   * combination specified, false in all other cases.
    */
   isStarted(board: Board, port: Port): boolean {
     const monitorID = this.monitorID(board, port);
@@ -317,6 +317,7 @@ export class MonitorManager extends CoreClientAware {
       board,
       port,
       monitorID,
+      coreClientProvider: this.coreClientProvider,
     });
     this.monitorServices.set(monitorID, monitor);
     monitor.onDispose(

--- a/arduino-ide-extension/src/node/monitor-service-factory.ts
+++ b/arduino-ide-extension/src/node/monitor-service-factory.ts
@@ -1,13 +1,20 @@
 import { Board, Port } from '../common/protocol';
+import { CoreClientProvider } from './core-client-provider';
 import { MonitorService } from './monitor-service';
 
 export const MonitorServiceFactory = Symbol('MonitorServiceFactory');
 export interface MonitorServiceFactory {
-  (options: { board: Board; port: Port; monitorID: string }): MonitorService;
+  (options: {
+    board: Board;
+    port: Port;
+    monitorID: string;
+    coreClientProvider: CoreClientProvider;
+  }): MonitorService;
 }
 
 export interface MonitorServiceFactoryOptions {
   board: Board;
   port: Port;
   monitorID: string;
+  coreClientProvider: CoreClientProvider;
 }

--- a/arduino-ide-extension/src/node/monitor-service.ts
+++ b/arduino-ide-extension/src/node/monitor-service.ts
@@ -10,7 +10,7 @@ import {
   MonitorRequest,
   MonitorResponse,
 } from './cli-protocol/cc/arduino/cli/commands/v1/monitor_pb';
-import { CoreClientAware } from './core-client-provider';
+import { CoreClientAware, CoreClientProvider } from './core-client-provider';
 import { WebSocketProvider } from './web-socket/web-socket-provider';
 import { Port as gRPCPort } from 'arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/port_pb';
 import {
@@ -77,6 +77,7 @@ export class MonitorService extends CoreClientAware implements Disposable {
 
     private readonly board: Board,
     private readonly port: Port,
+    protected override readonly coreClientProvider: CoreClientProvider,
     private readonly monitorID: string
   ) {
     super();


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To fix non-functional monitor in IDE2.

### Change description
<!-- What does your code do? -->

Restored monitor service creation state before a36524e:
Pass core client-provider into new instances as a field.

This PR restores the state of the following files before https://github.com/arduino/arduino-ide/pull/1132:
 - `arduino-ide-extension/src/node/monitor-manager.ts` (changes from breaking PR [here](https://github.com/arduino/arduino-ide/pull/1132/files#diff-cf90510ad3f811b7073a1934f11698463693bf446a2521eb2a55f27a48328427)),
 - `arduino-ide-extension/src/node/monitor-service-factory.ts` ([here](https://github.com/arduino/arduino-ide/pull/1132/files#diff-cf90510ad3f811b7073a1934f11698463693bf446a2521eb2a55f27a48328427)),
 - `arduino-ide-extension/src/node/monitor-service.ts` ([here](https://github.com/arduino/arduino-ide/pull/1132/files#diff-a8376e8868924af4420dee72fdc9b0aad60936adef6edcd13105302ff45ac831)),
 - `arduino-ide-extension/src/node/arduino-ide-backend-module.ts`: ([here](https://github.com/arduino/arduino-ide/pull/1132/files#diff-5b5ca93308d4c7f39d0f257776642b9d4ffcb6cea004348a4c5ead373357bf86))

### Other information
<!-- Any additional information that could help the review process -->

Closes #1161

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)