### PR TITLE
Let DI framework create `MonitorService` instances

### DIFF
--- a/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
+++ b/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
@@ -236,26 +236,14 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(MonitorServiceFactory).toFactory(
     ({ container }) =>
       (options: MonitorServiceFactoryOptions) => {
-        const logger = container.get<ILogger>(ILogger);
-
-        const monitorSettingsProvider = container.get<MonitorSettingsProvider>(
-          MonitorSettingsProvider
-        );
-
-        const webSocketProvider =
-          container.get<WebSocketProvider>(WebSocketProvider);
-
-        const { board, port, coreClientProvider, monitorID } = options;
-
-        return new MonitorService(
-          logger,
-          monitorSettingsProvider,
-          webSocketProvider,
-          board,
-          port,
-          coreClientProvider,
-          monitorID
-        );
+        const child = container.createChild();
+        child
+          .bind<MonitorServiceFactoryOptions>(MonitorServiceFactoryOptions)
+          .toConstantValue({
+            ...options,
+          });
+        child.bind(MonitorService).toSelf();
+        return child.get<MonitorService>(MonitorService);
       }
   );
 

--- a/arduino-ide-extension/src/node/core-client-provider.ts
+++ b/arduino-ide-extension/src/node/core-client-provider.ts
@@ -397,7 +397,7 @@ export namespace CoreClientProvider {
 @injectable()
 export abstract class CoreClientAware {
   @inject(CoreClientProvider)
-  protected readonly coreClientProvider: CoreClientProvider; // TODO: should be `private`, fix injection in subclasses. (https://github.com/arduino/arduino-ide/issues/1161)
+  private readonly coreClientProvider: CoreClientProvider;
   /**
    * Returns with a promise that resolves when the core client is initialized and ready.
    */

--- a/arduino-ide-extension/src/node/monitor-manager.ts
+++ b/arduino-ide-extension/src/node/monitor-manager.ts
@@ -317,7 +317,6 @@ export class MonitorManager extends CoreClientAware {
       board,
       port,
       monitorID,
-      coreClientProvider: this.coreClientProvider,
     });
     this.monitorServices.set(monitorID, monitor);
     monitor.onDispose(

--- a/arduino-ide-extension/src/node/monitor-service-factory.ts
+++ b/arduino-ide-extension/src/node/monitor-service-factory.ts
@@ -1,20 +1,16 @@
-import { Board, Port } from '../common/protocol';
-import { CoreClientProvider } from './core-client-provider';
-import { MonitorService } from './monitor-service';
+import type { Board, Port } from '../common/protocol';
+import type { MonitorService } from './monitor-service';
 
 export const MonitorServiceFactory = Symbol('MonitorServiceFactory');
 export interface MonitorServiceFactory {
-  (options: {
-    board: Board;
-    port: Port;
-    monitorID: string;
-    coreClientProvider: CoreClientProvider;
-  }): MonitorService;
+  (options: MonitorServiceFactoryOptions): MonitorService;
 }
 
+export const MonitorServiceFactoryOptions = Symbol(
+  'MonitorServiceFactoryOptions'
+);
 export interface MonitorServiceFactoryOptions {
   board: Board;
   port: Port;
   monitorID: string;
-  coreClientProvider: CoreClientProvider;
 }


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Let the dependency injection framework create the service instances. This PR is a dev thing only and the follow-up of #1162.

### Change description
 - Reduced the visibility of the `coreClientProvider` field to `private`,
 - Inject `MonitorServiceFactoryOptions` into the `MonitorService` instances,
 - Removed `coreClientProvider` field from the `MonitorServiceFactoryOptions`. The DI will take care of injecting props from superclasses.

### Other information

The monitor functionality must be the same as on the `main`. The PR is a dev-only thing; expect no behavioral changes.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)