### PR TITLE
Restart discovery after re-initializing client.

### DIFF
--- a/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
+++ b/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
@@ -203,6 +203,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
   // Shared port/board discovery for the server
   bind(BoardDiscovery).toSelf().inSingletonScope();
+  bind(BackendApplicationContribution).toService(BoardDiscovery);
 
   // Core service -> `verify` and `upload`. Singleton per BE, each FE connection gets its proxy.
   bind(ConnectionContainerModule).toConstantValue(
@@ -350,10 +351,10 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(ILogger)
     .toDynamicValue((ctx) => {
       const parentLogger = ctx.container.get<ILogger>(ILogger);
-      return parentLogger.child('discovery');
+      return parentLogger.child('discovery-log'); // TODO: revert
     })
     .inSingletonScope()
-    .whenTargetNamed('discovery');
+    .whenTargetNamed('discovery-log'); // TODO: revert
 
   // Logger for the CLI config service. From the CLI config (FS path aware), we make a URI-aware app config.
   bind(ILogger)

--- a/arduino-ide-extension/src/node/board-discovery.ts
+++ b/arduino-ide-extension/src/node/board-discovery.ts
@@ -56,6 +56,11 @@ export class BoardDiscovery extends CoreClientAware {
   @postConstruct()
   protected async init(): Promise<void> {
     this.coreClient.then((client) => this.startBoardListWatch(client));
+    this.onClientDidRefresh((client) =>
+      this.stopBoardListWatch(client).then(() =>
+        this.startBoardListWatch(client)
+      )
+    );
   }
 
   stopBoardListWatch(coreClient: CoreClientProvider.Client): Promise<void> {
@@ -79,7 +84,7 @@ export class BoardDiscovery extends CoreClientAware {
   startBoardListWatch(coreClient: CoreClientProvider.Client): void {
     if (this.watching) {
       // We want to avoid starting the board list watch process multiple
-      // times to meet unforseen consequences
+      // times to meet unforeseen consequences
       return;
     }
     this.watching = true;

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -414,7 +414,7 @@ export class BoardsServiceImpl
     console.info('>>> Starting boards package installation...', item);
 
     // stop the board discovery
-    await this.boardDiscovery.stopBoardListWatch(coreClient);
+    await this.boardDiscovery.stop();
 
     const resp = client.platformInstall(req);
     resp.on(
@@ -426,7 +426,7 @@ export class BoardsServiceImpl
     );
     await new Promise<void>((resolve, reject) => {
       resp.on('end', () => {
-        this.boardDiscovery.startBoardListWatch(coreClient);
+        this.boardDiscovery.start(); // TODO: remove discovery dependency from boards service. See https://github.com/arduino/arduino-ide/pull/1107 why this is here.
         resolve();
       });
       resp.on('error', (error) => {
@@ -465,7 +465,7 @@ export class BoardsServiceImpl
     console.info('>>> Starting boards package uninstallation...', item);
 
     // stop the board discovery
-    await this.boardDiscovery.stopBoardListWatch(coreClient);
+    await this.boardDiscovery.stop();
 
     const resp = client.platformUninstall(req);
     resp.on(
@@ -477,7 +477,7 @@ export class BoardsServiceImpl
     );
     await new Promise<void>((resolve, reject) => {
       resp.on('end', () => {
-        this.boardDiscovery.startBoardListWatch(coreClient);
+        this.boardDiscovery.start(); // TODO: remove discovery dependency from boards service. See https://github.com/arduino/arduino-ide/pull/1107 why this is here.
         resolve();
       });
       resp.on('error', reject);

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -60,7 +60,7 @@ export class BoardsServiceImpl
   protected readonly boardDiscovery: BoardDiscovery;
 
   async getState(): Promise<AvailablePorts> {
-    return this.boardDiscovery.state;
+    return this.boardDiscovery.availablePorts;
   }
 
   async getAttachedBoards(): Promise<Board[]> {

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -1,4 +1,4 @@
-import { injectable, inject, named } from '@theia/core/shared/inversify';
+import { injectable, inject } from '@theia/core/shared/inversify';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { notEmpty } from '@theia/core/lib/common/objects';
 import {
@@ -49,10 +49,6 @@ export class BoardsServiceImpl
 {
   @inject(ILogger)
   protected logger: ILogger;
-
-  @inject(ILogger)
-  @named('discovery')
-  protected discoveryLogger: ILogger;
 
   @inject(ResponseService)
   protected readonly responseService: ResponseService;

--- a/arduino-ide-extension/src/node/library-service-impl.ts
+++ b/arduino-ide-extension/src/node/library-service-impl.ts
@@ -269,7 +269,7 @@ export class LibraryServiceImpl
     console.info('>>> Starting library package installation...', item);
 
     // stop the board discovery
-    await this.boardDiscovery.stopBoardListWatch(coreClient);
+    await this.boardDiscovery.stop();
 
     const resp = client.libraryInstall(req);
     resp.on(
@@ -281,7 +281,7 @@ export class LibraryServiceImpl
     );
     await new Promise<void>((resolve, reject) => {
       resp.on('end', () => {
-        this.boardDiscovery.startBoardListWatch(coreClient);
+        this.boardDiscovery.start(); // TODO: remove discovery dependency from boards service. See https://github.com/arduino/arduino-ide/pull/1107 why this is here.
         resolve();
       });
       resp.on('error', (error) => {
@@ -323,7 +323,7 @@ export class LibraryServiceImpl
     }
 
     // stop the board discovery
-    await this.boardDiscovery.stopBoardListWatch(coreClient);
+    await this.boardDiscovery.stop();
 
     const resp = client.zipLibraryInstall(req);
     resp.on(
@@ -335,7 +335,7 @@ export class LibraryServiceImpl
     );
     await new Promise<void>((resolve, reject) => {
       resp.on('end', () => {
-        this.boardDiscovery.startBoardListWatch(coreClient);
+        this.boardDiscovery.start(); // TODO: remove discovery dependency from boards service. See https://github.com/arduino/arduino-ide/pull/1107 why this is here.
         resolve();
       });
       resp.on('error', reject);
@@ -358,7 +358,7 @@ export class LibraryServiceImpl
     console.info('>>> Starting library package uninstallation...', item);
 
     // stop the board discovery
-    await this.boardDiscovery.stopBoardListWatch(coreClient);
+    await this.boardDiscovery.stop();
 
     const resp = client.libraryUninstall(req);
     resp.on(
@@ -370,7 +370,7 @@ export class LibraryServiceImpl
     );
     await new Promise<void>((resolve, reject) => {
       resp.on('end', () => {
-        this.boardDiscovery.startBoardListWatch(coreClient);
+        this.boardDiscovery.start(); // TODO: remove discovery dependency from boards service. See https://github.com/arduino/arduino-ide/pull/1107 why this is here.
         resolve();
       });
       resp.on('error', reject);

--- a/arduino-ide-extension/src/node/service-error.ts
+++ b/arduino-ide-extension/src/node/service-error.ts
@@ -2,6 +2,9 @@ import { Metadata, StatusObject } from '@grpc/grpc-js';
 
 export type ServiceError = StatusObject & Error;
 export namespace ServiceError {
+  export function isCancel(arg: unknown): arg is ServiceError & { code: 1 } {
+    return is(arg) && arg.code === 1; // https://grpc.github.io/grpc/core/md_doc_statuscodes.html
+  }
   export function is(arg: unknown): arg is ServiceError {
     return arg instanceof Error && isStatusObjet(arg);
   }


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Before #1132 the core gRPC client was not re-initialized (`InitRequest`) after the indexes update. Hence; the CLI could not provide up-to-date `core search` results to the IDE2. Now, it is working in IDE2 but after the core gRPC re-initialization, the board discovery (`BoardListWatchRequest`) is non-functional. This PR fixes it by sending out an event after the core client re-initialization so that the board discovery can restart in IDE2.

From [here](https://github.com/arduino/arduino-cli/pull/1274#issue-866154638):

> The `Rescan` gRPC function has been removed completely in favour of `Init`.
> 
> `UpdateIndex` and `UpdateLibrariesIndex` gRPC functions now don't implicitly reload the indexes, it has to be done explicitly with the `Init` function.

How to test:
 - start IDE2,
 - make sure you have at least one 3rd party URL in the _Settings_,
 - after the indexes update progress notification, try to attach and detach boards, the IDE2 should show the attached boards. This is not working on the `main` with f4a68e7.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)