### PR TITLE
Prevent overwriting existing libraries and platforms at first IDE start-up

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -155,7 +155,11 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.24.0"
+      "version": {
+        "owner": "arduino",
+        "repo": "arduino-cli",
+        "commitish": "ffe4232b359fcfa87238d68acf1c3b64a1621f14"  
+      }
     },
     "fwuploader": {
       "version": "2.2.0"

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -155,11 +155,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": {
-        "owner": "arduino",
-        "repo": "arduino-cli",
-        "commitish": "ffe4232b359fcfa87238d68acf1c3b64a1621f14"  
-      }
+      "version": "0.25.0-rc1"
     },
     "fwuploader": {
       "version": "2.2.0"

--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -10,7 +10,6 @@ import {
   SketchesService,
   ExecutableService,
   Sketch,
-  LibraryService,
   ArduinoDaemon,
 } from '../common/protocol';
 import { Mutex } from 'async-mutex';
@@ -77,7 +76,6 @@ import { IDEUpdater } from '../common/protocol/ide-updater';
 import { FileSystemFrontendContribution } from '@theia/filesystem/lib/browser/filesystem-frontend-contribution';
 import { HostedPluginEvents } from './hosted-plugin-events';
 
-const INIT_LIBS_AND_PACKAGES = 'initializedLibsAndPackages';
 export const SKIP_IDE_VERSION = 'skipIDEVersion';
 
 @injectable()
@@ -97,9 +95,6 @@ export class ArduinoFrontendContribution
 
   @inject(BoardsService)
   private readonly boardsService: BoardsService;
-
-  @inject(LibraryService)
-  private readonly libraryService: LibraryService;
 
   @inject(BoardsServiceProvider)
   private readonly boardsServiceClientImpl: BoardsServiceProvider;
@@ -162,27 +157,6 @@ export class ArduinoFrontendContribution
 
   @postConstruct()
   protected async init(): Promise<void> {
-    const isFirstStartup = !(await this.localStorageService.getData(
-      INIT_LIBS_AND_PACKAGES
-    ));
-    if (isFirstStartup) {
-      await this.localStorageService.setData(INIT_LIBS_AND_PACKAGES, true);
-      const avrPackage = await this.boardsService.getBoardPackage({
-        id: 'arduino:avr',
-      });
-      const builtInLibrary = (
-        await this.libraryService.search({
-          query: 'Arduino_BuiltIn',
-        })
-      )[0];
-
-      !!avrPackage && (await this.boardsService.install({ item: avrPackage }));
-      !!builtInLibrary &&
-        (await this.libraryService.install({
-          item: builtInLibrary,
-          installDependencies: true,
-        }));
-    }
     if (!window.navigator.onLine) {
       // tslint:disable-next-line:max-line-length
       this.messageService.warn(

--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -304,6 +304,7 @@ import { WidgetManager as TheiaWidgetManager } from '@theia/core/lib/browser/wid
 import { StartupTask } from './widgets/sketchbook/startup-task';
 import { IndexesUpdateProgress } from './contributions/indexes-update-progress';
 import { Daemon } from './contributions/daemon';
+import { InitLibsPlatforms } from './contributions/init-libs-platforms';
 
 MonacoThemingService.register({
   id: 'arduino-theme',
@@ -699,6 +700,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   Contribution.configure(bind, StartupTask);
   Contribution.configure(bind, IndexesUpdateProgress);
   Contribution.configure(bind, Daemon);
+  Contribution.configure(bind, InitLibsPlatforms);
 
   // Disabled the quick-pick customization from Theia when multiple formatters are available.
   // Use the default VS Code behavior, and pick the first one. In the IDE2, clang-format has `exclusive` selectors.

--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -304,7 +304,7 @@ import { WidgetManager as TheiaWidgetManager } from '@theia/core/lib/browser/wid
 import { StartupTask } from './widgets/sketchbook/startup-task';
 import { IndexesUpdateProgress } from './contributions/indexes-update-progress';
 import { Daemon } from './contributions/daemon';
-import { InitLibsPlatforms } from './contributions/init-libs-platforms';
+import { FirstStartupInstaller } from './contributions/first-startup-installer';
 
 MonacoThemingService.register({
   id: 'arduino-theme',
@@ -700,7 +700,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   Contribution.configure(bind, StartupTask);
   Contribution.configure(bind, IndexesUpdateProgress);
   Contribution.configure(bind, Daemon);
-  Contribution.configure(bind, InitLibsPlatforms);
+  Contribution.configure(bind, FirstStartupInstaller);
 
   // Disabled the quick-pick customization from Theia when multiple formatters are available.
   // Use the default VS Code behavior, and pick the first one. In the IDE2, clang-format has `exclusive` selectors.

--- a/arduino-ide-extension/src/browser/contributions/first-startup-installer.ts
+++ b/arduino-ide-extension/src/browser/contributions/first-startup-installer.ts
@@ -4,7 +4,7 @@ import { BoardsService, LibraryService } from '../../common/protocol';
 import { Contribution } from './contribution';
 
 @injectable()
-export class InitLibsPlatforms extends Contribution {
+export class FirstStartupInstaller extends Contribution {
   @inject(LocalStorageService)
   private readonly localStorageService: LocalStorageService;
   @inject(BoardsService)
@@ -14,7 +14,7 @@ export class InitLibsPlatforms extends Contribution {
 
   override async onReady(): Promise<void> {
     const isFirstStartup = !(await this.localStorageService.getData(
-      InitLibsPlatforms.INIT_LIBS_AND_PACKAGES
+      FirstStartupInstaller.INIT_LIBS_AND_PACKAGES
     ));
     if (isFirstStartup) {
       const avrPackage = await this.boardsService.getBoardPackage({
@@ -85,13 +85,13 @@ export class InitLibsPlatforms extends Contribution {
 
       if (!avrPackageError && !builtInLibraryError) {
         await this.localStorageService.setData(
-          InitLibsPlatforms.INIT_LIBS_AND_PACKAGES,
+          FirstStartupInstaller.INIT_LIBS_AND_PACKAGES,
           true
         );
       }
     }
   }
 }
-export namespace InitLibsPlatforms {
+export namespace FirstStartupInstaller {
   export const INIT_LIBS_AND_PACKAGES = 'initializedLibsAndPackages';
 }

--- a/arduino-ide-extension/src/browser/contributions/init-libs-platforms.ts
+++ b/arduino-ide-extension/src/browser/contributions/init-libs-platforms.ts
@@ -1,0 +1,47 @@
+import { LocalStorageService } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { BoardsService, LibraryService } from '../../common/protocol';
+import { Contribution } from './contribution';
+
+@injectable()
+export class InitLibsPlatforms extends Contribution {
+  @inject(LocalStorageService)
+  private readonly localStorageService: LocalStorageService;
+  @inject(BoardsService)
+  private readonly boardsService: BoardsService;
+  @inject(LibraryService)
+  private readonly libraryService: LibraryService;
+
+  override async onReady(): Promise<void> {
+    const isFirstStartup = !(await this.localStorageService.getData(
+      InitLibsPlatforms.INIT_LIBS_AND_PACKAGES
+    ));
+    if (isFirstStartup) {
+      await this.localStorageService.setData(
+        InitLibsPlatforms.INIT_LIBS_AND_PACKAGES,
+        true
+      );
+      const avrPackage = await this.boardsService.getBoardPackage({
+        id: 'arduino:avr',
+      });
+      const builtInLibrary = (
+        await this.libraryService.search({
+          query: 'Arduino_BuiltIn',
+        })
+      )[0];
+
+      if (avrPackage) {
+        await this.boardsService.install({ item: avrPackage });
+      }
+      if (builtInLibrary) {
+        await this.libraryService.install({
+          item: builtInLibrary,
+          installDependencies: true,
+        });
+      }
+    }
+  }
+}
+export namespace InitLibsPlatforms {
+  export const INIT_LIBS_AND_PACKAGES = 'initializedLibsAndPackages';
+}

--- a/arduino-ide-extension/src/browser/contributions/init-libs-platforms.ts
+++ b/arduino-ide-extension/src/browser/contributions/init-libs-platforms.ts
@@ -17,18 +17,15 @@ export class InitLibsPlatforms extends Contribution {
       InitLibsPlatforms.INIT_LIBS_AND_PACKAGES
     ));
     if (isFirstStartup) {
-      await this.localStorageService.setData(
-        InitLibsPlatforms.INIT_LIBS_AND_PACKAGES,
-        true
-      );
       const avrPackage = await this.boardsService.getBoardPackage({
         id: 'arduino:avr',
       });
       const builtInLibrary = (
-        await this.libraryService.search({
-          query: 'Arduino_BuiltIn',
-        })
+        await this.libraryService.search({ query: 'Arduino_BuiltIn' })
       )[0];
+
+      let avrPackageError: Error | undefined;
+      let builtInLibraryError: Error | undefined;
 
       if (avrPackage) {
         try {
@@ -36,8 +33,24 @@ export class InitLibsPlatforms extends Contribution {
             item: avrPackage,
             noOverwrite: true, // We don't want to automatically replace custom platforms the user might already have in place
           });
-        } catch {} // If this fails, we still want to install the libraries
+        } catch (e) {
+          // There's no error code, I need to parse the error message: https://github.com/arduino/arduino-cli/commit/ffe4232b359fcfa87238d68acf1c3b64a1621f14#diff-10ffbdde46838dd9caa881fd1f2a5326a49f8061f6cfd7c9d430b4875a6b6895R62
+          if (
+            e.message.includes(
+              `Platform ${avrPackage.id}@${avrPackage.installedVersion} already installed`
+            )
+          ) {
+            // If arduino:avr installation fails because it's already installed we don't want to retry on next start-up
+            console.error(e);
+          } else {
+            // But if there is any other error (e.g.: no interntet cconnection), we want to retry next time
+            avrPackageError = e;
+          }
+        }
+      } else {
+        avrPackageError = new Error('Could not find platform.');
       }
+
       if (builtInLibrary) {
         try {
           await this.libraryService.install({
@@ -45,7 +58,40 @@ export class InitLibsPlatforms extends Contribution {
             installDependencies: true,
             noOverwrite: true, // We don't want to automatically replace custom libraries the user might already have in place
           });
-        } catch {}
+        } catch (e) {
+          // There's no error code, I need to parse the error message: https://github.com/arduino/arduino-cli/commit/2ea3608453b17b1157f8a1dc892af2e13e40f4f0#diff-1de7569144d4e260f8dde0e0d00a4e2a218c57966d583da1687a70d518986649R95
+          if (
+            e.message.includes(
+              `Library ${builtInLibrary.name} is already installed`
+            )
+          ) {
+            // If Arduino_BuiltIn installation fails because it's already installed we don't want to retry on next start-up
+            console.log('error installing core', e);
+          } else {
+            // But if there is any other error (e.g.: no interntet cconnection), we want to retry next time
+            builtInLibraryError = e;
+          }
+        }
+      } else {
+        builtInLibraryError = new Error('Could not find library');
+      }
+
+      if (avrPackageError) {
+        this.messageService.error(
+          `Could not install Arduino AVR platform: ${avrPackageError}`
+        );
+      }
+      if (builtInLibraryError) {
+        this.messageService.error(
+          `Could not install ${builtInLibrary.name} library: ${builtInLibraryError}`
+        );
+      }
+
+      if (!avrPackageError && !builtInLibraryError) {
+        await this.localStorageService.setData(
+          InitLibsPlatforms.INIT_LIBS_AND_PACKAGES,
+          true
+        );
       }
     }
   }

--- a/arduino-ide-extension/src/browser/contributions/init-libs-platforms.ts
+++ b/arduino-ide-extension/src/browser/contributions/init-libs-platforms.ts
@@ -31,12 +31,16 @@ export class InitLibsPlatforms extends Contribution {
       )[0];
 
       if (avrPackage) {
-        await this.boardsService.install({ item: avrPackage });
+        await this.boardsService.install({
+          item: avrPackage,
+          noOverwrite: true, // We don't want to automatically replace custom platforms the user might already have in place
+        });
       }
       if (builtInLibrary) {
         await this.libraryService.install({
           item: builtInLibrary,
           installDependencies: true,
+          noOverwrite: true, // We don't want to automatically replace custom libraries the user might already have in place
         });
       }
     }

--- a/arduino-ide-extension/src/browser/contributions/init-libs-platforms.ts
+++ b/arduino-ide-extension/src/browser/contributions/init-libs-platforms.ts
@@ -31,17 +31,21 @@ export class InitLibsPlatforms extends Contribution {
       )[0];
 
       if (avrPackage) {
-        await this.boardsService.install({
-          item: avrPackage,
-          noOverwrite: true, // We don't want to automatically replace custom platforms the user might already have in place
-        });
+        try {
+          await this.boardsService.install({
+            item: avrPackage,
+            noOverwrite: true, // We don't want to automatically replace custom platforms the user might already have in place
+          });
+        } catch {} // If this fails, we still want to install the libraries
       }
       if (builtInLibrary) {
-        await this.libraryService.install({
-          item: builtInLibrary,
-          installDependencies: true,
-          noOverwrite: true, // We don't want to automatically replace custom libraries the user might already have in place
-        });
+        try {
+          await this.libraryService.install({
+            item: builtInLibrary,
+            installDependencies: true,
+            noOverwrite: true, // We don't want to automatically replace custom libraries the user might already have in place
+          });
+        } catch {}
       }
     }
   }

--- a/arduino-ide-extension/src/browser/contributions/init-libs-platforms.ts
+++ b/arduino-ide-extension/src/browser/contributions/init-libs-platforms.ts
@@ -60,11 +60,7 @@ export class InitLibsPlatforms extends Contribution {
           });
         } catch (e) {
           // There's no error code, I need to parse the error message: https://github.com/arduino/arduino-cli/commit/2ea3608453b17b1157f8a1dc892af2e13e40f4f0#diff-1de7569144d4e260f8dde0e0d00a4e2a218c57966d583da1687a70d518986649R95
-          if (
-            e.message.includes(
-              `Library ${builtInLibrary.name} is already installed`
-            )
-          ) {
+          if (/Library (.*) is already installed/.test(e.message)) {
             // If Arduino_BuiltIn installation fails because it's already installed we don't want to retry on next start-up
             console.log('error installing core', e);
           } else {

--- a/arduino-ide-extension/src/common/protocol/installable.ts
+++ b/arduino-ide-extension/src/common/protocol/installable.ts
@@ -17,6 +17,7 @@ export interface Installable<T extends ArduinoComponent> {
     item: T;
     progressId?: string;
     version?: Installable.Version;
+    noOverwrite?: boolean;
   }): Promise<void>;
 
   /**

--- a/arduino-ide-extension/src/common/protocol/library-service.ts
+++ b/arduino-ide-extension/src/common/protocol/library-service.ts
@@ -16,6 +16,7 @@ export interface LibraryService
     progressId?: string;
     version?: Installable.Version;
     installDependencies?: boolean;
+    noOverwrite?: boolean;
   }): Promise<void>;
   installZip(options: {
     zipUri: string;

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -395,6 +395,7 @@ export class BoardsServiceImpl
     item: BoardsPackage;
     progressId?: string;
     version?: Installable.Version;
+    noOverwrite?: boolean;
   }): Promise<void> {
     const item = options.item;
     const version = !!options.version
@@ -410,6 +411,7 @@ export class BoardsServiceImpl
     req.setArchitecture(architecture);
     req.setPlatformPackage(platform);
     req.setVersion(version);
+    req.setNoOverwrite(Boolean(options.noOverwrite));
 
     console.info('>>> Starting boards package installation...', item);
 

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -436,7 +436,7 @@ export class BoardsServiceImpl
           chunk: `Failed to install platform: ${item.id}.\n`,
         });
         this.responseService.appendToOutput({
-          chunk: error.toString(),
+          chunk: `${error.toString()}\n`,
         });
         reject(error);
       });

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.d.ts
@@ -95,6 +95,9 @@ export class CompileRequest extends jspb.Message {
     getEncryptKey(): string;
     setEncryptKey(value: string): CompileRequest;
 
+    getSkipLibrariesDiscovery(): boolean;
+    setSkipLibrariesDiscovery(value: boolean): CompileRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): CompileRequest.AsObject;
@@ -133,6 +136,7 @@ export namespace CompileRequest {
         keysKeychain: string,
         signKey: string,
         encryptKey: string,
+        skipLibrariesDiscovery: boolean,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.js
@@ -149,7 +149,8 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.toObject = function(includeInsta
     libraryList: (f = jspb.Message.getRepeatedField(msg, 24)) == null ? undefined : f,
     keysKeychain: jspb.Message.getFieldWithDefault(msg, 25, ""),
     signKey: jspb.Message.getFieldWithDefault(msg, 26, ""),
-    encryptKey: jspb.Message.getFieldWithDefault(msg, 27, "")
+    encryptKey: jspb.Message.getFieldWithDefault(msg, 27, ""),
+    skipLibrariesDiscovery: jspb.Message.getBooleanFieldWithDefault(msg, 28, false)
   };
 
   if (includeInstance) {
@@ -285,6 +286,10 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.deserializeBinaryFromReader = fu
     case 27:
       var value = /** @type {string} */ (reader.readString());
       msg.setEncryptKey(value);
+      break;
+    case 28:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setSkipLibrariesDiscovery(value);
       break;
     default:
       reader.skipField();
@@ -479,6 +484,13 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.serializeBinaryToWriter = functi
   if (f.length > 0) {
     writer.writeString(
       27,
+      f
+    );
+  }
+  f = message.getSkipLibrariesDiscovery();
+  if (f) {
+    writer.writeBool(
+      28,
       f
     );
   }
@@ -1013,6 +1025,24 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.getEncryptKey = functi
  */
 proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.setEncryptKey = function(value) {
   return jspb.Message.setProto3StringField(this, 27, value);
+};
+
+
+/**
+ * optional bool skip_libraries_discovery = 28;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.getSkipLibrariesDiscovery = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 28, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.CompileRequest} returns this
+ */
+proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.setSkipLibrariesDiscovery = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 28, value);
 };
 
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.d.ts
@@ -26,6 +26,9 @@ export class PlatformInstallRequest extends jspb.Message {
     getSkipPostInstall(): boolean;
     setSkipPostInstall(value: boolean): PlatformInstallRequest;
 
+    getNoOverwrite(): boolean;
+    setNoOverwrite(value: boolean): PlatformInstallRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): PlatformInstallRequest.AsObject;
@@ -44,6 +47,7 @@ export namespace PlatformInstallRequest {
         architecture: string,
         version: string,
         skipPostInstall: boolean,
+        noOverwrite: boolean,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.js
@@ -339,7 +339,8 @@ proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.toObject = function(incl
     platformPackage: jspb.Message.getFieldWithDefault(msg, 2, ""),
     architecture: jspb.Message.getFieldWithDefault(msg, 3, ""),
     version: jspb.Message.getFieldWithDefault(msg, 4, ""),
-    skipPostInstall: jspb.Message.getBooleanFieldWithDefault(msg, 5, false)
+    skipPostInstall: jspb.Message.getBooleanFieldWithDefault(msg, 5, false),
+    noOverwrite: jspb.Message.getBooleanFieldWithDefault(msg, 6, false)
   };
 
   if (includeInstance) {
@@ -396,6 +397,10 @@ proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.deserializeBinaryFromRea
     case 5:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setSkipPostInstall(value);
+      break;
+    case 6:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setNoOverwrite(value);
       break;
     default:
       reader.skipField();
@@ -459,6 +464,13 @@ proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.serializeBinaryToWriter 
   if (f) {
     writer.writeBool(
       5,
+      f
+    );
+  }
+  f = message.getNoOverwrite();
+  if (f) {
+    writer.writeBool(
+      6,
       f
     );
   }
@@ -571,6 +583,24 @@ proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.prototype.getSkipPostIns
  */
 proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.prototype.setSkipPostInstall = function(value) {
   return jspb.Message.setProto3BooleanField(this, 5, value);
+};
+
+
+/**
+ * optional bool no_overwrite = 6;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.prototype.getNoOverwrite = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 6, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.PlatformInstallRequest} returns this
+ */
+proto.cc.arduino.cli.commands.v1.PlatformInstallRequest.prototype.setNoOverwrite = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 6, value);
 };
 
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.d.ts
@@ -79,6 +79,9 @@ export class LibraryInstallRequest extends jspb.Message {
     getNoDeps(): boolean;
     setNoDeps(value: boolean): LibraryInstallRequest;
 
+    getNoOverwrite(): boolean;
+    setNoOverwrite(value: boolean): LibraryInstallRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): LibraryInstallRequest.AsObject;
@@ -96,6 +99,7 @@ export namespace LibraryInstallRequest {
         name: string,
         version: string,
         noDeps: boolean,
+        noOverwrite: boolean,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.js
@@ -967,7 +967,8 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.toObject = function(inclu
     instance: (f = msg.getInstance()) && cc_arduino_cli_commands_v1_common_pb.Instance.toObject(includeInstance, f),
     name: jspb.Message.getFieldWithDefault(msg, 2, ""),
     version: jspb.Message.getFieldWithDefault(msg, 3, ""),
-    noDeps: jspb.Message.getBooleanFieldWithDefault(msg, 4, false)
+    noDeps: jspb.Message.getBooleanFieldWithDefault(msg, 4, false),
+    noOverwrite: jspb.Message.getBooleanFieldWithDefault(msg, 5, false)
   };
 
   if (includeInstance) {
@@ -1020,6 +1021,10 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.deserializeBinaryFromRead
     case 4:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setNoDeps(value);
+      break;
+    case 5:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setNoOverwrite(value);
       break;
     default:
       reader.skipField();
@@ -1076,6 +1081,13 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.serializeBinaryToWriter =
   if (f) {
     writer.writeBool(
       4,
+      f
+    );
+  }
+  f = message.getNoOverwrite();
+  if (f) {
+    writer.writeBool(
+      5,
       f
     );
   }
@@ -1170,6 +1182,24 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.getNoDeps = fun
  */
 proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.setNoDeps = function(value) {
   return jspb.Message.setProto3BooleanField(this, 4, value);
+};
+
+
+/**
+ * optional bool no_overwrite = 5;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.getNoOverwrite = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 5, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.LibraryInstallRequest} returns this
+ */
+proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.setNoOverwrite = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 5, value);
 };
 
 

--- a/arduino-ide-extension/src/node/library-service-impl.ts
+++ b/arduino-ide-extension/src/node/library-service-impl.ts
@@ -252,6 +252,7 @@ export class LibraryServiceImpl
     progressId?: string;
     version?: Installable.Version;
     installDependencies?: boolean;
+    noOverwrite?: boolean;
   }): Promise<void> {
     const item = options.item;
     const version = !!options.version
@@ -265,6 +266,7 @@ export class LibraryServiceImpl
     req.setName(item.name);
     req.setVersion(version);
     req.setNoDeps(!options.installDependencies);
+    req.setNoOverwrite(Boolean(options.noOverwrite));
 
     console.info('>>> Starting library package installation...', item);
 

--- a/arduino-ide-extension/src/node/library-service-impl.ts
+++ b/arduino-ide-extension/src/node/library-service-impl.ts
@@ -293,7 +293,7 @@ export class LibraryServiceImpl
           }.\n`,
         });
         this.responseService.appendToOutput({
-          chunk: error.toString(),
+          chunk: `${error.toString()}\n`,
         });
         reject(error);
       });


### PR DESCRIPTION
### Motivation
The first time the IDE is launched, it has a mechanism in place to automatically install the most common libraries and platforms, in order to deliver a better out-of-the-box experience for a majority of users.
Right now though, this process would [overwrite libraries and platforms](#798) that were previously installed by the user.


### Change description
- when installing libraries and platforms _at first start-up_, use the `--no-overwrite` flag of the arduino-cli 
- [refactor] move the code that manages the initialization of these libraries to a new contribution.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)