### PR TITLE
Fix settings dialog size

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-dialog.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-dialog.tsx
@@ -63,7 +63,7 @@ export class SettingsDialog extends AbstractDialog<Promise<Settings>> {
     protected override readonly props: SettingsDialogProps
   ) {
     super(props);
-    this.node.classList.add('arduino-settings-dialog-container');
+    this.node.id = 'arduino-settings-dialog-container';
     this.contentNode.classList.add('arduino-settings-dialog');
     this.appendCloseButton(
       nls.localize('vscode/issueMainService/cancel', 'Cancel')

--- a/arduino-ide-extension/src/browser/style/settings-dialog.css
+++ b/arduino-ide-extension/src/browser/style/settings-dialog.css
@@ -1,4 +1,4 @@
-.arduino-settings-dialog-container > .dialogBlock {
+#arduino-settings-dialog-container > .dialogBlock {
     width: calc(100% - 96px);
     max-width: 740px !important;
 }

--- a/arduino-ide-extension/src/browser/style/settings-dialog.css
+++ b/arduino-ide-extension/src/browser/style/settings-dialog.css
@@ -1,6 +1,11 @@
 #arduino-settings-dialog-container > .dialogBlock {
-    width: calc(100% - 96px);
+    height: 531px;;
     max-width: 740px !important;
+    width: calc(100% - 96px);
+}
+
+#arduino-settings-dialog-container > .dialogBlock > .dialogContent {
+    justify-content: flex-start;
 }
 
 .arduino-settings-dialog .content {


### PR DESCRIPTION
### Motivation
The [`max-width` rule of the settings dialog](https://github.com/arduino/arduino-ide/compare/fix-settings-dialog-width?expand=1#diff-485ef8a1bfa1280fa7e76193e4ab2b4d596b28f232e2075bda4eb8736a61c57fL3) is being overridden by the [default dialog `max-width`](https://github.com/arduino/arduino-ide/blob/main/arduino-ide-extension/src/browser/style/dialogs.css#L11), resulting in a _VERY_ big (and ugly) dialog. Also, the height of the dialog shouldn't change when switching to the _Network_ tab.

### Change description
- [give an id](https://github.com/arduino/arduino-ide/compare/fix-settings-dialog-width?expand=1#diff-6d93cde46877c7fcc99a5fdf6798f96d138d2237ac44ea249f5924279710ff1fL66) to the settings dialog html element and use it in the css rule to grant it a higher priority.
- fix settings dialog height

### Other information
The credit for this fix goes to @davegarthsimpson, who suggested it 🌼
Fixes #1158 

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)