### PR TITLE
Avoid twice serial plotter apps

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -4,7 +4,7 @@
   "description": "An extension for Theia building the Arduino IDE",
   "license": "AGPL-3.0-or-later",
   "scripts": {
-    "prepare": "yarn download-cli && yarn download-fwuploader && yarn download-ls && yarn copy-serial-plotter && yarn copy-i18n && yarn clean && yarn download-examples && yarn build && yarn test",
+    "prepare": "yarn download-cli && yarn download-fwuploader && yarn download-ls && yarn copy-i18n && yarn clean && yarn download-examples && yarn build && yarn test",
     "clean": "rimraf lib",
     "compose-changelog": "node ./scripts/compose-changelog.js",
     "download-cli": "node ./scripts/download-cli.js",

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -9,7 +9,6 @@
     "compose-changelog": "node ./scripts/compose-changelog.js",
     "download-cli": "node ./scripts/download-cli.js",
     "download-fwuploader": "node ./scripts/download-fwuploader.js",
-    "copy-serial-plotter": "npx ncp ../node_modules/arduino-serial-plotter-webapp ./build/arduino-serial-plotter-webapp",
     "copy-i18n": "npx ncp ../i18n ./build/i18n",
     "download-ls": "node ./scripts/download-ls.js",
     "download-examples": "node ./scripts/download-examples.js",

--- a/arduino-ide-extension/src/node/plotter/plotter-backend-contribution.ts
+++ b/arduino-ide-extension/src/node/plotter/plotter-backend-contribution.ts
@@ -14,7 +14,8 @@ export class PlotterBackendContribution
       '..',
       '..',
       '..',
-      'build',
+      '..',
+      'node_modules',
       'arduino-serial-plotter-webapp',
       'build',
     ];

--- a/arduino-ide-extension/src/node/plotter/plotter-backend-contribution.ts
+++ b/arduino-ide-extension/src/node/plotter/plotter-backend-contribution.ts
@@ -1,30 +1,22 @@
+import * as path from 'path';
 import * as express from 'express';
 import { injectable } from '@theia/core/shared/inversify';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
-import path = require('path');
 
 @injectable()
 export class PlotterBackendContribution
   implements BackendApplicationContribution
 {
-  async initialize(): Promise<void> {}
-
   configure(app: express.Application): void {
-    const relativePath = [
-      '..',
-      '..',
-      '..',
-      '..',
-      'node_modules',
-      'arduino-serial-plotter-webapp',
-      'build',
-    ];
-    app.use(express.static(path.join(__dirname, ...relativePath)));
+    const index = require.resolve(
+      'arduino-serial-plotter-webapp/build/index.html'
+    );
+    app.use(express.static(path.join(index, '..')));
     app.get('/plotter', (req, res) => {
       console.log(
         `Serving serial plotter on http://${req.headers.host}${req.url}`
       );
-      res.sendFile(path.join(__dirname, ...relativePath, 'index.html'));
+      res.sendFile(index);
     });
   }
 }


### PR DESCRIPTION
### Motivation
IDE2 contains two serial plotter apps, one in the `build` directory and the other in` node_modules/arduino-ide-extension/build`.

### Change description
Do not copy the app into the `build` folder.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)