### PR TITLE
Use `require#resolve` to locate the plotter app.

### DIFF
--- a/arduino-ide-extension/src/node/plotter/plotter-backend-contribution.ts
+++ b/arduino-ide-extension/src/node/plotter/plotter-backend-contribution.ts
@@ -1,30 +1,22 @@
+import * as path from 'path';
 import * as express from 'express';
 import { injectable } from '@theia/core/shared/inversify';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
-import path = require('path');
 
 @injectable()
 export class PlotterBackendContribution
   implements BackendApplicationContribution
 {
-  async initialize(): Promise<void> {}
-
   configure(app: express.Application): void {
-    const relativePath = [
-      '..',
-      '..',
-      '..',
-      '..',
-      'node_modules',
-      'arduino-serial-plotter-webapp',
-      'build',
-    ];
-    app.use(express.static(path.join(__dirname, ...relativePath)));
+    const index = require.resolve(
+      'arduino-serial-plotter-webapp/build/index.html'
+    );
+    app.use(express.static(path.join(index, '..')));
     app.get('/plotter', (req, res) => {
       console.log(
         `Serving serial plotter on http://${req.headers.host}${req.url}`
       );
-      res.sendFile(path.join(__dirname, ...relativePath, 'index.html'));
+      res.sendFile(index);
     });
   }
 }


### PR DESCRIPTION
### Motivation
Avoid to have the serial plotter app twice in the IDE.

### Change description
Use `require#resolve` to locate the plotter app.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)