### PR TITLE
Discovery cleanup

### DIFF
--- a/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
+++ b/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
@@ -351,10 +351,10 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(ILogger)
     .toDynamicValue((ctx) => {
       const parentLogger = ctx.container.get<ILogger>(ILogger);
-      return parentLogger.child('discovery-log'); // TODO: revert
+      return parentLogger.child('discovery');
     })
     .inSingletonScope()
-    .whenTargetNamed('discovery-log'); // TODO: revert
+    .whenTargetNamed('discovery');
 
   // Logger for the CLI config service. From the CLI config (FS path aware), we make a URI-aware app config.
   bind(ILogger)

--- a/arduino-ide-extension/src/node/board-discovery.ts
+++ b/arduino-ide-extension/src/node/board-discovery.ts
@@ -71,7 +71,8 @@ export class BoardDiscovery
 
   onStart(): void {
     this.start();
-    this.onClientDidRefresh(() => this.stop().then(() => this.start()));
+    this.onClientWillRefresh(() => this.stop());
+    this.onClientDidRefresh(() => this.start());
   }
 
   onStop(): void {
@@ -181,6 +182,16 @@ export class BoardDiscovery
       Disposable.create(() => {
         this.watching?.reject(new Error(`Stopping watcher.`));
         this.watching = undefined;
+      }),
+      Disposable.create(() => {
+        const oldState = deepClone(this._state);
+        const boards = this.getAttachedBoards(oldState);
+        const ports = this.getAvailablePorts(oldState);
+        this._state = {};
+        this.notificationService.notifyAttachedBoardsDidChange({
+          newState: { boards: [], ports: [] },
+          oldState: { boards, ports },
+        });
       }),
     ]);
     return wrapper;

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -60,7 +60,7 @@ export class BoardsServiceImpl
   protected readonly boardDiscovery: BoardDiscovery;
 
   async getState(): Promise<AvailablePorts> {
-    return this.boardDiscovery.availablePorts;
+    return this.boardDiscovery.state;
   }
 
   async getAttachedBoards(): Promise<Board[]> {

--- a/arduino-ide-extension/src/node/core-client-provider.ts
+++ b/arduino-ide-extension/src/node/core-client-provider.ts
@@ -55,6 +55,7 @@ export class CoreClientProvider {
   private readonly onClientReady = this.onClientReadyEmitter.event;
   private readonly onClientDidRefreshEmitter =
     new Emitter<CoreClientProvider.Client>();
+  private readonly onClientWillRefreshEmitter = new Emitter<void>();
 
   @postConstruct()
   protected init(): void {
@@ -92,6 +93,10 @@ export class CoreClientProvider {
 
   get onClientDidRefresh(): Event<CoreClientProvider.Client> {
     return this.onClientDidRefreshEmitter.event;
+  }
+
+  get onClientWillRefresh(): Event<void> {
+    return this.onClientWillRefreshEmitter.event;
   }
 
   /**
@@ -253,6 +258,7 @@ export class CoreClientProvider {
   private async refreshIndexes(): Promise<void> {
     const client = this._client;
     if (client) {
+      this.onClientWillRefreshEmitter.fire();
       const progressHandler = this.createProgressHandler();
       try {
         await this.updateIndexes(client, progressHandler);
@@ -414,6 +420,10 @@ export abstract class CoreClientAware {
 
   protected get onClientDidRefresh(): Event<CoreClientProvider.Client> {
     return this.coreClientProvider.onClientDidRefresh;
+  }
+
+  protected get onClientWillRefresh(): Event<void> {
+    return this.coreClientProvider.onClientWillRefresh;
   }
 }
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

This is another variant of #1167.

There is a bug with #1167 that can be reproduced on my Windows machine with the following steps:
 - IDE2 is up and running, a board is connected and recognized by IDE2; it's the selected board,
 - Stop IDE2,
 - Start IDE2 (You can see the board is connected from the dropdown),
 - Disconnect the board when the `Downloading ....` notification message (this is when IDE2 initializes the core client),
 - Core client reinitialization is done, the board is not connected, but IDE2 still shows it as a connected board.

This PR fixes this issue, but IDE2 must stop the board discovery before re-initializing the core client and restarting after it. WheIDE2 stops the board discoveryE2 before the re-init; zero available board and ports must be broadcasted to the frontends. So users will see a disconnect/reconnect board before/after the index update and the core client re-init.

See it in action:

https://user-images.githubusercontent.com/1405703/178764796-ad717398-16da-44e7-aac6-4bba0ee86498.mp4


### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)