### PR TITLE
#1207: Forward the `realTimeDiagnostics` to the LS.

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/ino-language.ts
+++ b/arduino-ide-extension/src/browser/contributions/ino-language.ts
@@ -107,6 +107,9 @@ export class InoLanguage extends SketchContribution {
       }
       this.logger.info(`Starting language server: ${fqbn}`);
       const log = this.preferences.get('arduino.language.log');
+      const realTimeDiagnostics = this.preferences.get(
+        'arduino.language.realTimeDiagnostics'
+      );
       let currentSketchPath: string | undefined = undefined;
       if (log) {
         const currentSketch = await this.sketchServiceClient.currentSketch();
@@ -141,6 +144,7 @@ export class InoLanguage extends SketchContribution {
               fqbn,
               name: name ? `"${name}"` : undefined,
             },
+            realTimeDiagnostics,
           }
         ),
       ]);


### PR DESCRIPTION

### Motivation
<!-- Why this pull request? -->

The ` arduino.language.realTimeDiagnostics` preference value was not forwarded to the LS; hence it's always published the diagnostics to the IDE2.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Closes #1207.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)