### PR TITLE
Fix board selector synchronization

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -516,6 +516,7 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
     for (let i = 0; !hasChanged && i < availableBoards.length; i++) {
       const [left, right] = [availableBoards[i], currentAvailableBoards[i]];
       hasChanged =
+        left.fqbn !== right.fqbn ||
         !!AvailableBoard.compare(left, right) ||
         left.selected !== right.selected;
     }

--- a/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
@@ -200,18 +200,17 @@ export class BoardsToolBarItem extends React.Component<
 
   override render(): React.ReactNode {
     const { coords, availableBoards } = this.state;
-    const selectedBoard = availableBoards.find(({ selected }) => selected);
+    const { selectedBoard, selectedPort } =
+      this.props.boardsServiceProvider.boardsConfig;
 
     const boardLabel =
       selectedBoard?.name ||
       nls.localize('arduino/board/selectBoard', 'Select Board');
-    const selectedPortLabel = portLabel(selectedBoard?.port?.address);
+    const selectedPortLabel = portLabel(selectedPort?.address);
 
-    const isConnected = Boolean(
-      selectedBoard && AvailableBoard.hasPort(selectedBoard)
-    );
+    const isConnected = Boolean(selectedBoard && selectedPort);
     const protocolIcon = isConnected
-      ? iconNameFromProtocol(selectedBoard?.port?.protocol || '')
+      ? iconNameFromProtocol(selectedPort?.protocol || '')
       : null;
     const protocolIconClassNames = classNames(
       'arduino-boards-toolbar-item--protocol',
@@ -245,7 +244,7 @@ export class BoardsToolBarItem extends React.Component<
             .map((board) => ({
               ...board,
               onClick: () => {
-                if (board.state === AvailableBoard.State.incomplete) {
+                if (!board.fqbn) {
                   const previousBoardConfig =
                     this.props.boardsServiceProvider.boardsConfig;
                   this.props.boardsServiceProvider.boardsConfig = {

--- a/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
@@ -10,6 +10,7 @@ import {
 } from './boards-service-provider';
 import { nls } from '@theia/core/lib/common';
 import classNames from 'classnames';
+import { BoardsConfig } from './boards-config';
 
 export interface BoardsDropDownListCoords {
   readonly top: number;
@@ -245,10 +246,12 @@ export class BoardsToolBarItem extends React.Component<
               ...board,
               onClick: () => {
                 if (board.state === AvailableBoard.State.incomplete) {
+                  const previousBoardConfig =
+                    this.props.boardsServiceProvider.boardsConfig;
                   this.props.boardsServiceProvider.boardsConfig = {
                     selectedPort: board.port,
                   };
-                  this.openDialog();
+                  this.openDialog(previousBoardConfig);
                 } else {
                   this.props.boardsServiceProvider.boardsConfig = {
                     selectedBoard: board,
@@ -264,10 +267,20 @@ export class BoardsToolBarItem extends React.Component<
     );
   }
 
-  protected openDialog = (): void => {
-    this.props.commands.executeCommand(
-      OpenBoardsConfig.Commands.OPEN_DIALOG.id
-    );
+  protected openDialog = async (
+    previousBoardConfig?: BoardsConfig.Config
+  ): Promise<void> => {
+    const selectedBoardConfig =
+      await this.props.commands.executeCommand<BoardsConfig.Config>(
+        OpenBoardsConfig.Commands.OPEN_DIALOG.id
+      );
+    if (
+      previousBoardConfig &&
+      (!selectedBoardConfig?.selectedPort ||
+        !selectedBoardConfig?.selectedBoard)
+    ) {
+      this.props.boardsServiceProvider.boardsConfig = previousBoardConfig;
+    }
   };
 }
 export namespace BoardsToolBarItem {

--- a/arduino-ide-extension/src/browser/contributions/open-boards-config.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-boards-config.ts
@@ -17,7 +17,7 @@ export class OpenBoardsConfig extends Contribution {
       execute: async (query?: string | undefined) => {
         const boardsConfig = await this.boardsConfigDialog.open(query);
         if (boardsConfig) {
-          this.boardsServiceProvider.boardsConfig = boardsConfig;
+          return (this.boardsServiceProvider.boardsConfig = boardsConfig);
         }
       },
     });


### PR DESCRIPTION
### Motivation
The Board selector is not correctly synchronized when the board/port config changes, which results in inconsistent and confusing UI.

We also want to prevent deselecting the current board from the Board Selector by clicking on Unknown boards

#1204
#1206 


### Change description
- if no board is selected after closing the board selection dialog, restore the previously connected board https://github.com/arduino/arduino-ide/pull/1214/files#diff-85056a8e2611f77f68cc49f8ea30ab9e5e8ea370f0123e9f1ac63b404fc36195R247-R282
- rely on `boardsServiceProvider` when showing the currently selected board and port https://github.com/arduino/arduino-ide/pull/1214/files#diff-85056a8e2611f77f68cc49f8ea30ab9e5e8ea370f0123e9f1ac63b404fc36195L202-R213
- update available boards in `boardsServiceProvider` when fqbn changes (this fixes a bug that was there in RC8 too)  https://github.com/arduino/arduino-ide/pull/1214/files#diff-e42c82bb67e277cfa4598239952afd65db44dba55dc7d68df619dfccfa648279R519


### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)