### PR TITLE
Toolbar debug button

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/debug.ts
+++ b/arduino-ide-extension/src/browser/contributions/debug.ts
@@ -10,6 +10,7 @@ import {
   Command,
   CommandRegistry,
   SketchContribution,
+  TabBarToolbarRegistry,
 } from './contribution';
 import { MaybePromise, MenuModelRegistry, nls } from '@theia/core/lib/common';
 import { CurrentSketch } from '../../common/protocol/sketches-service-client-impl';
@@ -109,6 +110,10 @@ export class Debug extends SketchContribution {
       execute: () => this.toggleOptimizeForDebug(),
       isToggled: () => this.isOptimizeForDebug(),
     });
+  }
+
+  override registerToolbarItems(registry: TabBarToolbarRegistry): void {
+    registry.registerItem(this.debugToolbarItem);
   }
 
   override registerMenus(registry: MenuModelRegistry): void {

--- a/arduino-ide-extension/src/browser/style/main.css
+++ b/arduino-ide-extension/src/browser/style/main.css
@@ -23,7 +23,8 @@
 }
 
 .p-TabBar-toolbar .item.arduino-tool-item .arduino-upload-sketch--toolbar,
-.p-TabBar-toolbar .item.arduino-tool-item .arduino-verify-sketch--toolbar {
+.p-TabBar-toolbar .item.arduino-tool-item .arduino-verify-sketch--toolbar,
+.p-TabBar-toolbar .item.arduino-tool-item .arduino-start-debug {
     background: var(--theia-arduino-toolbar-button-background);
 }
 
@@ -38,7 +39,8 @@
 }
 
 .arduino-verify-sketch--toolbar,
-.arduino-upload-sketch--toolbar {
+.arduino-upload-sketch--toolbar,
+.arduino-start-debug {
     border-radius: 14px;
 }
 
@@ -79,20 +81,14 @@
 }
 
 .arduino-start-debug-icon {
-    -webkit-mask: url('../icons/debug-dark.svg') 50%;
-    mask: url('../icons/debug-dark.svg') 50%;
+    -webkit-mask: url('../icons/debug-dark.svg') 50% 60%;
     -webkit-mask-size: 70%;
-    mask-size: 70%;
     -webkit-mask-repeat: no-repeat;
-    mask-repeat: no-repeat;
     display: flex;
     justify-content: center;
     align-items: center;
-    color: var(--theia-ui-button-font-color);
-}
+    background-color: var(--theia-titleBar-activeBackground);   
 
-.arduino-start-debug {
-    border-radius: 12px;
 }
 
 #arduino-toolbar-container {


### PR DESCRIPTION
### Motivation
The debug button should be present in the toolbar.

### Change description
Restore the previous button.

Enabled:
![Screenshot 2022-07-19 114038](https://user-images.githubusercontent.com/94986937/179720132-edcefd50-ebed-4228-bf33-b5031dd0c52a.png)

Disabled:
![Screenshot 2022-07-19 114116](https://user-images.githubusercontent.com/94986937/179720202-6e23c89e-a2b3-4bc6-8cbe-9492a82e3ef2.png)

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)