### PR TITLE
Prevent board selector item labels to overflow

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
@@ -130,11 +130,14 @@ export class BoardsDropDown extends React.Component<BoardsDropDown.Props> {
             protocolIcon
           )}
         />
-        <div className="arduino-boards-dropdown-item--label">
-          <div className="arduino-boards-dropdown-item--board-label">
+        <div
+          className="arduino-boards-dropdown-item--label"
+          title={`${boardLabel}\n${port.address}`}
+        >
+          <div className="arduino-boards-dropdown-item--board-label noWrapInfo noselect">
             {boardLabel}
           </div>
-          <div className="arduino-boards-dropdown-item--port-label">
+          <div className="arduino-boards-dropdown-item--port-label noWrapInfo noselect">
             {port.address}
           </div>
         </div>
@@ -229,7 +232,8 @@ export class BoardsToolBarItem extends React.Component<
           <div
             className={classNames(
               'arduino-boards-toolbar-item--label',
-              'noWrapInfo noselect',
+              'noWrapInfo',
+              'noselect',
               { 'arduino-boards-toolbar-item--label-connected': isConnected }
             )}
           >

--- a/arduino-ide-extension/src/browser/style/boards-config-dialog.css
+++ b/arduino-ide-extension/src/browser/style/boards-config-dialog.css
@@ -180,9 +180,6 @@ div#select-board-dialog .selectBoardContainer .body .list .item.selected i {
 }
 
 .arduino-boards-toolbar-item--label {
-  height: 100%;
-  display: flex;
-  align-items: center;
   width: 100%;
 }
 

--- a/arduino-ide-extension/src/browser/style/boards-config-dialog.css
+++ b/arduino-ide-extension/src/browser/style/boards-config-dialog.css
@@ -226,6 +226,7 @@ div#select-board-dialog .selectBoardContainer .body .list .item.selected i {
 }
 
 .arduino-boards-dropdown-item--label {
+  overflow: hidden;
   flex: 1;
 }
 


### PR DESCRIPTION
### Motivation
As stated in #998, the items of the Board Selector dropdown may overflow in an ugly way if the label is too long. 

### Change description
Adding `overflow: hidden` to parent and ellipsis to children.
I also added a tooltip to show the complete board/port combination, so that a user is able to see when hovering over the item.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)