### PR TITLE
Move Auto Format to the Edit menu

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/edit-contributions.ts
+++ b/arduino-ide-extension/src/browser/contributions/edit-contributions.ts
@@ -143,7 +143,7 @@ ${value}
     });
     registry.registerMenuAction(ArduinoMenus.EDIT__CODE_CONTROL_GROUP, {
       commandId: EditContributions.Commands.AUTO_FORMAT.id,
-      label: nls.localize('arduino/editor/autoFormat', 'Auto Format'), // XXX: The Java IDE uses `Use Selection For Find`.
+      label: nls.localize('arduino/editor/autoFormat', 'Auto Format'),
       order: '3',
     });
 

--- a/arduino-ide-extension/src/browser/contributions/edit-contributions.ts
+++ b/arduino-ide-extension/src/browser/contributions/edit-contributions.ts
@@ -193,6 +193,13 @@ ${value}
       ), // XXX: The Java IDE uses `Use Selection For Find`.
       order: '3',
     });
+
+    // `Tools`
+    registry.registerMenuAction(ArduinoMenus.TOOLS__MAIN_GROUP, {
+      commandId: EditContributions.Commands.AUTO_FORMAT.id,
+      label: nls.localize('arduino/editor/autoFormat', 'Auto Format'), // XXX: The Java IDE uses `Use Selection For Find`.
+      order: '0',
+    });
   }
 
   override registerKeybindings(registry: KeybindingRegistry): void {

--- a/arduino-ide-extension/src/browser/contributions/edit-contributions.ts
+++ b/arduino-ide-extension/src/browser/contributions/edit-contributions.ts
@@ -141,6 +141,11 @@ ${value}
       label: nls.localize('arduino/editor/decreaseIndent', 'Decrease Indent'),
       order: '2',
     });
+    registry.registerMenuAction(ArduinoMenus.EDIT__CODE_CONTROL_GROUP, {
+      commandId: EditContributions.Commands.AUTO_FORMAT.id,
+      label: nls.localize('arduino/editor/autoFormat', 'Auto Format'), // XXX: The Java IDE uses `Use Selection For Find`.
+      order: '3',
+    });
 
     registry.registerMenuAction(ArduinoMenus.EDIT__FONT_CONTROL_GROUP, {
       commandId: EditContributions.Commands.INCREASE_FONT_SIZE.id,
@@ -187,13 +192,6 @@ ${value}
         'Use Selection for Find'
       ), // XXX: The Java IDE uses `Use Selection For Find`.
       order: '3',
-    });
-
-    // `Tools`
-    registry.registerMenuAction(ArduinoMenus.TOOLS__MAIN_GROUP, {
-      commandId: EditContributions.Commands.AUTO_FORMAT.id,
-      label: nls.localize('arduino/editor/autoFormat', 'Auto Format'), // XXX: The Java IDE uses `Use Selection For Find`.
-      order: '0',
     });
   }
 
@@ -248,10 +246,13 @@ ${value}
     });
   }
 
-  protected async current(): Promise<ICodeEditor | StandaloneCodeEditor  | undefined> {
+  protected async current(): Promise<
+    ICodeEditor | StandaloneCodeEditor | undefined
+  > {
     return (
       this.codeEditorService.getFocusedCodeEditor() ||
-      this.codeEditorService.getActiveCodeEditor() || undefined
+      this.codeEditorService.getActiveCodeEditor() ||
+      undefined
     );
   }
 

--- a/arduino-ide-extension/src/browser/menu/arduino-menus.ts
+++ b/arduino-ide-extension/src/browser/menu/arduino-menus.ts
@@ -86,7 +86,7 @@ export namespace ArduinoMenus {
 
   // -- Tools
   export const TOOLS = [...MAIN_MENU_BAR, '4_tools'];
-  // `Archive Sketch`, `Manage Libraries...`, `Serial Monitor`, Serial Plotter
+  // `Auto Format`, `Archive Sketch`, `Manage Libraries...`, `Serial Monitor`, Serial Plotter
   export const TOOLS__MAIN_GROUP = [...TOOLS, '0_main'];
   // `WiFi101 /  WiFiNINA Firmware Updater`
   export const TOOLS__FIRMWARE_UPLOADER_GROUP = [

--- a/arduino-ide-extension/src/browser/menu/arduino-menus.ts
+++ b/arduino-ide-extension/src/browser/menu/arduino-menus.ts
@@ -86,7 +86,7 @@ export namespace ArduinoMenus {
 
   // -- Tools
   export const TOOLS = [...MAIN_MENU_BAR, '4_tools'];
-  // `Auto Format`, `Archive Sketch`, `Manage Libraries...`, `Serial Monitor`, Serial Plotter
+  // `Archive Sketch`, `Manage Libraries...`, `Serial Monitor`, Serial Plotter
   export const TOOLS__MAIN_GROUP = [...TOOLS, '0_main'];
   // `WiFi101 /  WiFiNINA Firmware Updater`
   export const TOOLS__FIRMWARE_UPLOADER_GROUP = [


### PR DESCRIPTION
### Motivation
`Auto Format` should be placed under the `Edit` menu according to the design specifications.

### Change description
A new `registerMenuAction` has been added under the `Edit` menu with the `Auto Format` command.

### Other information
Closes #1229.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)