### PR TITLE
use variable for step button container bkgnd

### DIFF
--- a/arduino-ide-extension/src/browser/style/settings-step-input.css
+++ b/arduino-ide-extension/src/browser/style/settings-step-input.css
@@ -18,7 +18,7 @@
     height: calc(100% - 4px);
     width: 14px;
     padding: 2px;
-    background: white;
+    background: var(--theia-input-background);
 }
 
 .settings-step-input-container:hover > .settings-step-input-buttons-container {
@@ -33,7 +33,6 @@
     border: none;
     border-radius: 0;
     height: 50%;
-    width: 1;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
### Motivation
Hard coded color was used in stepper styling, hence mismatch with dark theme.

### Change description
Uses a variable instead of a hard coded color. A typo width property has also been removed.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)