### PR TITLE
Primary action button to the right of the notification box

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-auto-installer.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-auto-installer.ts
@@ -238,6 +238,16 @@ export class BoardsAutoInstaller implements FrontendApplicationContribution {
 
     const actions: AutoInstallPromptActions = [
       {
+        key: manualInstall,
+        handler: () => {
+          this.boardsManagerFrontendContribution
+            .openView({ reveal: true })
+            .then((widget) =>
+              widget.refresh(candidate.name.toLocaleLowerCase())
+            );
+        },
+      },
+      {
         isAcceptance: true,
         key: yes,
         handler: () => {
@@ -248,16 +258,6 @@ export class BoardsAutoInstaller implements FrontendApplicationContribution {
             responseService: this.responseService,
             version: candidate.availableVersions[0],
           });
-        },
-      },
-      {
-        key: manualInstall,
-        handler: () => {
-          this.boardsManagerFrontendContribution
-            .openView({ reveal: true })
-            .then((widget) =>
-              widget.refresh(candidate.name.toLocaleLowerCase())
-            );
         },
       },
     ];


### PR DESCRIPTION
### Motivation
The primary action button should be to the right of the notification box.

### Change description
Reverses the position of the buttons.

Before:
![Screenshot 2022-07-20 152656](https://user-images.githubusercontent.com/94986937/179993974-a5b17a4f-bfb6-49de-be76-82675c5f3f7e.png)

After:
![Screenshot 2022-07-20 150825](https://user-images.githubusercontent.com/94986937/179994004-34623ec8-95e7-455c-8a3c-4b2244ca7e3e.png)

### Other information
Closes #1227. 

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)