### PR TITLE
#374: ensure compile verbose pref is included on upload

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -217,6 +217,7 @@ export class UploadSketch extends CoreServiceContribution {
         verbose,
         sourceOverride,
         optimizeForDebug,
+        compileVerbose,
       ] = await Promise.all([
         this.boardsDataStore.appendConfigToFqbn(
           boardsConfig.selectedBoard?.fqbn
@@ -228,7 +229,12 @@ export class UploadSketch extends CoreServiceContribution {
         this.commandService.executeCommand<boolean>(
           'arduino-is-optimize-for-debug'
         ),
+        this.preferences.get('arduino.compile.verbose'),
       ]);
+
+      const compileStepOptions: Partial<CoreService.Compile.Options> = {
+        verbose: compileVerbose,
+      };
 
       const board = {
         ...boardsConfig.selectedBoard,
@@ -277,9 +283,12 @@ export class UploadSketch extends CoreServiceContribution {
       }
       this.outputChannelManager.getChannel('Arduino').clear();
       if (usingProgrammer) {
-        await this.coreService.uploadUsingProgrammer(options);
+        await this.coreService.uploadUsingProgrammer(
+          options,
+          compileStepOptions
+        );
       } else {
-        await this.coreService.upload(options);
+        await this.coreService.upload(options, compileStepOptions);
       }
       this.messageService.info(
         nls.localize('arduino/sketch/doneUploading', 'Done uploading.'),

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -214,7 +214,7 @@ export class UploadSketch extends CoreServiceContribution {
         fqbn,
         { selectedProgrammer },
         verify,
-        verbose,
+        uploadVerbose,
         sourceOverride,
         optimizeForDebug,
         compileVerbose,
@@ -232,10 +232,7 @@ export class UploadSketch extends CoreServiceContribution {
         this.preferences.get('arduino.compile.verbose'),
       ]);
 
-      const compileStepOptions: Partial<CoreService.Compile.Options> = {
-        verbose: compileVerbose,
-      };
-
+      const verbose = { compile: compileVerbose, upload: uploadVerbose };
       const board = {
         ...boardsConfig.selectedBoard,
         name: boardsConfig.selectedBoard?.name || '',
@@ -283,12 +280,9 @@ export class UploadSketch extends CoreServiceContribution {
       }
       this.outputChannelManager.getChannel('Arduino').clear();
       if (usingProgrammer) {
-        await this.coreService.uploadUsingProgrammer(
-          options,
-          compileStepOptions
-        );
+        await this.coreService.uploadUsingProgrammer(options);
       } else {
-        await this.coreService.upload(options, compileStepOptions);
+        await this.coreService.upload(options);
       }
       this.messageService.info(
         nls.localize('arduino/sketch/doneUploading', 'Done uploading.'),

--- a/arduino-ide-extension/src/common/protocol/core-service.ts
+++ b/arduino-ide-extension/src/common/protocol/core-service.ts
@@ -67,14 +67,8 @@ export interface CoreService {
         compilerWarnings?: CompilerWarnings;
       }>
   ): Promise<void>;
-  upload(
-    options: CoreService.Upload.Options,
-    additionalCompileOptions: Partial<CoreService.Compile.Options>
-  ): Promise<void>;
-  uploadUsingProgrammer(
-    options: CoreService.Upload.Options,
-    additionalCompileOptions: Partial<CoreService.Compile.Options>
-  ): Promise<void>;
+  upload(options: CoreService.Upload.Options): Promise<void>;
+  uploadUsingProgrammer(options: CoreService.Upload.Options): Promise<void>;
   burnBootloader(options: CoreService.Bootloader.Options): Promise<void>;
 }
 
@@ -90,11 +84,12 @@ export namespace CoreService {
   }
 
   export namespace Upload {
-    export interface Options extends Compile.Options {
+    export interface Options extends Omit<Compile.Options, 'verbose'> {
       readonly port?: Port;
       readonly programmer?: Programmer | undefined;
       readonly verify: boolean;
       readonly userFields: BoardUserField[];
+      readonly verbose: { compile: boolean; upload: boolean };
     }
   }
 

--- a/arduino-ide-extension/src/common/protocol/core-service.ts
+++ b/arduino-ide-extension/src/common/protocol/core-service.ts
@@ -67,8 +67,14 @@ export interface CoreService {
         compilerWarnings?: CompilerWarnings;
       }>
   ): Promise<void>;
-  upload(options: CoreService.Upload.Options): Promise<void>;
-  uploadUsingProgrammer(options: CoreService.Upload.Options): Promise<void>;
+  upload(
+    options: CoreService.Upload.Options,
+    additionalCompileOptions: Partial<CoreService.Compile.Options>
+  ): Promise<void>;
+  uploadUsingProgrammer(
+    options: CoreService.Upload.Options,
+    additionalCompileOptions: Partial<CoreService.Compile.Options>
+  ): Promise<void>;
   burnBootloader(options: CoreService.Bootloader.Options): Promise<void>;
 }
 

--- a/arduino-ide-extension/src/node/core-service-impl.ts
+++ b/arduino-ide-extension/src/node/core-service-impl.ts
@@ -163,13 +163,9 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
     return request;
   }
 
-  upload(
-    options: CoreService.Upload.Options,
-    additionalCompileOptions: Partial<CoreService.Compile.Options>
-  ): Promise<void> {
+  upload(options: CoreService.Upload.Options): Promise<void> {
     return this.doUpload(
       options,
-      additionalCompileOptions,
       () => new UploadRequest(),
       (client, req) => client.upload(req),
       (message: string, locations: CoreError.ErrorLocation[]) =>
@@ -179,12 +175,10 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
   }
 
   async uploadUsingProgrammer(
-    options: CoreService.Upload.Options,
-    additionalCompileOptions: Partial<CoreService.Compile.Options>
+    options: CoreService.Upload.Options
   ): Promise<void> {
     return this.doUpload(
       options,
-      additionalCompileOptions,
       () => new UploadUsingProgrammerRequest(),
       (client, req) => client.uploadUsingProgrammer(req),
       (message: string, locations: CoreError.ErrorLocation[]) =>
@@ -195,7 +189,6 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
 
   protected async doUpload(
     options: CoreService.Upload.Options,
-    additionalCompileOptions: Partial<CoreService.Compile.Options>,
     requestFactory: () => UploadRequest | UploadUsingProgrammerRequest,
     responseHandler: (
       client: ArduinoCoreServiceClient,
@@ -209,7 +202,7 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
   ): Promise<void> {
     await this.compile({
       ...options,
-      ...additionalCompileOptions,
+      verbose: options.verbose.compile,
       exportBinaries: false,
     });
 
@@ -273,7 +266,7 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
     if (programmer) {
       request.setProgrammer(programmer.id);
     }
-    request.setVerbose(options.verbose);
+    request.setVerbose(options.verbose.upload);
     request.setVerify(options.verify);
 
     options.userFields.forEach((e) => {

--- a/arduino-ide-extension/src/node/core-service-impl.ts
+++ b/arduino-ide-extension/src/node/core-service-impl.ts
@@ -163,9 +163,13 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
     return request;
   }
 
-  upload(options: CoreService.Upload.Options): Promise<void> {
+  upload(
+    options: CoreService.Upload.Options,
+    additionalCompileOptions: Partial<CoreService.Compile.Options>
+  ): Promise<void> {
     return this.doUpload(
       options,
+      additionalCompileOptions,
       () => new UploadRequest(),
       (client, req) => client.upload(req),
       (message: string, locations: CoreError.ErrorLocation[]) =>
@@ -175,10 +179,12 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
   }
 
   async uploadUsingProgrammer(
-    options: CoreService.Upload.Options
+    options: CoreService.Upload.Options,
+    additionalCompileOptions: Partial<CoreService.Compile.Options>
   ): Promise<void> {
     return this.doUpload(
       options,
+      additionalCompileOptions,
       () => new UploadUsingProgrammerRequest(),
       (client, req) => client.uploadUsingProgrammer(req),
       (message: string, locations: CoreError.ErrorLocation[]) =>
@@ -189,6 +195,7 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
 
   protected async doUpload(
     options: CoreService.Upload.Options,
+    additionalCompileOptions: Partial<CoreService.Compile.Options>,
     requestFactory: () => UploadRequest | UploadUsingProgrammerRequest,
     responseHandler: (
       client: ArduinoCoreServiceClient,
@@ -200,7 +207,11 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
     ) => ApplicationError<number, CoreError.ErrorLocation[]>,
     task: string
   ): Promise<void> {
-    await this.compile(Object.assign(options, { exportBinaries: false }));
+    await this.compile({
+      ...options,
+      ...additionalCompileOptions,
+      exportBinaries: false,
+    });
 
     const coreClient = await this.coreClient;
     const { client, instance } = coreClient;


### PR DESCRIPTION
### Motivation
Verbose output preferences reported as incorrect during upload actions.

### Change description
Ensure compile "verbose" preference is considered when performing compile step prior to upload.

### Other information
Upload "verbose" preference was being used for both compile and upload steps of the "upload operation".

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)