### PR TITLE
#1223: use theme service on settings load

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
@@ -122,7 +122,6 @@ export class SettingsService {
       languages,
       currentLanguage,
       editorFontSize,
-      themeId,
       autoSave,
       quickSuggestions,
       autoScaleInterface,
@@ -137,10 +136,6 @@ export class SettingsService {
       ['en', ...(await this.localizationProvider.getAvailableLanguages())],
       this.localizationProvider.getCurrentLanguage(),
       this.preferenceService.get<number>(FONT_SIZE_SETTING, 12),
-      this.preferenceService.get<string>(
-        'workbench.colorTheme',
-        'arduino-theme'
-      ),
       this.preferenceService.get<Settings.AutoSave>(
         AUTO_SAVE_SETTING,
         Settings.AutoSave.DEFAULT_ON
@@ -165,7 +160,7 @@ export class SettingsService {
     const sketchbookPath = await this.fileService.fsPath(new URI(sketchDirUri));
     return {
       editorFontSize,
-      themeId,
+      themeId: ThemeService.get().getCurrentTheme().id,
       languages,
       currentLanguage,
       autoSave,

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
@@ -168,7 +168,7 @@ export class SettingsService {
     const sketchbookPath = await this.fileService.fsPath(new URI(sketchDirUri));
     return {
       editorFontSize,
-      themeId: ThemeService.get().getCurrentTheme().id,
+      themeId,
       languages,
       currentLanguage,
       autoSave,

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
@@ -122,6 +122,7 @@ export class SettingsService {
       languages,
       currentLanguage,
       editorFontSize,
+      themeId,
       autoSave,
       quickSuggestions,
       autoScaleInterface,
@@ -136,6 +137,13 @@ export class SettingsService {
       ['en', ...(await this.localizationProvider.getAvailableLanguages())],
       this.localizationProvider.getCurrentLanguage(),
       this.preferenceService.get<number>(FONT_SIZE_SETTING, 12),
+      this.preferenceService.get<string>(
+        'workbench.colorTheme',
+        window.matchMedia &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches
+          ? 'arduino-theme-dark'
+          : 'arduino-theme'
+      ),
       this.preferenceService.get<Settings.AutoSave>(
         AUTO_SAVE_SETTING,
         Settings.AutoSave.DEFAULT_ON

--- a/electron/build/patch/frontend/index.js
+++ b/electron/build/patch/frontend/index.js
@@ -13,6 +13,9 @@ const {
 const {
   ApplicationProps,
 } = require('@theia/application-package/lib/application-props');
+const {
+  FrontendApplicationConfigProvider,
+} = require('@theia/core/lib/browser/frontend-application-config-provider');
 
 const lightTheme = 'arduino-theme';
 const darkTheme = 'arduino-theme-dark';
@@ -21,13 +24,19 @@ const defaultTheme =
     ? darkTheme
     : lightTheme;
 
+const originalGet = FrontendApplicationConfigProvider.get;
+FrontendApplicationConfigProvider.get = function () {
+  const originalProps = originalGet.bind(FrontendApplicationConfigProvider)();
+  return { ...originalProps, defaultTheme };
+}.bind(FrontendApplicationConfigProvider);
+
 const arduinoDarkTheme = {
   id: 'arduino-theme-dark',
   type: 'dark',
   label: 'Dark (Arduino)',
   editorTheme: 'arduino-theme-dark',
-  activate() { },
-  deactivate() { }
+  activate() {},
+  deactivate() {},
 };
 
 const arduinoLightTheme = {
@@ -35,8 +44,8 @@ const arduinoLightTheme = {
   type: 'light',
   label: 'Light (Arduino)',
   editorTheme: 'arduino-theme',
-  activate() { },
-  deactivate() { }
+  activate() {},
+  deactivate() {},
 };
 
 if (!window[ThemeServiceSymbol]) {
@@ -49,7 +58,11 @@ if (!window[ThemeServiceSymbol]) {
       );
     },
   });
-  themeService.register(...BuiltinThemeProvider.themes, arduinoDarkTheme, arduinoLightTheme);
+  themeService.register(
+    ...BuiltinThemeProvider.themes,
+    arduinoDarkTheme,
+    arduinoLightTheme
+  );
   themeService.startupTheme();
   themeService.setCurrentTheme(defaultTheme);
   window[ThemeServiceSymbol] = themeService;


### PR DESCRIPTION
### Motivation
Incorrect theme shown on first start in settings.

### Change description
Use `matchMedia` method to determine initial UI dropdown value. Patch the app config provider to dispatch based on the OS' theme.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)