### PR TITLE
#1205: improve "broken UI" with settings dialog when app is scaled up

### DIFF
--- a/arduino-ide-extension/src/browser/style/settings-dialog.css
+++ b/arduino-ide-extension/src/browser/style/settings-dialog.css
@@ -6,6 +6,11 @@
 
 #arduino-settings-dialog-container > .dialogBlock > .dialogContent {
     justify-content: flex-start;
+    overflow: auto;
+}
+
+#arduino-settings-dialog-container > .dialogBlock > .dialogControl {
+    padding: 16px 0 26px;
 }
 
 .arduino-settings-dialog .content {
@@ -62,7 +67,7 @@
 }
 
 .arduino-settings-dialog .react-tabs__tab-panel {
-    padding-bottom: 25px;
+    padding-bottom: 8px;
 }
 
 .arduino-settings-dialog .react-tabs__tab-list {


### PR DESCRIPTION
### Motivation
Settings dialog reported as visually unpleasing, and functionally impaired when scaling up the IDE.

### Change description
Uses a fixed footer and `overflow: auto` for settings dialog content.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)