### PR TITLE
#575, #1175 Show 'progress' indicator during verify/upload

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/add-zip-library.ts
+++ b/arduino-ide-extension/src/browser/contributions/add-zip-library.ts
@@ -4,11 +4,8 @@ import URI from '@theia/core/lib/common/uri';
 import { ConfirmDialog } from '@theia/core/lib/browser/dialogs';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { ArduinoMenus } from '../menu/arduino-menus';
-import {
-  Installable,
-  LibraryService,
-  ResponseServiceClient,
-} from '../../common/protocol';
+import { LibraryService, ResponseServiceClient } from '../../common/protocol';
+import { ExecuteWithProgress } from '../../common/protocol/progressible';
 import {
   SketchContribution,
   Command,
@@ -88,7 +85,7 @@ export class AddZipLibrary extends SketchContribution {
 
   private async doInstall(zipUri: string, overwrite?: boolean): Promise<void> {
     try {
-      await Installable.doWithProgress({
+      await ExecuteWithProgress.doWithProgress({
         messageService: this.messageService,
         progressText:
           nls.localize('arduino/common/processing', 'Processing') +

--- a/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
@@ -2,8 +2,6 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { Emitter } from '@theia/core/lib/common/event';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { ArduinoToolbar } from '../toolbar/arduino-toolbar';
-import { BoardsDataStore } from '../boards/boards-data-store';
-import { BoardsServiceProvider } from '../boards/boards-service-provider';
 import {
   CoreServiceContribution,
   Command,
@@ -14,27 +12,36 @@ import {
 } from './contribution';
 import { nls } from '@theia/core/lib/common';
 import { CurrentSketch } from '../../common/protocol/sketches-service-client-impl';
+import { CoreService } from '../../common/protocol';
+import { CoreErrorHandler } from './core-error-handler';
+
+export interface VerifySketchParams {
+  /**
+   * Same as `CoreService.Options.Compile#exportBinaries`
+   */
+  readonly exportBinaries?: boolean;
+  /**
+   * If `true`, there won't be any UI indication of the verify command. It's `false` by default.
+   */
+  readonly silent?: boolean;
+}
 
 @injectable()
 export class VerifySketch extends CoreServiceContribution {
-  @inject(BoardsDataStore)
-  protected readonly boardsDataStore: BoardsDataStore;
+  @inject(CoreErrorHandler)
+  private readonly coreErrorHandler: CoreErrorHandler;
 
-  @inject(BoardsServiceProvider)
-  protected readonly boardsServiceClientImpl: BoardsServiceProvider;
-
-  protected readonly onDidChangeEmitter = new Emitter<Readonly<void>>();
-  readonly onDidChange = this.onDidChangeEmitter.event;
-
-  protected verifyInProgress = false;
+  private readonly onDidChangeEmitter = new Emitter<void>();
+  private readonly onDidChange = this.onDidChangeEmitter.event;
+  private verifyInProgress = false;
 
   override registerCommands(registry: CommandRegistry): void {
     registry.registerCommand(VerifySketch.Commands.VERIFY_SKETCH, {
-      execute: () => this.verifySketch(),
+      execute: (params?: VerifySketchParams) => this.verifySketch(params),
       isEnabled: () => !this.verifyInProgress,
     });
     registry.registerCommand(VerifySketch.Commands.EXPORT_BINARIES, {
-      execute: () => this.verifySketch(true),
+      execute: () => this.verifySketch({ exportBinaries: true }),
       isEnabled: () => !this.verifyInProgress,
     });
     registry.registerCommand(VerifySketch.Commands.VERIFY_SKETCH_TOOLBAR, {
@@ -84,60 +91,86 @@ export class VerifySketch extends CoreServiceContribution {
     });
   }
 
-  async verifySketch(exportBinaries?: boolean): Promise<void> {
-    // even with buttons disabled, better to double check if a verify is already in progress
+  protected override handleError(error: unknown): void {
+    this.coreErrorHandler.tryHandle(error);
+    super.handleError(error);
+  }
+
+  private async verifySketch(
+    params?: VerifySketchParams
+  ): Promise<CoreService.Options.Compile | undefined> {
     if (this.verifyInProgress) {
-      return;
+      return undefined;
     }
 
-    // toggle the toolbar button and menu item state.
-    // verifyInProgress will be set to false whether the compilation fails or not
-    const sketch = await this.sketchServiceClient.currentSketch();
-    if (!CurrentSketch.isValid(sketch)) {
-      return;
-    }
     try {
-      this.verifyInProgress = true;
+      if (!params?.silent) {
+        this.verifyInProgress = true;
+        this.onDidChangeEmitter.fire();
+      }
       this.coreErrorHandler.reset();
-      this.onDidChangeEmitter.fire();
-      const { boardsConfig } = this.boardsServiceClientImpl;
-      const [fqbn, sourceOverride] = await Promise.all([
-        this.boardsDataStore.appendConfigToFqbn(
-          boardsConfig.selectedBoard?.fqbn
+
+      const options = await this.options(params?.exportBinaries);
+      if (!options) {
+        return undefined;
+      }
+
+      await this.doWithProgress({
+        progressText: nls.localize(
+          'arduino/sketch/compile',
+          'Compiling sketch...'
         ),
-        this.sourceOverride(),
-      ]);
-      const board = {
-        ...boardsConfig.selectedBoard,
-        name: boardsConfig.selectedBoard?.name || '',
-        fqbn,
-      };
-      const verbose = this.preferences.get('arduino.compile.verbose');
-      const compilerWarnings = this.preferences.get('arduino.compile.warnings');
-      const optimizeForDebug =
-        await this.commandService.executeCommand<boolean>(
-          'arduino-is-optimize-for-debug'
-        );
-      this.outputChannelManager.getChannel('Arduino').clear();
-      await this.coreService.compile({
-        sketch,
-        board,
-        optimizeForDebug: Boolean(optimizeForDebug),
-        verbose,
-        exportBinaries,
-        sourceOverride,
-        compilerWarnings,
+        task: (progressId, coreService) =>
+          coreService.compile({
+            ...options,
+            progressId,
+          }),
       });
       this.messageService.info(
         nls.localize('arduino/sketch/doneCompiling', 'Done compiling.'),
         { timeout: 3000 }
       );
+      // Returns with the used options for the compilation
+      // so that follow-up tasks (such as upload) can reuse the compiled code.
+      // Note that the `fqbn` is already decorated with the board settings, if any.
+      return options;
     } catch (e) {
       this.handleError(e);
+      return undefined;
     } finally {
       this.verifyInProgress = false;
-      this.onDidChangeEmitter.fire();
+      if (!params?.silent) {
+        this.onDidChangeEmitter.fire();
+      }
     }
+  }
+
+  private async options(
+    exportBinaries?: boolean
+  ): Promise<CoreService.Options.Compile | undefined> {
+    const sketch = await this.sketchServiceClient.currentSketch();
+    if (!CurrentSketch.isValid(sketch)) {
+      return undefined;
+    }
+    const { boardsConfig } = this.boardsServiceProvider;
+    const [fqbn, sourceOverride, optimizeForDebug] = await Promise.all([
+      this.boardsDataStore.appendConfigToFqbn(boardsConfig.selectedBoard?.fqbn),
+      this.sourceOverride(),
+      this.commandService.executeCommand<boolean>(
+        'arduino-is-optimize-for-debug'
+      ),
+    ]);
+    const verbose = this.preferences.get('arduino.compile.verbose');
+    const compilerWarnings = this.preferences.get('arduino.compile.warnings');
+    return {
+      sketch,
+      fqbn,
+      optimizeForDebug: Boolean(optimizeForDebug),
+      verbose,
+      exportBinaries,
+      sourceOverride,
+      compilerWarnings,
+    };
   }
 }
 

--- a/arduino-ide-extension/src/browser/widgets/component-list/filterable-list-container.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/filterable-list-container.tsx
@@ -5,6 +5,7 @@ import { CommandService } from '@theia/core/lib/common/command';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import { ConfirmDialog } from '@theia/core/lib/browser/dialogs';
 import { Searchable } from '../../../common/protocol/searchable';
+import { ExecuteWithProgress } from '../../../common/protocol/progressible';
 import { Installable } from '../../../common/protocol/installable';
 import { ArduinoComponent } from '../../../common/protocol/arduino-component';
 import { SearchBar } from './search-bar';
@@ -111,7 +112,7 @@ export class FilterableListContainer<
     version: Installable.Version
   ): Promise<void> {
     const { install, searchable } = this.props;
-    await Installable.doWithProgress({
+    await ExecuteWithProgress.doWithProgress({
       ...this.props,
       progressText:
         nls.localize('arduino/common/processing', 'Processing') +
@@ -137,7 +138,7 @@ export class FilterableListContainer<
       return;
     }
     const { uninstall, searchable } = this.props;
-    await Installable.doWithProgress({
+    await ExecuteWithProgress.doWithProgress({
       ...this.props,
       progressText:
         nls.localize('arduino/common/processing', 'Processing') +

--- a/arduino-ide-extension/src/common/protocol/installable.ts
+++ b/arduino-ide-extension/src/common/protocol/installable.ts
@@ -1,10 +1,6 @@
 import * as semver from 'semver';
-import type { Progress } from '@theia/core/lib/common/message-service-protocol';
-import {
-  CancellationToken,
-  CancellationTokenSource,
-} from '@theia/core/lib/common/cancellation';
-import { naturalCompare } from './../utils';
+import { ExecuteWithProgress } from './progressible';
+import { naturalCompare } from '../utils';
 import type { ArduinoComponent } from './arduino-component';
 import type { MessageService } from '@theia/core/lib/common/message-service';
 import type { ResponseServiceClient } from './response-service';
@@ -32,7 +28,7 @@ export namespace Installable {
     /**
      * Most recent version comes first, then the previous versions. (`1.8.1`, `1.6.3`, `1.6.2`, `1.6.1` and so on.)
      */
-    export const COMPARATOR = (left: Version, right: Version) => {
+    export const COMPARATOR = (left: Version, right: Version): number => {
       if (semver.valid(left) && semver.valid(right)) {
         return semver.compare(left, right);
       }
@@ -50,7 +46,7 @@ export namespace Installable {
     version: Installable.Version;
   }): Promise<void> {
     const { item, version } = options;
-    return doWithProgress({
+    return ExecuteWithProgress.doWithProgress({
       ...options,
       progressText: `Processing ${item.name}:${version}`,
       run: ({ progressId }) =>
@@ -71,7 +67,7 @@ export namespace Installable {
     item: T;
   }): Promise<void> {
     const { item } = options;
-    return doWithProgress({
+    return ExecuteWithProgress.doWithProgress({
       ...options,
       progressText: `Processing ${item.name}${
         item.installedVersion ? `:${item.installedVersion}` : ''
@@ -82,52 +78,5 @@ export namespace Installable {
           progressId,
         }),
     });
-  }
-
-  export async function doWithProgress(options: {
-    run: ({ progressId }: { progressId: string }) => Promise<void>;
-    messageService: MessageService;
-    responseService: ResponseServiceClient;
-    progressText: string;
-  }): Promise<void> {
-    return withProgress(
-      options.progressText,
-      options.messageService,
-      async (progress, _) => {
-        const progressId = progress.id;
-        const toDispose = options.responseService.onProgressDidChange(
-          (progressMessage) => {
-            if (progressId === progressMessage.progressId) {
-              const { message, work } = progressMessage;
-              progress.report({ message, work });
-            }
-          }
-        );
-        try {
-          options.responseService.clearOutput();
-          await options.run({ progressId });
-        } finally {
-          toDispose.dispose();
-        }
-      }
-    );
-  }
-
-  async function withProgress(
-    text: string,
-    messageService: MessageService,
-    cb: (progress: Progress, token: CancellationToken) => Promise<void>
-  ): Promise<void> {
-    const cancellationSource = new CancellationTokenSource();
-    const { token } = cancellationSource;
-    const progress = await messageService.showProgress(
-      { text, options: { cancelable: false } },
-      () => cancellationSource.cancel()
-    );
-    try {
-      await cb(progress, token);
-    } finally {
-      progress.cancel();
-    }
   }
 }

--- a/arduino-ide-extension/src/common/protocol/progressible.ts
+++ b/arduino-ide-extension/src/common/protocol/progressible.ts
@@ -1,0 +1,60 @@
+import type { CancellationToken } from '@theia/core/lib/common/cancellation';
+import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
+import type { MessageService } from '@theia/core/lib/common/message-service';
+import type { Progress } from '@theia/core/lib/common/message-service-protocol';
+import type { ResponseServiceClient } from './response-service';
+
+export namespace ExecuteWithProgress {
+  export async function doWithProgress<T>(options: {
+    run: ({ progressId }: { progressId: string }) => Promise<T>;
+    messageService: MessageService;
+    responseService: ResponseServiceClient;
+    progressText: string;
+    keepOutput?: boolean;
+  }): Promise<T> {
+    return withProgress(
+      options.progressText,
+      options.messageService,
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      async (progress, _token) => {
+        const progressId = progress.id;
+        const toDispose = options.responseService.onProgressDidChange(
+          (progressMessage) => {
+            if (progressId === progressMessage.progressId) {
+              const { message, work } = progressMessage;
+              progress.report({ message, work });
+            }
+          }
+        );
+        try {
+          if (!options.keepOutput) {
+            options.responseService.clearOutput();
+          }
+          const result = await options.run({ progressId });
+          return result;
+        } finally {
+          toDispose.dispose();
+        }
+      }
+    );
+  }
+
+  async function withProgress<T>(
+    text: string,
+    messageService: MessageService,
+    cb: (progress: Progress, token: CancellationToken) => Promise<T>
+  ): Promise<T> {
+    const cancellationSource = new CancellationTokenSource();
+    const { token } = cancellationSource;
+    const progress = await messageService.showProgress(
+      { text, options: { cancelable: false } },
+      () => cancellationSource.cancel()
+    );
+    try {
+      const result = await cb(progress, token);
+      return result;
+    } finally {
+      progress.cancel();
+    }
+  }
+}

--- a/arduino-ide-extension/src/common/protocol/response-service.ts
+++ b/arduino-ide-extension/src/common/protocol/response-service.ts
@@ -46,5 +46,5 @@ export interface ResponseService {
 export const ResponseServiceClient = Symbol('ResponseServiceClient');
 export interface ResponseServiceClient extends ResponseService {
   onProgressDidChange: Event<ProgressMessage>;
-  clearOutput: () => void;
+  clearOutput: () => void; // TODO: this should not belong here.
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -36,6 +36,7 @@
     "boardsManager": "Boards Manager",
     "bootloader": {
       "burnBootloader": "Burn Bootloader",
+      "burningBootloader": "Burning bootloader...",
       "doneBurningBootloader": "Done burning bootloader."
     },
     "burnBootloader": {
@@ -306,6 +307,7 @@
       "archiveSketch": "Archive Sketch",
       "cantOpen": "A folder named \"{0}\" already exists. Can't open sketch.",
       "close": "Are you sure you want to close the sketch?",
+      "compile": "Compiling sketch...",
       "configureAndUpload": "Configure And Upload",
       "createdArchive": "Created archive '{0}'.",
       "doneCompiling": "Done compiling.",
@@ -327,6 +329,7 @@
       "titleSketchbook": "Sketchbook",
       "upload": "Upload",
       "uploadUsingProgrammer": "Upload Using Programmer",
+      "uploading": "Uploading...",
       "userFieldsNotFoundError": "Can't find user fields for connected board",
       "verify": "Verify",
       "verifyOrCompile": "Verify/Compile"


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Show progress indication when running the `verify`, `upload`, `upload using programmer` or `burn bootloader` commands from IDE2.

The changes in action:
1. Verfiy:

https://user-images.githubusercontent.com/1405703/181473877-daa198b2-d102-446f-bf3d-1aa8d065e2e2.mp4


2. Upload:

https://user-images.githubusercontent.com/1405703/181473936-ba90256c-f925-4dde-9406-c9de7054af50.mp4

### Change description
<!-- What does your code do? -->

 - [dev]: The core service (backend) does not run `compile` before `verify`; it's the caller's responsibility to run it.

### Other information
<!-- Any additional information that could help the review process -->

~Noteworthy UI/UX changes:~

~An `Upload` consists of two tasks: `Verfiy` and `Upload`. With the proposed changes, users will see on the toolbar (Verify toolbar icon is yellow with the light Arduino theme) that if `Verify` is in progress, then `Upload` is in progress. See in action.~

~https://user-images.githubusercontent.com/1405703/181474498-14e02b6b-1f4e-4b07-b93c-7e819f874e8e.mp4~

~This is a UI change compared to the `HEAD` of the `main` branch, but I believe this is the correct solution What do you think @per1234 and @ubidefeo?~

For reviewers:
 - The _Output_ view should be revealed but not focused on `Verify`/`Upload`,
 - Please double check #1132,
 - The progress indication must be the same for platform/library install/uninstall and index updates.

Closes #575
Closes #1175

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)