### PR TITLE
Fix current IDE language on start-up

### DIFF
--- a/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
+++ b/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
@@ -82,7 +82,7 @@ import {
 } from '../common/protocol/authentication-service';
 import { ArduinoFirmwareUploaderImpl } from './arduino-firmware-uploader-impl';
 import { PlotterBackendContribution } from './plotter/plotter-backend-contribution';
-import { ArduinoLocalizationContribution } from './arduino-localization-contribution';
+import { ArduinoLocalizationContribution } from './i18n/arduino-localization-contribution';
 import { LocalizationContribution } from '@theia/core/lib/node/i18n/localization-contribution';
 import { MonitorManagerProxyImpl } from './monitor-manager-proxy-impl';
 import { MonitorManager, MonitorManagerName } from './monitor-manager';
@@ -102,6 +102,8 @@ import WebSocketProviderImpl from './web-socket/web-socket-provider-impl';
 import { WebSocketProvider } from './web-socket/web-socket-provider';
 import { ClangFormatter } from './clang-formatter';
 import { FormatterPath } from '../common/protocol/formatter';
+import { LocalizationBackendContribution } from './i18n/localization-backend-contribution';
+import { LocalizationBackendContribution as TheiaLocalizationBackendContribution } from '@theia/core/lib/node/i18n/localization-backend-contribution';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(BackendApplication).toSelf().inSingletonScope();
@@ -395,4 +397,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(BackendApplicationContribution).toService(PlotterBackendContribution);
   bind(ArduinoLocalizationContribution).toSelf().inSingletonScope();
   bind(LocalizationContribution).toService(ArduinoLocalizationContribution);
+  bind(LocalizationBackendContribution).toSelf().inSingletonScope();
+  rebind(TheiaLocalizationBackendContribution).toService(
+    LocalizationBackendContribution
+  );
 });

--- a/arduino-ide-extension/src/node/i18n/arduino-localization-contribution.ts
+++ b/arduino-ide-extension/src/node/i18n/arduino-localization-contribution.ts
@@ -11,142 +11,142 @@ export class ArduinoLocalizationContribution
   async registerLocalizations(registry: LocalizationRegistry): Promise<void> {
     registry.registerLocalizationFromRequire(
       'af',
-      require('../../build/i18n/af.json')
+      require('../../../build/i18n/af.json')
     );
 
     registry.registerLocalizationFromRequire(
       'en',
-      require('../../build/i18n/en.json')
+      require('../../../build/i18n/en.json')
     );
 
     registry.registerLocalizationFromRequire(
       'fr',
-      require('../../build/i18n/fr.json')
+      require('../../../build/i18n/fr.json')
     );
 
     registry.registerLocalizationFromRequire(
       'ko',
-      require('../../build/i18n/ko.json')
+      require('../../../build/i18n/ko.json')
     );
 
     registry.registerLocalizationFromRequire(
       'pt-br',
-      require('../../build/i18n/pt.json')
+      require('../../../build/i18n/pt.json')
     );
 
     registry.registerLocalizationFromRequire(
       'uk_UA',
-      require('../../build/i18n/uk_UA.json')
+      require('../../../build/i18n/uk_UA.json')
     );
 
     registry.registerLocalizationFromRequire(
       'ar',
-      require('../../build/i18n/ar.json')
+      require('../../../build/i18n/ar.json')
     );
 
     registry.registerLocalizationFromRequire(
       'es',
-      require('../../build/i18n/es.json')
+      require('../../../build/i18n/es.json')
     );
 
     registry.registerLocalizationFromRequire(
       'he',
-      require('../../build/i18n/he.json')
+      require('../../../build/i18n/he.json')
     );
 
     registry.registerLocalizationFromRequire(
       'my_MM',
-      require('../../build/i18n/my_MM.json')
+      require('../../../build/i18n/my_MM.json')
     );
 
     registry.registerLocalizationFromRequire(
       'ro',
-      require('../../build/i18n/ro.json')
+      require('../../../build/i18n/ro.json')
     );
 
     registry.registerLocalizationFromRequire(
       'zh-cn',
-      require('../../build/i18n/zh.json')
+      require('../../../build/i18n/zh.json')
     );
 
     registry.registerLocalizationFromRequire(
       'bg',
-      require('../../build/i18n/bg.json')
+      require('../../../build/i18n/bg.json')
     );
 
     registry.registerLocalizationFromRequire(
       'eu',
-      require('../../build/i18n/eu.json')
+      require('../../../build/i18n/eu.json')
     );
 
     registry.registerLocalizationFromRequire(
       'hu',
-      require('../../build/i18n/hu.json')
+      require('../../../build/i18n/hu.json')
     );
 
     registry.registerLocalizationFromRequire(
       'ne',
-      require('../../build/i18n/ne.json')
+      require('../../../build/i18n/ne.json')
     );
 
     registry.registerLocalizationFromRequire(
       'ru',
-      require('../../build/i18n/ru.json')
+      require('../../../build/i18n/ru.json')
     );
 
     registry.registerLocalizationFromRequire(
       'zh_TW',
-      require('../../build/i18n/zh_TW.json')
+      require('../../../build/i18n/zh_TW.json')
     );
 
     registry.registerLocalizationFromRequire(
       'de',
-      require('../../build/i18n/de.json')
+      require('../../../build/i18n/de.json')
     );
 
     registry.registerLocalizationFromRequire(
       'fa',
-      require('../../build/i18n/fa.json')
+      require('../../../build/i18n/fa.json')
     );
 
     registry.registerLocalizationFromRequire(
       'it',
-      require('../../build/i18n/it.json')
+      require('../../../build/i18n/it.json')
     );
 
     registry.registerLocalizationFromRequire(
       'nl',
-      require('../../build/i18n/nl.json')
+      require('../../../build/i18n/nl.json')
     );
 
     registry.registerLocalizationFromRequire(
       'sv_SE',
-      require('../../build/i18n/sv_SE.json')
+      require('../../../build/i18n/sv_SE.json')
     );
 
     registry.registerLocalizationFromRequire(
       'el',
-      require('../../build/i18n/el.json')
+      require('../../../build/i18n/el.json')
     );
 
     registry.registerLocalizationFromRequire(
       'fil',
-      require('../../build/i18n/fil.json')
+      require('../../../build/i18n/fil.json')
     );
 
     registry.registerLocalizationFromRequire(
       'ja',
-      require('../../build/i18n/ja.json')
+      require('../../../build/i18n/ja.json')
     );
 
     registry.registerLocalizationFromRequire(
       'pl',
-      require('../../build/i18n/pl.json')
+      require('../../../build/i18n/pl.json')
     );
 
     registry.registerLocalizationFromRequire(
       'tr',
-      require('../../build/i18n/tr.json')
+      require('../../../build/i18n/tr.json')
     );
   }
 }

--- a/arduino-ide-extension/src/node/i18n/localization-backend-contribution.ts
+++ b/arduino-ide-extension/src/node/i18n/localization-backend-contribution.ts
@@ -1,0 +1,45 @@
+import * as express from 'express';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { LocalizationBackendContribution as TheiaLocalizationBackendContribution } from '@theia/core/lib/node/i18n/localization-backend-contribution';
+import { PluginDeployer } from '@theia/plugin-ext/lib/common/plugin-protocol';
+import { PluginDeployerImpl } from '@theia/plugin-ext/lib/main/node/plugin-deployer-impl';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+
+@injectable()
+export class LocalizationBackendContribution extends TheiaLocalizationBackendContribution {
+  @inject(PluginDeployer)
+  private readonly pluginDeployer: PluginDeployerImpl;
+
+  private readonly initialized = new Deferred<void>();
+
+  override async initialize(): Promise<void> {
+    this.pluginDeployer.onDidDeploy(() => {
+      this.initialized.resolve();
+    });
+    return super.initialize();
+  }
+
+  override configure(app: express.Application): void {
+    app.get('/i18n/:locale', async (req, res) => {
+      let locale = req.params.locale;
+      /*
+        Waiting for the deploy of the language plugins is neecessary to avoid checking the available
+        languages before they're finished to be loaded: https://github.com/eclipse-theia/theia/issues/11471 
+      */
+      const start = performance.now();
+      await this.initialized.promise;
+      console.info(
+        'Waiting for the deploy of the language plugins took: ' +
+          (performance.now() - start) +
+          ' ms.'
+      );
+      locale = this.localizationProvider
+        .getAvailableLanguages()
+        .some((e) => e.languageId === locale)
+        ? locale
+        : 'en';
+      this.localizationProvider.setCurrentLanguage(locale);
+      res.send(this.localizationProvider.loadLocalization(locale));
+    });
+  }
+}


### PR DESCRIPTION
### Motivation
[IDE2 might forget the selected language](https://github.com/arduino/arduino-ide/issues/1219)

I noticed the root of the problem is here:

https://github.com/eclipse-theia/theia/blob/f4327c2f0c0f47f960a302590a51698879357841/packages/core/src/node/i18n/localization-backend-contribution.ts#L38-L39

`req.params.locale` is always restored correctly, but `this.localizationProvider.getAvailableLanguages()` doesn't return all the available languages. This happens because `getAvailableLanguages()` returns all the registered localizations with `languagePack` set to `true` (unless we call `getAvailableLanguages(true)`, in that case, it would always return all the languages):

https://github.com/eclipse-theia/theia/blob/f4327c2f0c0f47f960a302590a51698879357841/packages/core/src/node/i18n/localization-provider.ts#L50

The weird thing is that this happens also with _some_ languages registered with a language pack (so they'll eventually have `languagePack` set to `true`). I say _some_ languages because _some others_ work as expected. I strongly believe this is happening because of a race condition happening because `getAvailableLanguages` is called before the language packs are finished loading.

EDIT:
The root cause of this appears to be that `PluginDeployer` completes the execution of `deployPlugins` after the express backend tries to restore the current language

https://github.com/eclipse-theia/theia/blob/26649452aeac342f7551b8cae502740799085772/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts#L269

The solution I've found is to wait for [this event to emit](https://github.com/eclipse-theia/theia/blob/26649452aeac342f7551b8cae502740799085772/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts#L291)
 
### Change description
Re-implemented the restoration of the language in `localization-backend-contribution.ts`

Wait for the plugins to complete the deploy before restoring the current language:
https://github.com/arduino/arduino-ide/pull/1261/files#diff-19d891f1ffb8ce2979b6bee0d166700e20a6b965d1be5f72b3e331d0442eba35R16-R18


### Other information
This PR is a workaround for a Theia issue.
I opened an issue in the Theia repo here: https://github.com/eclipse-theia/theia/issues/11471
As soon as Theia fixes it, we can remove this code and the rebinding.

I've also opened a PR on Theia here: https://github.com/eclipse-theia/theia/pull/11472


Fixes #1219

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)