### PR TITLE
High Contrast theme updates

### DIFF
--- a/arduino-ide-extension/src/browser/style/arduino-select.css
+++ b/arduino-ide-extension/src/browser/style/arduino-select.css
@@ -49,3 +49,14 @@
     padding-top: 0 !important;
     padding-bottom: 0 !important;
 }
+
+
+/* High Contrast Theme rules */
+/* TODO: Remove it when the Theia version is upgraded to 1.27.0 and use Theia APIs to implement it*/
+.hc-black.hc-theia.theia-hc .arduino-select__option--is-selected {
+    outline: 1px solid var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc .arduino-select__option--is-focused {
+    outline: 1px dashed var(--theia-focusBorder);
+}

--- a/arduino-ide-extension/src/browser/style/boards-config-dialog.css
+++ b/arduino-ide-extension/src/browser/style/boards-config-dialog.css
@@ -272,6 +272,6 @@ div#select-board-dialog .selectBoardContainer .body .list .item.selected i {
   outline: 1px dashed var(--theia-focusBorder);
 }
 
-div#select-board-dialog .selectBoardContainer .body .list .item.selected {
+.hc-black.hc-theia.theia-hc div#select-board-dialog .selectBoardContainer .body .list .item.selected {
   outline: 1px solid var(--theia-focusBorder);
 }

--- a/arduino-ide-extension/src/browser/style/boards-config-dialog.css
+++ b/arduino-ide-extension/src/browser/style/boards-config-dialog.css
@@ -148,6 +148,7 @@ div#select-board-dialog .selectBoardContainer .body .list .item.selected i {
   background: var(--theia-arduino-toolbar-dropdown-background);
   border-radius: 1px;
   color: var(--theia-arduino-toolbar-dropdown-label);
+  border: 1px solid var(--theia-dropdown-border);
   display: flex;
   gap: 10px;
   height: 28px;
@@ -263,4 +264,14 @@ div#select-board-dialog .selectBoardContainer .body .list .item.selected i {
 .arduino-board-dropdown-footer {
   color: var(--theia-arduino-branding-primary);
   border-top: 1px solid var(--theia-arduino-toolbar-dropdown-border);
+}
+
+/* High Contrast Theme rules */
+/* TODO: Remove it when the Theia version is upgraded to 1.27.0 and use Theia APIs to implement it*/
+.hc-black.hc-theia.theia-hc #select-board-dialog .selectBoardContainer .body .list .item:hover {
+  outline: 1px dashed var(--theia-focusBorder);
+}
+
+div#select-board-dialog .selectBoardContainer .body .list .item.selected {
+  outline: 1px solid var(--theia-focusBorder);
 }

--- a/arduino-ide-extension/src/browser/style/certificate-uploader-dialog.css
+++ b/arduino-ide-extension/src/browser/style/certificate-uploader-dialog.css
@@ -72,3 +72,9 @@
   box-sizing: border-box;
 
 }
+
+/* High Contrast Theme rules */
+/* TODO: Remove it when the Theia version is upgraded to 1.27.0 and use Theia APIs to implement it*/
+.hc-black.hc-theia.theia-hc .certificate-add {
+  background-color: var(--theia-editorWidget-background);
+}

--- a/arduino-ide-extension/src/browser/style/index.css
+++ b/arduino-ide-extension/src/browser/style/index.css
@@ -135,3 +135,15 @@ button.secondary[disabled], .theia-button.secondary[disabled] {
 .fa-reload {
   font-size: 14px;
 }
+
+
+/* High Contrast Theme rules */
+/* TODO: Remove it when the Theia version is upgraded to 1.27.0 and use Theia APIs to implement it*/
+.hc-black.hc-theia.theia-hc button.theia-button:hover, 
+.hc-black.hc-theia.theia-hc .theia-button:hover {
+  outline: 1px dashed var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc .theia-button:focus {
+  outline: 1px solid var(--theia-focusBorder);
+}

--- a/arduino-ide-extension/src/browser/style/index.css
+++ b/arduino-ide-extension/src/browser/style/index.css
@@ -149,3 +149,9 @@ button.secondary[disabled], .theia-button.secondary[disabled] {
 .hc-black.hc-theia.theia-hc button.theia-button.secondary {
   border: 1px solid var(--theia-button-border);
 }
+
+.hc-black.hc-theia.theia-hc .theia-notification-list-item:hover:not(:focus) {
+  background-color: var(--theia-notifications-background);
+  outline: 1px dashed var(--theia-focusBorder);
+  outline-offset: -2px;
+}

--- a/arduino-ide-extension/src/browser/style/index.css
+++ b/arduino-ide-extension/src/browser/style/index.css
@@ -144,6 +144,8 @@ button.secondary[disabled], .theia-button.secondary[disabled] {
   outline: 1px dashed var(--theia-focusBorder);
 }
 
-.hc-black.hc-theia.theia-hc .theia-button:focus {
-  outline: 1px solid var(--theia-focusBorder);
+.hc-black.hc-theia.theia-hc button.theia-button,
+.hc-black.hc-theia.theia-hc .theia-button,
+.hc-black.hc-theia.theia-hc button.theia-button.secondary {
+  border: 1px solid var(--theia-button-border);
 }

--- a/arduino-ide-extension/src/browser/style/list-widget.css
+++ b/arduino-ide-extension/src/browser/style/list-widget.css
@@ -145,3 +145,14 @@ https://github.com/arduino/arduino-pro-ide/issues/82 */
 .component-list-item a:hover {
     text-decoration: underline;
 }
+
+/* High Contrast Theme rules */
+/* TODO: Remove it when the Theia version is upgraded to 1.27.0 and use Theia APIs to implement it*/
+.hc-black.hc-theia.theia-hc .component-list-item .header .installed:hover:before {
+    background-color: transparent;
+    outline: 1px dashed var(--theia-focusBorder);    
+}
+
+.hc-black.hc-theia.theia-hc .component-list-item .header .installed:before {
+    border: 1px solid var(--theia-button-border);
+}

--- a/arduino-ide-extension/src/browser/style/main.css
+++ b/arduino-ide-extension/src/browser/style/main.css
@@ -188,3 +188,59 @@
     border-right: none;
     background-color: var(--theia-arduino-output-background);
 }
+
+
+/* High Contrast Theme rules */
+/* TODO: Remove it when the Theia version is upgraded to 1.27.0 and use Theia APIs to implement it*/
+.hc-black.hc-theia.theia-hc .p-TabBar-toolbar .item.arduino-tool-item .arduino-upload-sketch--toolbar, 
+.hc-black.hc-theia.theia-hc .p-TabBar-toolbar .item.arduino-tool-item .arduino-verify-sketch--toolbar, 
+.hc-black.hc-theia.theia-hc .p-TabBar-toolbar .item.arduino-tool-item .arduino-start-debug {
+    background: transparent;
+}
+
+.hc-black.hc-theia.theia-hc .arduino-verify-sketch--toolbar-icon,
+.hc-black.hc-theia.theia-hc .arduino-upload-sketch--toolbar-icon,
+.hc-black.hc-theia.theia-hc .arduino-start-debug-icon {
+    background-color: var(--theia-arduino-toolbar-button-secondary-label);
+}
+
+.hc-black.hc-theia.theia-hc .p-TabBar-toolbar .item.arduino-tool-item.enabled:hover > div {
+    background: transparent;
+    outline: 1px dashed var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc .item.arduino-tool-item.toggled .arduino-verify-sketch--toolbar,
+.hc-black.hc-theia.theia-hc .item.arduino-tool-item.toggled .arduino-upload-sketch--toolbar {
+    background-color: transparent !important;
+    outline: 1px solid var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc .arduino-boards-dropdown-item:hover {
+    background: var(--theia-dropdown-background);
+}
+
+.hc-black.hc-theia.theia-hc .arduino-boards-dropdown-item:hover > div {
+    outline: 1px dashed var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc #theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current {
+    outline: 1px solid var(--theia-focusBorder);
+    outline-offset: -4px;
+}
+
+.hc-black.hc-theia.theia-hc #theia-main-content-panel .p-TabBar .p-TabBar-tab:hover {
+    outline: 1px dashed var(--theia-focusBorder);
+    outline-offset: -4px;
+}
+
+.hc-black.hc-theia.theia-hc .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:hover {
+  outline: 1px dashed var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc .quick-input-list .monaco-list-row.focused {
+    outline: 1px dotted var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc .quick-input-list .monaco-list-row:hover {
+    outline: 1px dashed var(--theia-focusBorder);
+}

--- a/arduino-ide-extension/src/browser/style/main.css
+++ b/arduino-ide-extension/src/browser/style/main.css
@@ -212,8 +212,9 @@
     background: var(--theia-dropdown-background);
 }
 
-.hc-black.hc-theia.theia-hc .arduino-boards-dropdown-item:hover > div {
+.hc-black.hc-theia.theia-hc .arduino-boards-dropdown-item:hover {
     outline: 1px dashed var(--theia-focusBorder);
+    outline-offset: -2px;
 }
 
 .hc-black.hc-theia.theia-hc #theia-main-content-panel .p-TabBar .p-TabBar-tab.p-mod-current {
@@ -236,4 +237,9 @@
 
 .hc-black.hc-theia.theia-hc .quick-input-list .monaco-list-row:hover {
     outline: 1px dashed var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc .quick-input-widget {
+    outline: 1px solid var(--theia-contrastBorder);
+    outline-offset: -1px;
 }

--- a/arduino-ide-extension/src/browser/style/main.css
+++ b/arduino-ide-extension/src/browser/style/main.css
@@ -192,26 +192,19 @@
 
 /* High Contrast Theme rules */
 /* TODO: Remove it when the Theia version is upgraded to 1.27.0 and use Theia APIs to implement it*/
-.hc-black.hc-theia.theia-hc .p-TabBar-toolbar .item.arduino-tool-item .arduino-upload-sketch--toolbar, 
-.hc-black.hc-theia.theia-hc .p-TabBar-toolbar .item.arduino-tool-item .arduino-verify-sketch--toolbar, 
-.hc-black.hc-theia.theia-hc .p-TabBar-toolbar .item.arduino-tool-item .arduino-start-debug {
-    background: transparent;
-}
-
-.hc-black.hc-theia.theia-hc .arduino-verify-sketch--toolbar-icon,
-.hc-black.hc-theia.theia-hc .arduino-upload-sketch--toolbar-icon,
-.hc-black.hc-theia.theia-hc .arduino-start-debug-icon {
-    background-color: var(--theia-arduino-toolbar-button-secondary-label);
-}
-
 .hc-black.hc-theia.theia-hc .p-TabBar-toolbar .item.arduino-tool-item.enabled:hover > div {
-    background: transparent;
+    background: var(--theia-arduino-toolbar-button-background);
     outline: 1px dashed var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc .p-TabBar-toolbar .item.arduino-tool-item.enabled:hover > div.toggle-serial-plotter,
+.hc-black.hc-theia.theia-hc .p-TabBar-toolbar .item.arduino-tool-item.enabled:hover > div.toggle-serial-monitor {
+    background: transparent;
 }
 
 .hc-black.hc-theia.theia-hc .item.arduino-tool-item.toggled .arduino-verify-sketch--toolbar,
 .hc-black.hc-theia.theia-hc .item.arduino-tool-item.toggled .arduino-upload-sketch--toolbar {
-    background-color: transparent !important;
+    background-color: var(--theia-arduino-toolbar-button-background) !important;
     outline: 1px solid var(--theia-focusBorder);
 }
 
@@ -234,7 +227,7 @@
 }
 
 .hc-black.hc-theia.theia-hc .p-TabBar.theia-app-centers .p-TabBar-tab.p-mod-closable > .p-TabBar-tabCloseIcon:hover {
-  outline: 1px dashed var(--theia-focusBorder);
+    outline: 1px dashed var(--theia-focusBorder);
 }
 
 .hc-black.hc-theia.theia-hc .quick-input-list .monaco-list-row.focused {

--- a/arduino-ide-extension/src/browser/style/sketchbook.css
+++ b/arduino-ide-extension/src/browser/style/sketchbook.css
@@ -70,3 +70,19 @@
 .theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected {
   background: var(--theia-list-inactiveSelectionBackground);
 }
+
+
+/* High Contrast Theme rules */
+/* TODO: Remove it when the Theia version is upgraded to 1.27.0 and use Theia APIs to implement it*/
+.hc-black.hc-theia.theia-hc .theia-TreeNode:hover {
+  outline: 1px dashed var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc .theia-Tree .theia-TreeNode.theia-mod-selected {
+  outline: 1px dotted var(--theia-focusBorder);
+}
+
+.hc-black.hc-theia.theia-hc .theia-Tree:focus .theia-TreeNode.theia-mod-selected, 
+.hc-black.hc-theia.theia-hc .theia-Tree .ReactVirtualized__List:focus .theia-TreeNode.theia-mod-selected {
+  outline: 1px solid var(--theia-focusBorder);
+}


### PR DESCRIPTION
### Motivation
The High Contrast theme needs to be updated as hover status in drop-down menus and sketchbook is missing, board selector has no borders, and other design issues make the experience unpleasant to use.

### Change description

- Serial Monitor drop-down menu selector hover and selected state.
- Board selector border.
- Board selector hover and selected state.
- Buttons hover and focus state.
- Side bar elements (Sketchbook etc.) hover and selected state.
- Toolbar buttons hover and selected state.
- Quick inputs hover and selected state.
- Install/Uninstall button hover state.
- Buttons borders.
- Notification hover status.
- Command palette border.

### Other information
This is a workaround until the version of Theia used is updated to 1.27.0, where the Theia High Contrast theme is updated and it's possible to use the Theia APIs to customize it.

Closes #1202.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)