### PR TITLE
#118, #1154 Link compiler errors to editor.

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/burn-bootloader.ts
+++ b/arduino-ide-extension/src/browser/contributions/burn-bootloader.ts
@@ -29,6 +29,7 @@ export class BurnBootloader extends CoreServiceContribution {
   }
 
   private async burnBootloader(): Promise<void> {
+    this.clearVisibleNotification();
     const options = await this.options();
     try {
       await this.doWithProgress({

--- a/arduino-ide-extension/src/browser/contributions/format.ts
+++ b/arduino-ide-extension/src/browser/contributions/format.ts
@@ -2,8 +2,7 @@ import { MaybePromise } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import { Formatter } from '../../common/protocol/formatter';
-import { InoSelector } from '../ino-selectors';
-import { fullRange } from '../utils/monaco';
+import { InoSelector } from '../selectors';
 import { Contribution, URI } from './contribution';
 
 @injectable()
@@ -40,7 +39,7 @@ export class Format
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _token: monaco.CancellationToken
   ): Promise<monaco.languages.TextEdit[]> {
-    const range = fullRange(model);
+    const range = model.getFullModelRange();
     const text = await this.format(model, range, options);
     return [{ range, text }];
   }

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -191,6 +191,7 @@ export class UploadSketch extends CoreServiceContribution {
       // uploadInProgress will be set to false whether the upload fails or not
       this.uploadInProgress = true;
       this.onDidChangeEmitter.fire();
+      this.clearVisibleNotification();
 
       const verifyOptions =
         await this.commandService.executeCommand<CoreService.Options.Compile>(

--- a/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
@@ -108,6 +108,7 @@ export class VerifySketch extends CoreServiceContribution {
         this.verifyInProgress = true;
         this.onDidChangeEmitter.fire();
       }
+      this.clearVisibleNotification();
       this.coreErrorHandler.reset();
 
       const options = await this.options(params?.exportBinaries);

--- a/arduino-ide-extension/src/browser/selectors.ts
+++ b/arduino-ide-extension/src/browser/selectors.ts
@@ -1,4 +1,5 @@
 import * as monaco from '@theia/monaco-editor-core';
+import { OutputUri } from '@theia/output/lib/common/output-uri';
 /**
  * Exclusive "ino" document selector for monaco.
  */
@@ -11,3 +12,11 @@ function selectorOf(
     exclusive: true, // <-- this should make sure the custom formatter has higher precedence over the LS formatter.
   }));
 }
+
+/**
+ * Selector for the `monaco` resource in the Arduino _Output_ channel.
+ */
+export const ArduinoOutputSelector: monaco.languages.LanguageSelector = {
+  scheme: OutputUri.SCHEME,
+  pattern: '**/Arduino',
+};

--- a/arduino-ide-extension/src/browser/theia/messages/notifications-manager.ts
+++ b/arduino-ide-extension/src/browser/theia/messages/notifications-manager.ts
@@ -1,9 +1,10 @@
-import { injectable } from '@theia/core/shared/inversify';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
-import {
+import type {
+  Message,
   ProgressMessage,
   ProgressUpdate,
 } from '@theia/core/lib/common/message-service-protocol';
+import { injectable } from '@theia/core/shared/inversify';
 import { NotificationManager as TheiaNotificationManager } from '@theia/messages/lib/browser/notifications-manager';
 
 @injectable()
@@ -34,7 +35,9 @@ export class NotificationManager extends TheiaNotificationManager {
     this.fireUpdatedEvent();
   }
 
-  protected override toPlainProgress(update: ProgressUpdate): number | undefined {
+  protected override toPlainProgress(
+    update: ProgressUpdate
+  ): number | undefined {
     if (!update.work) {
       return undefined;
     }
@@ -42,5 +45,12 @@ export class NotificationManager extends TheiaNotificationManager {
       return Number.NaN; // This should trigger the unknown monitor.
     }
     return Math.min((update.work.done / update.work.total) * 100, 100);
+  }
+
+  /**
+   * For `public` visibility.
+   */
+  override getMessageId(message: Message): string {
+    return super.getMessageId(message);
   }
 }

--- a/arduino-ide-extension/src/browser/utils/monaco.ts
+++ b/arduino-ide-extension/src/browser/utils/monaco.ts
@@ -1,8 +1,0 @@
-import * as monaco from '@theia/monaco-editor-core';
-
-export function fullRange(model: monaco.editor.ITextModel): monaco.Range {
-  const lastLine = model.getLineCount();
-  const lastLineMaxColumn = model.getLineMaxColumn(lastLine);
-  const end = new monaco.Position(lastLine, lastLineMaxColumn);
-  return monaco.Range.fromPositions(new monaco.Position(1, 1), end);
-}

--- a/arduino-ide-extension/src/common/protocol/core-service.ts
+++ b/arduino-ide-extension/src/common/protocol/core-service.ts
@@ -1,5 +1,9 @@
 import { ApplicationError } from '@theia/core/lib/common/application-error';
-import type { Location } from '@theia/core/shared/vscode-languageserver-protocol';
+import type {
+  Location,
+  Range,
+  Position,
+} from '@theia/core/shared/vscode-languageserver-protocol';
 import type {
   BoardUserField,
   Port,
@@ -15,10 +19,40 @@ export const CompilerWarningLiterals = [
 ] as const;
 export type CompilerWarnings = typeof CompilerWarningLiterals[number];
 export namespace CoreError {
-  export interface ErrorLocation {
+  export interface ErrorLocationRef {
     readonly message: string;
     readonly location: Location;
     readonly details?: string;
+  }
+  export namespace ErrorLocationRef {
+    export function equals(
+      left: ErrorLocationRef,
+      right: ErrorLocationRef
+    ): boolean {
+      return (
+        left.message === right.message &&
+        left.details === right.details &&
+        equalsLocation(left.location, right.location)
+      );
+    }
+    function equalsLocation(left: Location, right: Location): boolean {
+      return left.uri === right.uri && equalsRange(left.range, right.range);
+    }
+    function equalsRange(left: Range, right: Range): boolean {
+      return (
+        equalsPosition(left.start, right.start) &&
+        equalsPosition(left.end, right.end)
+      );
+    }
+    function equalsPosition(left: Position, right: Position): boolean {
+      return left.character === right.character && left.line === right.line;
+    }
+  }
+  export interface ErrorLocation extends ErrorLocationRef {
+    /**
+     * The range of the error location source from the CLI output.
+     */
+    readonly rangesInOutput: Range[]; // The same error might show up multiple times in the CLI output: https://github.com/arduino/arduino-cli/issues/1761
   }
   export const Codes = {
     Verify: 4001,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -155,7 +155,8 @@
       "increaseFontSize": "Increase Font Size",
       "increaseIndent": "Increase Indent",
       "nextError": "Next Error",
-      "previousError": "Previous Error"
+      "previousError": "Previous Error",
+      "revealError": "Reveal Error"
     },
     "electron": {
       "couldNotSave": "Could not save the sketch. Please copy your unsaved work into your favorite text editor, and restart the IDE.",


### PR DESCRIPTION
### Motivation
Can reveal the error location in the editor from the _Output_ view.

### Change description

In-action:

https://user-images.githubusercontent.com/1405703/182376367-d2f5c299-9370-49bb-a67d-342d887115ec.mp4

Noteworthy changes:
 - The error decoration is automatically removed from the editor when a `TextDocumentChangeEvent` affects the line where the decorator is.

https://user-images.githubusercontent.com/1405703/182377221-75662cf7-54bc-44b7-a485-4595cc61d05b.mp4


### Other information

Closes #118
Closes #1154

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)