### PR TITLE
#1278 Use FQBN instead of `Board` for the monitor ID.

### DIFF
--- a/arduino-ide-extension/src/node/arduino-firmware-uploader-impl.ts
+++ b/arduino-ide-extension/src/node/arduino-firmware-uploader-impl.ts
@@ -76,7 +76,7 @@ export class ArduinoFirmwareUploaderImpl implements ArduinoFirmwareUploader {
       fqbn: firmware.board_fqbn,
     };
     try {
-      await this.monitorManager.notifyUploadStarted(board, port);
+      await this.monitorManager.notifyUploadStarted(board.fqbn, port);
       output = await this.runCommand([
         'firmware',
         'flash',
@@ -90,7 +90,7 @@ export class ArduinoFirmwareUploaderImpl implements ArduinoFirmwareUploader {
     } catch (e) {
       throw e;
     } finally {
-      await this.monitorManager.notifyUploadFinished(board, port);
+      await this.monitorManager.notifyUploadFinished(board.fqbn, port);
       return output;
     }
   }

--- a/arduino-ide-extension/src/node/core-service-impl.ts
+++ b/arduino-ide-extension/src/node/core-service-impl.ts
@@ -23,7 +23,7 @@ import {
   UploadUsingProgrammerResponse,
 } from './cli-protocol/cc/arduino/cli/commands/v1/upload_pb';
 import { ResponseService } from '../common/protocol/response-service';
-import { Board, OutputMessage, Port, Status } from '../common/protocol';
+import { OutputMessage, Port, Status } from '../common/protocol';
 import { ArduinoCoreServiceClient } from './cli-protocol/cc/arduino/cli/commands/v1/commands_grpc_pb';
 import { Port as GrpcPort } from './cli-protocol/cc/arduino/cli/commands/v1/port_pb';
 import { ApplicationError, CommandService, Disposable, nls } from '@theia/core';
@@ -376,23 +376,23 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
   }
 
   private async notifyUploadWillStart({
-    board,
+    fqbn,
     port,
   }: {
-    board?: Board | undefined;
+    fqbn?: string | undefined;
     port?: Port | undefined;
   }): Promise<void> {
-    return this.monitorManager.notifyUploadStarted(board, port);
+    return this.monitorManager.notifyUploadStarted(fqbn, port);
   }
 
   private async notifyUploadDidFinish({
-    board,
+    fqbn,
     port,
   }: {
-    board?: Board | undefined;
+    fqbn?: string | undefined;
     port?: Port | undefined;
   }): Promise<Status> {
-    return this.monitorManager.notifyUploadFinished(board, port);
+    return this.monitorManager.notifyUploadFinished(fqbn, port);
   }
 
   private mergeSourceOverrides(


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To fix the upload functionality in IDE2 when the monitor is running.

### Change description
 Use `fqbn` (`string | undefined`) type instead of the `Board | undefined` for the monitor ID when notifying `MonitorService` before/after executing the `upload` command.

### Other information

Closes #1278

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)