### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -41,7 +41,7 @@ The _frontend_ is running as an Electron renderer process and can invoke service
 
 If you’re familiar with TypeScript, the [Theia IDE](https://theia-ide.org/), and if you want to contribute to the
 project, you should be able to build the Arduino IDE locally.
-Please refer to the [Theia IDE prerequisites](https://github.com/theia-ide/theia/blob/master/doc/) documentation for the setup instructions.
+Please refer to the [Theia IDE prerequisites](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites) documentation for the setup instructions.
 > **Note**: Node.js 14 must be used instead of the version 12 recommended at the link above.
 
 Once you have all the tools installed, you can build the editor following these steps
@@ -88,19 +88,6 @@ This project is built on [GitHub Actions](https://github.com/arduino/arduino-ide
    ```sh
     git push origin 1.2.3
    ```
-
-## Notes for Linux contributors
-These are based on a XUbuntu 22.04 LTS system.
-You will need the following dependencies:
-
- - Nodejs-14.0 or up
- - Dependencies for node-native-keymap:
-
-```sudo apt-get install -y g++ gcc make python2.7 pkg-config libx11-dev libxkbfile-dev libsecret-1-dev```
-
-Source:  https://stackoverflow.com/a/55878577
-
-Yarn will then download additional dependencies automatically and start the build process. The initial setup and build with yarn takes less than 5 minutes on an AMD Athlon 200GE.
 
 ## Notes for macOS contributors
 Beginning in macOS 10.14.5, the software [must be notarized to run](https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution). The signing and notarization processes for the Arduino IDE are managed by our Continuous Integration (CI) workflows, implemented with GitHub Actions. On every push and pull request, the Arduino IDE is built and saved to a workflow artifact. These artifacts can be used by contributors and beta testers who don't want to set up a build system locally.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -89,6 +89,18 @@ This project is built on [GitHub Actions](https://github.com/arduino/arduino-ide
     git push origin 1.2.3
    ```
 
+## Notes for Linux contributors
+These are based on a XUbuntu 22.04 LTS system.
+You will need the following dependencies:
+
+ - Nodejs-14.0 or up
+ - Dependencies for node-native-keymap:
+
+```sudo apt-get install -y g++ gcc make python2.7 pkg-config libx11-dev libxkbfile-dev libsecret-1-dev```
+
+Source:  https://stackoverflow.com/a/55878577
+
+Yarn will then download additional dependencies automatically and start the build process. The initial setup and build with yarn takes less than 5 minutes on an AMD Athlon 200GE.
 
 ## Notes for macOS contributors
 Beginning in macOS 10.14.5, the software [must be notarized to run](https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution). The signing and notarization processes for the Arduino IDE are managed by our Continuous Integration (CI) workflows, implemented with GitHub Actions. On every push and pull request, the Arduino IDE is built and saved to a workflow artifact. These artifacts can be used by contributors and beta testers who don't want to set up a build system locally.


### PR DESCRIPTION
Added "Notes for Linux contributors" based on my own building experience

### Motivation
I wanted to test out #1279 for myself without having to wait for the nightly build.

### Change description
The changes in BUILDING.md add a subcategory for Linux contributors which talks about issues that arise by missing dependencies.

### Other information
I had these minor setbacks doing the build myself and saw that there was no subcategory in this manual for Linux users. I think it is handy to streamline the build process and therefore its documentation as much as possible to encourage maybe even very novice contributors that can then easily add minor and simple fixes and test them out on their own. Or possibly do it for the reasons I did it, to test changes without having to wait for the nightly build.

### Reviewer checklist

* [X] PR addresses a single concern.
* [X] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [X] PR title and description are properly filled.
* [X] Docs have been added / updated (for bug fixes / features)