### PR TITLE
Set `XDG_CONFIG_HOME` env on Linux when not set.

### DIFF
--- a/electron/build/patch/backend/main.js
+++ b/electron/build/patch/backend/main.js
@@ -1,4 +1,18 @@
 // @ts-check
+
+// Patch for on Linux when `XDG_CONFIG_HOME` is not available, `node-log-rotate` creates the folder with `undefined` name.
+// See https://github.com/lemon-sour/node-log-rotate/issues/23 and https://github.com/arduino/arduino-ide/issues/394.
+// If the IDE2 is running on Linux, and the `XDG_CONFIG_HOME` variable is not available, set it to avoid the `undefined` folder.
+// From the specs: https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
+// "If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used."
+const os = require('os');
+if (os.platform() === 'linux' && !process.env['XDG_CONFIG_HOME']) {
+    const { join } = require('path');
+    const home = process.env['HOME'];
+    const xdgConfigHome = home ? join(home, '.config') : join(os.homedir(), '.config');
+    process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
+}
+
 const { setup, log } = require('node-log-rotate');
 setup({
     appName: 'Arduino IDE',


### PR DESCRIPTION

### Motivation

Set the `XDG_CONFIG_HOME` env on Linux when not set. Otherwise, `node-log-rotate` creates a folder with the `undefined` name.

### Change description
<!-- What does your code do? -->
Patched the patched `main.js` for the Theia backend. 🤦 

### Other information

Closes #394.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)