### PR TITLE
Use the refactored CLI in IDE2

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -160,7 +160,11 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.26.0-rc.1"
+      "version": {
+        "owner": "arduino",
+        "repo": "arduino-cli",
+        "commitish": "test_1"
+      }
     },
     "fwuploader": {
       "version": "2.2.0"


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The IDE2 uses a CLI from the [`test_1`](https://github.com/arduino/arduino-cli/tree/test_1) branch from the `arduino` owner.

![Screen Shot 2022-08-11 at 10 11 03](https://user-images.githubusercontent.com/1405703/184092149-a904aac1-cbe3-4800-8643-400679109230.png)

![Screen Shot 2022-08-11 at 10 16 31](https://user-images.githubusercontent.com/1405703/184092170-9de27447-397d-421c-8a39-15dc81ba5f24.png)

### Change description
No code changes. The IDE2 uses the CLI from the `HEAD` of [this](https://github.com/arduino/arduino-cli/tree/test_1) branch.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)