### PR TITLE
Use `Task` to build pinned CLI for IDE2.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,12 @@ jobs:
         with:
           python-version: '3.x'
 
+      - name: Install Taskfile
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
       - name: Package
         shell: bash
         env:

--- a/.github/workflows/check-i18n-task.yml
+++ b/.github/workflows/check-i18n-task.yml
@@ -31,6 +31,12 @@ jobs:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install Taskfile
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
       - name: Install dependencies
         run: yarn
 

--- a/arduino-ide-extension/scripts/download-cli.js
+++ b/arduino-ide-extension/scripts/download-cli.js
@@ -6,7 +6,7 @@
   const semver = require('semver');
   const moment = require('moment');
   const downloader = require('./downloader');
-  const { goBuildFromGit } = require('./utils');
+  const { taskBuildFromGit } = require('./utils');
 
   const version = (() => {
     const pkg = require(path.join(__dirname, '..', 'package.json'));
@@ -82,6 +82,6 @@
       shell.exit(1);
     }
   } else {
-    goBuildFromGit(version, destinationPath, 'CLI');
+    taskBuildFromGit(version, destinationPath, 'CLI');
   }
 })();

--- a/arduino-ide-extension/scripts/utils.js
+++ b/arduino-ide-extension/scripts/utils.js
@@ -1,4 +1,15 @@
 /**
+ * Clones something from GitHub and builds it with [`Task`](https://taskfile.dev/).
+ *
+ * @param version {object} the version object.
+ * @param destinationPath {string} the absolute path of the output binary. For example, `C:\\folder\\arduino-cli.exe` or `/path/to/arduino-language-server`
+ * @param taskName {string} for the CLI logging . Can be `'CLI'` or `'language-server'`, etc.
+ */
+exports.taskBuildFromGit = (version, destinationPath, taskName) => {
+  return buildFromGit('task', version, destinationPath, taskName);
+};
+
+/**
  * Clones something from GitHub and builds it with `Golang`.
  *
  * @param version {object} the version object.
@@ -6,6 +17,13 @@
  * @param taskName {string} for the CLI logging . Can be `'CLI'` or `'language-server'`, etc.
  */
 exports.goBuildFromGit = (version, destinationPath, taskName) => {
+  return buildFromGit('go', version, destinationPath, taskName);
+};
+
+/**
+ * The `command` is either `go` or `task`.
+ */
+function buildFromGit(command, version, destinationPath, taskName) {
   const fs = require('fs');
   const path = require('path');
   const temp = require('temp');
@@ -62,7 +80,7 @@ exports.goBuildFromGit = (version, destinationPath, taskName) => {
   }
 
   shell.echo(`>>> Building the ${taskName}...`);
-  if (shell.exec('go build', { cwd: tempRepoPath }).code !== 0) {
+  if (shell.exec(`${command} build`, { cwd: tempRepoPath }).code !== 0) {
     shell.exit(1);
   }
   shell.echo(`<<< Done ${taskName} build.`);
@@ -89,4 +107,4 @@ exports.goBuildFromGit = (version, destinationPath, taskName) => {
     shell.exit(1);
   }
   shell.echo(`>>> Verified ${taskName}.`);
-};
+}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To show the exact CLI version (commit hash) in IDE2 when IDE2 is using a pinned version, not yet released CLI.

### Change description
<!-- What does your code do? -->
 - Updated the GH workflow and make `Task` available,
 - Changed the CLI downloader to use `task` instead of `go` when a CLI ought to be produced on the fly.

### Other information
<!-- Any additional information that could help the review process -->

It's recommended for devs to install `Task` on the dev env. See [here](https://taskfile.dev/installation/).

Closes #1313

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)