### PR TITLE
Document clangd update procedure

### DIFF
--- a/arduino-ide-extension/README.md
+++ b/arduino-ide-extension/README.md
@@ -62,6 +62,15 @@ The Config Service knows about your system, like for example the default sketch 
   - Some CLI updates can bring changes to the gRPC interfaces, as the API might change. gRPC interfaces can be updated running the command
     `yarn --cwd arduino-ide-extension generate-protocol`
 
+### Update **clangd** and **ClangFormat**
+
+The [**clangd** C++ language server](https://clangd.llvm.org/) and the [**ClangFormat** code formatter](https://clang.llvm.org/docs/ClangFormat.html) tool dependencies are managed in parallel. Updating them to a different version is done by the following procedure:
+
+1. If the target version is not already [available from the `arduino/clang-static-binaries` repository](https://github.com/arduino/clang-static-binaries/releases), submit [an issue there](https://github.com/arduino/clang-static-binaries/issues) requesting a build and wait for that to be completed.
+1. Validate the **ClangFormat** configuration for the target version by following the instructions [**here**](https://github.com/arduino/tooling-project-assets/tree/main/other/clang-format-configuration#clangformat-version-updates)
+1. Submit a pull request in the `arduino/arduino-ide` repository to update the version in the `arduino.clangd.version` key of [`package.json`](package.json).
+1. Submit a pull request in [the `arduino/tooling-project-assets` repository](https://github.com/arduino/tooling-project-assets) to update the version in the `vars.DEFAULT_CLANG_FORMAT_VERSION` field of [`Taskfile.yml`](https://github.com/arduino/tooling-project-assets/blob/main/Taskfile.yml).
+
 ### Customize Icons
 ArduinoIde uses a customized version of FontAwesome.
 In order to update/replace icons follow the following steps:


### PR DESCRIPTION
Arduino IDE has dependencies on the clangd C++ language server and ClangFormat code formatter tools. These are updated
periodically to benefit from the ongoing development on those projects.

The update procedure requires operations in three different repositories:

- Generate builds in [`arduino/clang-static-binaries`](https://github.com/arduino/clang-static-binaries/releases)
- Validate and update formatter configuration in [`arduino/tooling-project-assets`](https://github.com/arduino/tooling-project-assets)
- Update metadata in [`arduino/arduino-ide`](https://github.com/arduino/arduino-ide)

### Motivation

The above information is undocumented and the update procedure exists only in the form of ["institutional memory"](https://en.wikipedia.org/wiki/Institutional_memory).

This lack of documentation might result in inefficiency for future maintainers performing a task that has been very well streamlined in all other respects.

### Change description

Fully document the update procedure in the readme of **arduino-ide-extension**.

### Additional information

Rendered content can be previewed here:

https://github.com/per1234/arduino-ide/blob/clangd-update-docs/arduino-ide-extension/README.md#update-clangd-and-clangformat

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)