### PR TITLE
#411 Fixed bug when saving sketch as. Made native file dialogs modal.

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/add-file.ts
+++ b/arduino-ide-extension/src/browser/contributions/add-file.ts
@@ -15,7 +15,7 @@ import { CurrentSketch } from '../../common/protocol/sketches-service-client-imp
 @injectable()
 export class AddFile extends SketchContribution {
   @inject(FileDialogService)
-  protected readonly fileDialogService: FileDialogService;
+  private readonly fileDialogService: FileDialogService;
 
   override registerCommands(registry: CommandRegistry): void {
     registry.registerCommand(AddFile.Commands.ADD_FILE, {
@@ -31,7 +31,7 @@ export class AddFile extends SketchContribution {
     });
   }
 
-  protected async addFile(): Promise<void> {
+  private async addFile(): Promise<void> {
     const sketch = await this.sketchServiceClient.currentSketch();
     if (!CurrentSketch.isValid(sketch)) {
       return;
@@ -41,6 +41,7 @@ export class AddFile extends SketchContribution {
       canSelectFiles: true,
       canSelectFolders: false,
       canSelectMany: false,
+      modal: true,
     });
     if (!toAddUri) {
       return;

--- a/arduino-ide-extension/src/browser/contributions/add-zip-library.ts
+++ b/arduino-ide-extension/src/browser/contributions/add-zip-library.ts
@@ -17,13 +17,13 @@ import { nls } from '@theia/core/lib/common';
 @injectable()
 export class AddZipLibrary extends SketchContribution {
   @inject(EnvVariablesServer)
-  protected readonly envVariableServer: EnvVariablesServer;
+  private readonly envVariableServer: EnvVariablesServer;
 
   @inject(ResponseServiceClient)
-  protected readonly responseService: ResponseServiceClient;
+  private readonly responseService: ResponseServiceClient;
 
   @inject(LibraryService)
-  protected readonly libraryService: LibraryService;
+  private readonly libraryService: LibraryService;
 
   override registerCommands(registry: CommandRegistry): void {
     registry.registerCommand(AddZipLibrary.Commands.ADD_ZIP_LIBRARY, {
@@ -43,23 +43,26 @@ export class AddZipLibrary extends SketchContribution {
     });
   }
 
-  async addZipLibrary(): Promise<void> {
+  private async addZipLibrary(): Promise<void> {
     const homeUri = await this.envVariableServer.getHomeDirUri();
     const defaultPath = await this.fileService.fsPath(new URI(homeUri));
-    const { canceled, filePaths } = await remote.dialog.showOpenDialog({
-      title: nls.localize(
-        'arduino/selectZip',
-        "Select a zip file containing the library you'd like to add"
-      ),
-      defaultPath,
-      properties: ['openFile'],
-      filters: [
-        {
-          name: nls.localize('arduino/library/zipLibrary', 'Library'),
-          extensions: ['zip'],
-        },
-      ],
-    });
+    const { canceled, filePaths } = await remote.dialog.showOpenDialog(
+      remote.getCurrentWindow(),
+      {
+        title: nls.localize(
+          'arduino/selectZip',
+          "Select a zip file containing the library you'd like to add"
+        ),
+        defaultPath,
+        properties: ['openFile'],
+        filters: [
+          {
+            name: nls.localize('arduino/library/zipLibrary', 'Library'),
+            extensions: ['zip'],
+          },
+        ],
+      }
+    );
     if (!canceled && filePaths.length) {
       const zipUri = await this.fileSystemExt.getUri(filePaths[0]);
       try {

--- a/arduino-ide-extension/src/browser/contributions/archive-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/archive-sketch.ts
@@ -28,7 +28,7 @@ export class ArchiveSketch extends SketchContribution {
     });
   }
 
-  protected async archiveSketch(): Promise<void> {
+  private async archiveSketch(): Promise<void> {
     const [sketch, config] = await Promise.all([
       this.sketchServiceClient.currentSketch(),
       this.configService.getConfiguration(),
@@ -43,13 +43,16 @@ export class ArchiveSketch extends SketchContribution {
     const defaultPath = await this.fileService.fsPath(
       new URI(config.sketchDirUri).resolve(archiveBasename)
     );
-    const { filePath, canceled } = await remote.dialog.showSaveDialog({
-      title: nls.localize(
-        'arduino/sketch/saveSketchAs',
-        'Save sketch folder as...'
-      ),
-      defaultPath,
-    });
+    const { filePath, canceled } = await remote.dialog.showSaveDialog(
+      remote.getCurrentWindow(),
+      {
+        title: nls.localize(
+          'arduino/sketch/saveSketchAs',
+          'Save sketch folder as...'
+        ),
+        defaultPath,
+      }
+    );
     if (!filePath || canceled) {
       return;
     }

--- a/arduino-ide-extension/src/browser/contributions/open-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch.ts
@@ -26,21 +26,21 @@ import { nls } from '@theia/core/lib/common';
 @injectable()
 export class OpenSketch extends SketchContribution {
   @inject(MenuModelRegistry)
-  protected readonly menuRegistry: MenuModelRegistry;
+  private readonly menuRegistry: MenuModelRegistry;
 
   @inject(ContextMenuRenderer)
-  protected readonly contextMenuRenderer: ContextMenuRenderer;
+  private readonly contextMenuRenderer: ContextMenuRenderer;
 
   @inject(BuiltInExamples)
-  protected readonly builtInExamples: BuiltInExamples;
+  private readonly builtInExamples: BuiltInExamples;
 
   @inject(ExamplesService)
-  protected readonly examplesService: ExamplesService;
+  private readonly examplesService: ExamplesService;
 
   @inject(Sketchbook)
-  protected readonly sketchbook: Sketchbook;
+  private readonly sketchbook: Sketchbook;
 
-  protected readonly toDispose = new DisposableCollection();
+  private readonly toDispose = new DisposableCollection();
 
   override registerCommands(registry: CommandRegistry): void {
     registry.registerCommand(OpenSketch.Commands.OPEN_SKETCH, {
@@ -130,7 +130,7 @@ export class OpenSketch extends SketchContribution {
     });
   }
 
-  async openSketch(
+  private async openSketch(
     toOpen: MaybePromise<Sketch | undefined> = this.selectSketch()
   ): Promise<void> {
     const sketch = await toOpen;
@@ -139,21 +139,24 @@ export class OpenSketch extends SketchContribution {
     }
   }
 
-  protected async selectSketch(): Promise<Sketch | undefined> {
+  private async selectSketch(): Promise<Sketch | undefined> {
     const config = await this.configService.getConfiguration();
     const defaultPath = await this.fileService.fsPath(
       new URI(config.sketchDirUri)
     );
-    const { filePaths } = await remote.dialog.showOpenDialog({
-      defaultPath,
-      properties: ['createDirectory', 'openFile'],
-      filters: [
-        {
-          name: nls.localize('arduino/sketch/sketch', 'Sketch'),
-          extensions: ['ino', 'pde'],
-        },
-      ],
-    });
+    const { filePaths } = await remote.dialog.showOpenDialog(
+      remote.getCurrentWindow(),
+      {
+        defaultPath,
+        properties: ['createDirectory', 'openFile'],
+        filters: [
+          {
+            name: nls.localize('arduino/sketch/sketch', 'Sketch'),
+            extensions: ['ino', 'pde'],
+          },
+        ],
+      }
+    );
     if (!filePaths.length) {
       return undefined;
     }

--- a/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
@@ -50,7 +50,7 @@ export class SaveAsSketch extends SketchContribution {
   /**
    * Resolves `true` if the sketch was successfully saved as something.
    */
-  async saveAs(
+  private async saveAs(
     {
       execOnlyIfTemp,
       openAfterMove,
@@ -82,13 +82,16 @@ export class SaveAsSketch extends SketchContribution {
         : sketch.name
     );
     const defaultPath = await this.fileService.fsPath(defaultUri);
-    const { filePath, canceled } = await remote.dialog.showSaveDialog({
-      title: nls.localize(
-        'arduino/sketch/saveFolderAs',
-        'Save sketch folder as...'
-      ),
-      defaultPath,
-    });
+    const { filePath, canceled } = await remote.dialog.showSaveDialog(
+      remote.getCurrentWindow(),
+      {
+        title: nls.localize(
+          'arduino/sketch/saveFolderAs',
+          'Save sketch folder as...'
+        ),
+        defaultPath,
+      }
+    );
     if (!filePath || canceled) {
       return false;
     }

--- a/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
@@ -58,7 +58,10 @@ export class SaveAsSketch extends SketchContribution {
       markAsRecentlyOpened,
     }: SaveAsSketch.Options = SaveAsSketch.Options.DEFAULT
   ): Promise<boolean> {
-    const sketch = await this.sketchServiceClient.currentSketch();
+    const [sketch, configuration] = await Promise.all([
+      this.sketchServiceClient.currentSketch(),
+      this.configService.getConfiguration(),
+    ]);
     if (!CurrentSketch.isValid(sketch)) {
       return false;
     }
@@ -68,15 +71,23 @@ export class SaveAsSketch extends SketchContribution {
       return false;
     }
 
+    const sketchUri = new URI(sketch.uri);
+    const sketchbookDirUri = new URI(configuration.sketchDirUri);
+    // If the sketch is temp, IDE2 proposes the default sketchbook folder URI.
+    // If the sketch is not temp, but not contained in the default sketchbook folder, IDE2 proposes the default location.
+    // Otherwise, it proposes the parent folder of the current sketch.
+    const containerDirUri = isTemp
+      ? sketchbookDirUri
+      : !sketchbookDirUri.isEqualOrParent(sketchUri)
+      ? sketchbookDirUri
+      : sketchUri.parent;
+    const exists = await this.fileService.exists(
+      containerDirUri.resolve(sketch.name)
+    );
+
     // If target does not exist, propose a `directories.user`/${sketch.name} path
     // If target exists, propose `directories.user`/${sketch.name}_copy_${yyyymmddHHMMss}
-    const sketchDirUri = new URI(
-      (await this.configService.getConfiguration()).sketchDirUri
-    );
-    const exists = await this.fileService.exists(
-      sketchDirUri.resolve(sketch.name)
-    );
-    const defaultUri = sketchDirUri.resolve(
+    const defaultUri = containerDirUri.resolve(
       exists
         ? `${sketch.name}_copy_${dateFormat(new Date(), 'yyyymmddHHMMss')}`
         : sketch.name

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
@@ -502,6 +502,7 @@ export class SettingsComponent extends React.Component<
       canSelectFiles: false,
       canSelectMany: false,
       canSelectFolders: true,
+      modal: true,
     });
     if (uri) {
       const sketchbookPath = await this.props.fileService.fsPath(uri);


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

This PR is the outcome of the investigation of #411. This PR fixes the default location when saving a sketch as. From now on, every native file dialog is modal.

### Change description
Noteworthy changes:
 - If the sketch is temp, the default save location is `directories/user/sketch_$current_date`,


https://user-images.githubusercontent.com/1405703/184651953-0b0c5f6b-4ca8-42a7-b61b-628b8d89be0d.mp4


 - If a sketch is contained in the default location as `directories/user/sketch`, then the default location will be `directories/user/sketch_copy_date`,


https://user-images.githubusercontent.com/1405703/184652457-b41181d7-0dbb-4add-a74f-0344e870582b.mp4




 - If a sketch is outside of the sketchbook, then the default location will be `directories/user/sketch_$current_date`,

https://user-images.githubusercontent.com/1405703/184652035-772c1b19-5034-4ea6-85fd-644cec228ce1.mp4


 - If the sketch is in a nested folder in the sketchbook, then the default location will be `directories/user/nested/location/sketch_$current_date`.


https://user-images.githubusercontent.com/1405703/184652087-edd0d948-9894-44e6-9eb1-424d853ed7f0.mp4


### Other information
<!-- Any additional information that could help the review process -->

I could not reproduce the defect described [here](https://github.com/arduino/arduino-ide/issues/411#issue-917365586) and [here](https://github.com/arduino/arduino-ide/issues/411#issuecomment-1179394139).

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)