### PR TITLE
Change naming of nightly and snapshot builds

### DIFF
--- a/electron/packager/config.js
+++ b/electron/packager/config.js
@@ -80,9 +80,9 @@ function getVersion() {
   }
   if (!isRelease) {
     if (isNightly) {
-      version = `${version}-nightly-${timestamp()}`;
+      version = `${version}.nightly-${timestamp()}`;
     } else {
-      version = `${version}-snapshot-${currentCommitish()}`;
+      version = `${version}.snapshot-${currentCommitish()}`;
     }
     if (!semver.valid(version)) {
       throw new Error(`Invalid patched version: '${version}'.`);


### PR DESCRIPTION
Replace `-` with `.` to make auto-update work correctly

### Motivation
Automatic updates are not working anymore with nightly builds.

Fixes #1318.

### Change description
As suggested in #1318, using a `.` instead of a `-` to separate the "nightly" and "snapshot" build makes the semver comparison to work as expected.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)