### PR TITLE
fix 180: prevent erroneous "auto-reconnect"(s) in board selector

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -65,7 +65,7 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
   protected _availablePorts: Port[] = [];
   protected _availableBoards: AvailableBoard[] = [];
 
-  private uploadInProgress = false;
+  private uploadAttemptInProgress = false;
 
   private lastItemRemovedForUpload: { board: Board; port: Port } | undefined;
   // "lastPersistingUploadPort", is a port created during an upload, that persisted after
@@ -87,8 +87,8 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
   private readonly _reconciled = new Deferred<void>();
 
   onStart(): void {
-    this.notificationCenter.onUploadInProgress(
-      this.onUploadNotificationReceived.bind(this)
+    this.notificationCenter.onUploadAttemptInProgress(
+      this.onUploadAttemptEventReceived.bind(this)
     );
     this.notificationCenter.onAttachedBoardsDidChange(
       this.notifyAttachedBoardsChanged.bind(this)
@@ -121,8 +121,8 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
     return this._reconciled.promise;
   }
 
-  private onUploadNotificationReceived(uploadInProgress: boolean): void {
-    this.uploadInProgress = uploadInProgress;
+  private onUploadAttemptEventReceived(uploadAttemptInProgress: boolean): void {
+    this.uploadAttemptInProgress = uploadAttemptInProgress;
   }
 
   private checkForItemRemoved(event: AttachedBoardsChangeEvent): void {
@@ -192,7 +192,7 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
       this.logger.info('------------------------------------------');
     }
 
-    if (this.uploadInProgress) {
+    if (this.uploadAttemptInProgress) {
       this.checkForItemRemoved(event);
     } else {
       this.checkForPersistingPort(event);
@@ -202,7 +202,7 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
     this._availablePorts = event.newState.ports;
     this.onAvailablePortsChangedEmitter.fire(this._availablePorts);
     this.reconcileAvailableBoards().then(() => {
-      if (!this.uploadInProgress) {
+      if (!this.uploadAttemptInProgress) {
         this.tryReconnect();
       }
     });

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -15,6 +15,7 @@ import { UserFieldsDialog } from '../dialogs/user-fields/user-fields-dialog';
 import { DisposableCollection, nls } from '@theia/core/lib/common';
 import { CurrentSketch } from '../../common/protocol/sketches-service-client-impl';
 import type { VerifySketchParams } from './verify-sketch';
+import { NotificationCenter } from '../notification-center';
 
 @injectable()
 export class UploadSketch extends CoreServiceContribution {
@@ -23,6 +24,9 @@ export class UploadSketch extends CoreServiceContribution {
 
   @inject(UserFieldsDialog)
   private readonly userFieldsDialog: UserFieldsDialog;
+
+  @inject(NotificationCenter)
+  private readonly notificationCenter: NotificationCenter;
 
   private boardRequiresUserFields = false;
   private readonly cachedUserFields: Map<string, BoardUserField[]> = new Map();
@@ -191,6 +195,7 @@ export class UploadSketch extends CoreServiceContribution {
       // uploadInProgress will be set to false whether the upload fails or not
       this.uploadInProgress = true;
       this.onDidChangeEmitter.fire();
+      this.notificationCenter.notifyUploadInProgress(this.uploadInProgress);
 
       const verifyOptions =
         await this.commandService.executeCommand<CoreService.Options.Compile>(
@@ -243,6 +248,7 @@ export class UploadSketch extends CoreServiceContribution {
     } finally {
       this.uploadInProgress = false;
       this.onDidChangeEmitter.fire();
+      this.notificationCenter.notifyUploadInProgress(this.uploadInProgress);
     }
   }
 

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -195,8 +195,10 @@ export class UploadSketch extends CoreServiceContribution {
       // uploadInProgress will be set to false whether the upload fails or not
       this.uploadInProgress = true;
       this.onDidChangeEmitter.fire();
-      this.notificationCenter.notifyUploadInProgress(this.uploadInProgress);
       this.clearVisibleNotification();
+      this.notificationCenter.notifyUploadAttemptInProgress(
+        this.uploadInProgress
+      );
 
       const verifyOptions =
         await this.commandService.executeCommand<CoreService.Options.Compile>(
@@ -249,7 +251,9 @@ export class UploadSketch extends CoreServiceContribution {
     } finally {
       this.uploadInProgress = false;
       this.onDidChangeEmitter.fire();
-      this.notificationCenter.notifyUploadInProgress(this.uploadInProgress);
+      this.notificationCenter.notifyUploadAttemptInProgress(
+        this.uploadInProgress
+      );
     }
   }
 

--- a/arduino-ide-extension/src/browser/notification-center.ts
+++ b/arduino-ide-extension/src/browser/notification-center.ts
@@ -66,7 +66,7 @@ export class NotificationCenter
   }>();
   private readonly onAppStateDidChangeEmitter =
     new Emitter<FrontendApplicationState>();
-  private readonly onUploadInProgressEmitter = new Emitter<boolean>();
+  private readonly onUploadAttemptInProgressEmitter = new Emitter<boolean>();
 
   protected readonly toDispose = new DisposableCollection(
     this.indexWillUpdateEmitter,
@@ -81,7 +81,7 @@ export class NotificationCenter
     this.libraryDidInstallEmitter,
     this.libraryDidUninstallEmitter,
     this.attachedBoardsDidChangeEmitter,
-    this.onUploadInProgressEmitter
+    this.onUploadAttemptInProgressEmitter
   );
 
   readonly onIndexDidUpdate = this.indexDidUpdateEmitter.event;
@@ -99,7 +99,8 @@ export class NotificationCenter
     this.attachedBoardsDidChangeEmitter.event;
   readonly onRecentSketchesDidChange = this.recentSketchesChangedEmitter.event;
   readonly onAppStateDidChange = this.onAppStateDidChangeEmitter.event;
-  readonly onUploadInProgress = this.onUploadInProgressEmitter.event;
+  readonly onUploadAttemptInProgress =
+    this.onUploadAttemptInProgressEmitter.event;
 
   @postConstruct()
   protected init(): void {
@@ -173,7 +174,7 @@ export class NotificationCenter
     this.recentSketchesChangedEmitter.fire(event);
   }
 
-  notifyUploadInProgress(event: boolean): void {
-    this.onUploadInProgressEmitter.fire(event);
+  notifyUploadAttemptInProgress(event: boolean): void {
+    this.onUploadAttemptInProgressEmitter.fire(event);
   }
 }

--- a/arduino-ide-extension/src/browser/notification-center.ts
+++ b/arduino-ide-extension/src/browser/notification-center.ts
@@ -66,6 +66,7 @@ export class NotificationCenter
   }>();
   private readonly onAppStateDidChangeEmitter =
     new Emitter<FrontendApplicationState>();
+  private readonly onUploadInProgressEmitter = new Emitter<boolean>();
 
   protected readonly toDispose = new DisposableCollection(
     this.indexWillUpdateEmitter,
@@ -79,7 +80,8 @@ export class NotificationCenter
     this.platformDidUninstallEmitter,
     this.libraryDidInstallEmitter,
     this.libraryDidUninstallEmitter,
-    this.attachedBoardsDidChangeEmitter
+    this.attachedBoardsDidChangeEmitter,
+    this.onUploadInProgressEmitter
   );
 
   readonly onIndexDidUpdate = this.indexDidUpdateEmitter.event;
@@ -97,6 +99,7 @@ export class NotificationCenter
     this.attachedBoardsDidChangeEmitter.event;
   readonly onRecentSketchesDidChange = this.recentSketchesChangedEmitter.event;
   readonly onAppStateDidChange = this.onAppStateDidChangeEmitter.event;
+  readonly onUploadInProgress = this.onUploadInProgressEmitter.event;
 
   @postConstruct()
   protected init(): void {
@@ -168,5 +171,9 @@ export class NotificationCenter
 
   notifyRecentSketchesDidChange(event: { sketches: Sketch[] }): void {
     this.recentSketchesChangedEmitter.fire(event);
+  }
+
+  notifyUploadInProgress(event: boolean): void {
+    this.onUploadInProgressEmitter.fire(event);
   }
 }

--- a/arduino-ide-extension/src/common/protocol/notification-service.ts
+++ b/arduino-ide-extension/src/common/protocol/notification-service.ts
@@ -28,6 +28,7 @@ export interface NotificationServiceClient {
   notifyLibraryDidUninstall(event: { item: LibraryPackage }): void;
   notifyAttachedBoardsDidChange(event: AttachedBoardsChangeEvent): void;
   notifyRecentSketchesDidChange(event: { sketches: Sketch[] }): void;
+  notifyUploadInProgress(event: boolean): void;
 }
 
 export const NotificationServicePath = '/services/notification-service';

--- a/arduino-ide-extension/src/common/protocol/notification-service.ts
+++ b/arduino-ide-extension/src/common/protocol/notification-service.ts
@@ -28,7 +28,7 @@ export interface NotificationServiceClient {
   notifyLibraryDidUninstall(event: { item: LibraryPackage }): void;
   notifyAttachedBoardsDidChange(event: AttachedBoardsChangeEvent): void;
   notifyRecentSketchesDidChange(event: { sketches: Sketch[] }): void;
-  notifyUploadInProgress(event: boolean): void;
+  notifyUploadAttemptInProgress(event: boolean): void;
 }
 
 export const NotificationServicePath = '/services/notification-service';

--- a/arduino-ide-extension/src/node/notification-service-server.ts
+++ b/arduino-ide-extension/src/node/notification-service-server.ts
@@ -82,8 +82,10 @@ export class NotificationServiceServerImpl
     );
   }
 
-  notifyUploadInProgress(event: boolean): void {
-    this.clients.forEach((client) => client.notifyUploadInProgress(event));
+  notifyUploadAttemptInProgress(event: boolean): void {
+    this.clients.forEach((client) =>
+      client.notifyUploadAttemptInProgress(event)
+    );
   }
 
   setClient(client: NotificationServiceClient): void {

--- a/arduino-ide-extension/src/node/notification-service-server.ts
+++ b/arduino-ide-extension/src/node/notification-service-server.ts
@@ -82,6 +82,10 @@ export class NotificationServiceServerImpl
     );
   }
 
+  notifyUploadInProgress(event: boolean): void {
+    this.clients.forEach((client) => client.notifyUploadInProgress(event));
+  }
+
   setClient(client: NotificationServiceClient): void {
     this.clients.push(client);
   }


### PR DESCRIPTION
### Motivation
Users reported erroneous auto-selection of ports, in relation to uploads, unknown boards and using multiple boards of the same fqbn.

### Issue Identified
We were on occasion erroneously auto-reconnecting to the wrong port with the same associated board after upload / on disconnect. We were failing to check if the port we were auto-connecting to actually appeared and persisted due to an upload.

### Change description
Detects if a port disappears when an upload is invoked, subsequently checks if a new port is created and if that port persists after the upload is complete. Knowing if we have a "persisting port," we can now correctly determine if we should auto-reconnect after an upload - in the case that a new port is created which persists.

### Other information
This is a draft serving to illustrate where this issue resides and a potential solution, these changes should be unit tested prior to merge, and we may wish to centralise the new logic.

This PR also resolves the issue of "double selections" in the board selector dropdown with an additional check [here](url).

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)