### PR TITLE
#1327 Show all network and serial ports

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-config.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-config.tsx
@@ -335,17 +335,12 @@ export class BoardsConfig extends React.Component<
       ports = this.state.knownPorts;
     } else {
       ports = this.state.knownPorts.filter((port) => {
-        if (port.protocol === 'serial') {
+        if (port.protocol === 'serial' || port.protocol === 'network') {
+          // Allow all `serial` and `network` boards.
+          // IDE2 must support better label for unrecognized `network` boards: https://github.com/arduino/arduino-ide/issues/1331
           return true;
         }
-        // All other ports with different protocol are
-        // only shown if there is a recognized board
-        // connected
-        for (const board of this.availableBoards) {
-          if (board.port?.address === port.address) {
-            return true;
-          }
-        }
+        return false;
       });
     }
     return !ports.length ? (

--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -438,19 +438,10 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
     const availableBoards: AvailableBoard[] = [];
     const attachedBoards = this._attachedBoards.filter(({ port }) => !!port);
     const availableBoardPorts = availablePorts.filter((port) => {
-      if (port.protocol === 'serial') {
-        // We always show all serial ports, even if there
-        // is no recognized board connected to it
+      if (port.protocol === 'serial' || port.protocol === 'network') {
+        // Allow all `serial` and `network` boards.
+        // IDE2 must support better label for unrecognized `network` boards: https://github.com/arduino/arduino-ide/issues/1331
         return true;
-      }
-
-      // All other ports with different protocol are
-      // only shown if there is a recognized board
-      // connected
-      for (const board of attachedBoards) {
-        if (board.port?.address === port.address) {
-          return true;
-        }
       }
       return false;
     });

--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -66,10 +66,11 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
   protected _availableBoards: AvailableBoard[] = [];
 
   /**
-   * Unlike `onAttachedBoardsChanged` this even fires when the user modifies the selected board in the IDE.\
-   * This even also fires, when the boards package was not available for the currently selected board,
+   * Unlike `onAttachedBoardsChanged` this event fires when the user modifies the selected board in the IDE.\
+   * This event also fires, when the boards package was not available for the currently selected board,
    * and the user installs the board package. Note: installing a board package will set the `fqbn` of the
-   * currently selected board.\
+   * currently selected board.
+   *
    * This event is also emitted when the board package for the currently selected board was uninstalled.
    */
   readonly onBoardsConfigChanged = this.onBoardsConfigChangedEmitter.event;

--- a/arduino-ide-extension/src/common/protocol/boards-service.ts
+++ b/arduino-ide-extension/src/common/protocol/boards-service.ts
@@ -142,7 +142,7 @@ export interface BoardsService
 export interface Port {
   // id is the combination of address and protocol
   // formatted like "<address>|<protocol>" used
-  // to univocally recognize a port
+  // to uniquely recognize a port
   readonly id: string;
   readonly address: string;
   readonly addressLabel: string;


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Removed the filtering of unrecognized `network` boards. Unrecognized `network` boards should show up with their IP addresses.

### Change description

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)