### PR TITLE
#53 Refresh menus when opening example/recent fails.

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/new-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/new-sketch.ts
@@ -1,7 +1,6 @@
 import { nls } from '@theia/core/lib/common';
 import { injectable } from '@theia/core/shared/inversify';
 import { ArduinoMenus } from '../menu/arduino-menus';
-import { ArduinoToolbar } from '../toolbar/arduino-toolbar';
 import {
   SketchContribution,
   URI,
@@ -16,11 +15,6 @@ export class NewSketch extends SketchContribution {
   override registerCommands(registry: CommandRegistry): void {
     registry.registerCommand(NewSketch.Commands.NEW_SKETCH, {
       execute: () => this.newSketch(),
-    });
-    registry.registerCommand(NewSketch.Commands.NEW_SKETCH__TOOLBAR, {
-      isVisible: (widget) =>
-        ArduinoToolbar.is(widget) && widget.side === 'left',
-      execute: () => registry.executeCommand(NewSketch.Commands.NEW_SKETCH.id),
     });
   }
 
@@ -53,9 +47,6 @@ export namespace NewSketch {
   export namespace Commands {
     export const NEW_SKETCH: Command = {
       id: 'arduino-new-sketch',
-    };
-    export const NEW_SKETCH__TOOLBAR: Command = {
-      id: 'arduino-new-sketch--toolbar',
     };
   }
 }

--- a/arduino-ide-extension/src/browser/contributions/save-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/save-sketch.ts
@@ -1,7 +1,6 @@
 import { injectable } from '@theia/core/shared/inversify';
 import { CommonCommands } from '@theia/core/lib/browser/common-frontend-contribution';
 import { ArduinoMenus } from '../menu/arduino-menus';
-import { ArduinoToolbar } from '../toolbar/arduino-toolbar';
 import { SaveAsSketch } from './save-as-sketch';
 import {
   SketchContribution,
@@ -18,12 +17,6 @@ export class SaveSketch extends SketchContribution {
   override registerCommands(registry: CommandRegistry): void {
     registry.registerCommand(SaveSketch.Commands.SAVE_SKETCH, {
       execute: () => this.saveSketch(),
-    });
-    registry.registerCommand(SaveSketch.Commands.SAVE_SKETCH__TOOLBAR, {
-      isVisible: (widget) =>
-        ArduinoToolbar.is(widget) && widget.side === 'left',
-      execute: () =>
-        registry.executeCommand(SaveSketch.Commands.SAVE_SKETCH.id),
     });
   }
 
@@ -67,9 +60,6 @@ export namespace SaveSketch {
   export namespace Commands {
     export const SAVE_SKETCH: Command = {
       id: 'arduino-save-sketch',
-    };
-    export const SAVE_SKETCH__TOOLBAR: Command = {
-      id: 'arduino-save-sketch--toolbar',
     };
   }
 }

--- a/arduino-ide-extension/src/browser/contributions/sketchbook.ts
+++ b/arduino-ide-extension/src/browser/contributions/sketchbook.ts
@@ -1,32 +1,14 @@
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { injectable } from '@theia/core/shared/inversify';
 import { CommandHandler } from '@theia/core/lib/common/command';
-import { CommandRegistry, MenuModelRegistry } from './contribution';
+import { MenuModelRegistry } from './contribution';
 import { ArduinoMenus } from '../menu/arduino-menus';
-import { MainMenuManager } from '../../common/main-menu-manager';
-import { NotificationCenter } from '../notification-center';
 import { Examples } from './examples';
-import {
-  SketchContainer,
-  SketchesError,
-  SketchRef,
-} from '../../common/protocol';
+import { SketchContainer, SketchesError } from '../../common/protocol';
 import { OpenSketch } from './open-sketch';
-import { nls } from '@theia/core/lib/common';
+import { nls } from '@theia/core/lib/common/nls';
 
 @injectable()
 export class Sketchbook extends Examples {
-  @inject(CommandRegistry)
-  protected override readonly commandRegistry: CommandRegistry;
-
-  @inject(MenuModelRegistry)
-  protected override readonly menuRegistry: MenuModelRegistry;
-
-  @inject(MainMenuManager)
-  protected readonly mainMenuManager: MainMenuManager;
-
-  @inject(NotificationCenter)
-  protected readonly notificationCenter: NotificationCenter;
-
   override onStart(): void {
     this.sketchServiceClient.onSketchbookDidChange(() => this.update());
   }
@@ -35,10 +17,10 @@ export class Sketchbook extends Examples {
     this.update();
   }
 
-  private update() {
+  protected override update(): void {
     this.sketchService.getSketches({}).then((container) => {
       this.register(container);
-      this.mainMenuManager.update();
+      this.menuManager.update();
     });
   }
 
@@ -50,7 +32,7 @@ export class Sketchbook extends Examples {
     );
   }
 
-  protected register(container: SketchContainer): void {
+  private register(container: SketchContainer): void {
     this.toDispose.dispose();
     this.registerRecursively(
       [...container.children, ...container.sketches],
@@ -62,23 +44,18 @@ export class Sketchbook extends Examples {
   protected override createHandler(uri: string): CommandHandler {
     return {
       execute: async () => {
-        let sketch: SketchRef | undefined = undefined;
         try {
-          sketch = await this.sketchService.loadSketch(uri);
-        } catch (err) {
-          if (SketchesError.NotFound.is(err)) {
-            // To handle the following:
-            // Open IDE2, delete a sketch from sketchbook, click on File > Sketchbook > the deleted sketch.
-            // Filesystem watcher misses out delete events on macOS; hence IDE2 has no chance to update the menu items.
-            this.messageService.error(err.message);
-            this.update();
-          }
-        }
-        if (sketch) {
           await this.commandService.executeCommand(
             OpenSketch.Commands.OPEN_SKETCH.id,
-            sketch
+            uri
           );
+        } catch (err) {
+          if (SketchesError.NotFound.is(err)) {
+            // Force update the menu items to remove the absent sketch.
+            this.update();
+          } else {
+            throw err;
+          }
         }
       },
     };

--- a/arduino-ide-extension/src/browser/theia/core/about-dialog.ts
+++ b/arduino-ide-extension/src/browser/theia/core/about-dialog.ts
@@ -1,8 +1,6 @@
 import { AboutDialog as TheiaAboutDialog } from '@theia/core/lib/browser/about-dialog';
-import { duration } from '../../../common/decorators';
 
 export class AboutDialog extends TheiaAboutDialog {
-  @duration({ name: 'theia-about#init' })
   protected override async init(): Promise<void> {
     // NOOP
     // IDE2 has a custom about dialog, so it does not make sense to collect Theia extensions at startup time.

--- a/arduino-ide-extension/src/common/protocol/core-service.ts
+++ b/arduino-ide-extension/src/common/protocol/core-service.ts
@@ -108,6 +108,10 @@ export interface CoreService {
   compile(options: CoreService.Options.Compile): Promise<void>;
   upload(options: CoreService.Options.Upload): Promise<void>;
   burnBootloader(options: CoreService.Options.Bootloader): Promise<void>;
+  /**
+   * Refreshes the underling core gRPC client for the Arduino CLI.
+   */
+  refresh(): Promise<void>;
 }
 
 export namespace CoreService {

--- a/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
+++ b/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
@@ -332,6 +332,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     'fwuploader', // Arduino Firmware uploader
     'discovery-log', // Boards discovery
     'config', // Logger for the CLI config reading and manipulation
+    'sketches-service', // For creating, loading, and cloning sketches
     MonitorManagerName, // Logger for the monitor manager and its services
     MonitorServiceName,
   ].forEach((name) => bindChildLogger(bind, name));

--- a/arduino-ide-extension/src/node/config-service-impl.ts
+++ b/arduino-ide-extension/src/node/config-service-impl.ts
@@ -26,7 +26,6 @@ import { DefaultCliConfig, CLI_CONFIG } from './cli-config';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { deepClone } from '@theia/core';
-import { duration } from '../common/decorators';
 
 const deepmerge = require('deepmerge');
 
@@ -129,7 +128,6 @@ export class ConfigServiceImpl
     return this.daemon.getVersion();
   }
 
-  @duration()
   protected async loadCliConfig(
     initializeIfAbsent = true
   ): Promise<DefaultCliConfig | undefined> {

--- a/arduino-ide-extension/src/node/core-client-provider.ts
+++ b/arduino-ide-extension/src/node/core-client-provider.ts
@@ -94,6 +94,11 @@ export class CoreClientProvider {
     return this.onClientDidRefreshEmitter.event;
   }
 
+  async refresh(): Promise<void> {
+    const client = await this.client;
+    await this.initInstance(client);
+  }
+
   /**
    * Encapsulates both the gRPC core client creation (`CreateRequest`) and initialization (`InitRequest`).
    */
@@ -414,6 +419,10 @@ export abstract class CoreClientAware {
 
   protected get onClientDidRefresh(): Event<CoreClientProvider.Client> {
     return this.coreClientProvider.onClientDidRefresh;
+  }
+
+  refresh(): Promise<void> {
+    return this.coreClientProvider.refresh();
   }
 }
 

--- a/arduino-ide-extension/src/node/examples-service-impl.ts
+++ b/arduino-ide-extension/src/node/examples-service-impl.ts
@@ -11,14 +11,10 @@ import {
   SketchContainer,
 } from '../common/protocol/sketches-service';
 import { ExamplesService } from '../common/protocol/examples-service';
-import {
-  LibraryLocation,
-  LibraryPackage,
-  LibraryService,
-} from '../common/protocol';
-import { duration } from '../common/decorators';
+import { LibraryLocation, LibraryPackage } from '../common/protocol';
 import { URI } from '@theia/core/lib/common/uri';
 import { Path } from '@theia/core/lib/common/path';
+import { LibraryServiceImpl } from './library-service-impl';
 
 interface BuiltInSketchRef {
   readonly name: string;
@@ -84,8 +80,8 @@ export class BuiltInExamplesServiceImpl {
 
 @injectable()
 export class ExamplesServiceImpl implements ExamplesService {
-  @inject(LibraryService)
-  private readonly libraryService: LibraryService;
+  @inject(LibraryServiceImpl)
+  private readonly libraryService: LibraryServiceImpl;
 
   @inject(BuiltInExamplesServiceImpl)
   private readonly builtInExamplesService: BuiltInExamplesServiceImpl;
@@ -94,7 +90,6 @@ export class ExamplesServiceImpl implements ExamplesService {
     return this.builtInExamplesService.builtIns();
   }
 
-  @duration()
   async installed({ fqbn }: { fqbn?: string }): Promise<{
     user: SketchContainer[];
     current: SketchContainer[];


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

IDE2 must notify the user about missing/invalid sketches and update the menus when opening the sketch has failed. This is the expected behavior when opening from `File` > `Open Recent`, `File` > `Sketchbook`, and `File` > `Examples`.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Closes #53

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)