### PR TITLE
#740, #1331 Use port properties

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-config.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-config.tsx
@@ -354,7 +354,7 @@ export class BoardsConfig extends React.Component<
       <div className="ports list">
         {ports.map((port) => (
           <Item<Port>
-            key={`${port.id}`}
+            key={`${Port.keyOf(port)}`}
             item={port}
             label={Port.toString(port)}
             selected={Port.sameAs(this.state.selectedPort, port)}

--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -13,6 +13,7 @@ import {
   AttachedBoardsChangeEvent,
   BoardWithPackage,
   BoardUserField,
+  AvailablePorts,
 } from '../../common/protocol';
 import { BoardsConfig } from './boards-config';
 import { naturalCompare } from '../../common/utils';
@@ -21,6 +22,7 @@ import { StorageWrapper } from '../storage-wrapper';
 import { nls } from '@theia/core/lib/common';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
+import { Unknown } from '../../common/nls';
 
 @injectable()
 export class BoardsServiceProvider implements FrontendApplicationContribution {
@@ -96,11 +98,12 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
     );
 
     this.appStateService.reachedState('ready').then(async () => {
-      const [attachedBoards, availablePorts] = await Promise.all([
-        this.boardsService.getAttachedBoards(),
-        this.boardsService.getAvailablePorts(),
+      const [state] = await Promise.all([
+        this.boardsService.getState(),
         this.loadState(),
       ]);
+      const { boards: attachedBoards, ports: availablePorts } =
+        AvailablePorts.split(state);
       this._attachedBoards = attachedBoards;
       this._availablePorts = availablePorts;
       this.onAvailablePortsChangedEmitter.fire(this._availablePorts);
@@ -558,7 +561,7 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
         };
       } else {
         availableBoard = {
-          name: nls.localize('arduino/common/unknown', 'Unknown'),
+          name: Unknown,
           port: boardPort,
           state: AvailableBoard.State.incomplete,
         };

--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -462,6 +462,16 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
     return this._availableBoards;
   }
 
+  /**
+   * @deprecated Do not use this API, it will be removed. This is a hack to be able to set the missing port `properties` before an upload.
+   *
+   * See: https://github.com/arduino/arduino-ide/pull/1335#issuecomment-1224355236.
+   */
+  // TODO: remove this API and fix the selected board config store/restore correctly.
+  get availablePorts(): Port[] {
+    return this._availablePorts.slice();
+  }
+
   async waitUntilAvailable(
     what: Board & { port: Port },
     timeout?: number

--- a/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
@@ -138,7 +138,7 @@ export class BoardsDropDown extends React.Component<BoardsDropDown.Props> {
             {boardLabel}
           </div>
           <div className="arduino-boards-dropdown-item--port-label noWrapInfo noselect">
-            {port.address}
+            {port.addressLabel}
           </div>
         </div>
         {selected ? <div className="fa fa-check" /> : ''}

--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -331,7 +331,7 @@ PID: ${PID}`;
       }
     };
 
-    const grouped = AvailablePorts.byProtocol(availablePorts);
+    const grouped = AvailablePorts.groupByProtocol(availablePorts);
     let protocolOrder = 100;
     // We first show serial and network ports, then all the rest
     ['serial', 'network'].forEach((protocol) => {

--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -288,7 +288,7 @@ PID: ${PID}`;
       for (let i = 0; i < sortedIDs.length; i++) {
         const portID = sortedIDs[i];
         const [port, boards] = ports[portID];
-        let label = `${port.address}`;
+        let label = `${port.addressLabel}`;
         if (boards.length) {
           const boardsList = boards.map((board) => board.name).join(', ');
           label = `${label} (${boardsList})`;

--- a/arduino-ide-extension/src/browser/monitor-manager-proxy-client-impl.ts
+++ b/arduino-ide-extension/src/browser/monitor-manager-proxy-client-impl.ts
@@ -145,7 +145,10 @@ export class MonitorManagerProxyClientImpl
             if (
               selectedBoard?.fqbn !==
                 this.lastConnectedBoard?.selectedBoard?.fqbn ||
-              selectedPort?.id !== this.lastConnectedBoard?.selectedPort?.id
+              Port.keyOf(selectedPort) !==
+                (this.lastConnectedBoard.selectedPort
+                  ? Port.keyOf(this.lastConnectedBoard.selectedPort)
+                  : undefined)
             ) {
               this.onMonitorShouldResetEmitter.fire(null);
               this.lastConnectedBoard = {

--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-input.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-input.tsx
@@ -5,6 +5,7 @@ import { isOSX } from '@theia/core/lib/common/os';
 import { DisposableCollection, nls } from '@theia/core/lib/common';
 import { BoardsServiceProvider } from '../../boards/boards-service-provider';
 import { MonitorModel } from '../../monitor-model';
+import { Unknown } from '../../../common/nls';
 
 export namespace SerialMonitorSendInput {
   export interface Props {
@@ -86,8 +87,8 @@ export class SerialMonitorSendInput extends React.Component<
         ? Board.toString(board, {
             useFqbn: false,
           })
-        : 'unknown',
-      port ? port.address : 'unknown'
+        : Unknown,
+      port ? port.address : Unknown
     );
   }
 

--- a/arduino-ide-extension/src/browser/widgets/component-list/list-item-renderer.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/list-item-renderer.tsx
@@ -5,6 +5,7 @@ import { Installable } from '../../../common/protocol/installable';
 import { ArduinoComponent } from '../../../common/protocol/arduino-component';
 import { ComponentListItem } from './component-list-item';
 import { nls } from '@theia/core/lib/common';
+import { Unknown } from '../../../common/nls';
 
 @injectable()
 export class ListItemRenderer<T extends ArduinoComponent> {
@@ -42,11 +43,7 @@ export class ListItemRenderer<T extends ArduinoComponent> {
     } else if ((item as any).id) {
       nameAndAuthor = <span className="name">{(item as any).id}</span>;
     } else {
-      nameAndAuthor = (
-        <span className="name">
-          {nls.localize('arduino/common/unknown', 'Unknown')}
-        </span>
-      );
+      nameAndAuthor = <span className="name">{Unknown}</span>;
     }
     const onClickUninstall = () => uninstall(item);
     const installedVersion = !!item.installedVersion && (

--- a/arduino-ide-extension/src/common/nls.ts
+++ b/arduino-ide-extension/src/common/nls.ts
@@ -1,0 +1,3 @@
+import { nls } from '@theia/core/lib/common/nls';
+
+export const Unknown = nls.localize('arduino/common/unknown', 'Unknown');

--- a/arduino-ide-extension/src/node/auth/utils.ts
+++ b/arduino-ide-extension/src/node/auth/utils.ts
@@ -3,6 +3,7 @@ import { sha256 } from 'hash.js';
 import { randomBytes } from 'crypto';
 import btoa = require('btoa'); // TODO: check why we cannot
 import { AuthenticationSession } from './types';
+import { Unknown } from '../../common/nls';
 
 export interface IToken {
   accessToken: string; // When unable to refresh due to network problems, the access token becomes undefined
@@ -62,10 +63,10 @@ export function token2IToken(token: Token): IToken {
     sessionId: parsedIdToken.sub,
     scope: token.scope,
     account: {
-      id: parsedIdToken.sub || 'unknown',
-      email: parsedIdToken.email || 'unknown',
-      nickname: parsedIdToken.nickname || 'unknown',
-      picture: parsedIdToken.picture || 'unknown',
+      id: parsedIdToken.sub || Unknown,
+      email: parsedIdToken.email || Unknown,
+      nickname: parsedIdToken.nickname || Unknown,
+      picture: parsedIdToken.picture || Unknown,
     },
   };
 }

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -6,7 +6,6 @@ import {
   Installable,
   BoardsPackage,
   Board,
-  Port,
   BoardDetails,
   Tool,
   ConfigOption,
@@ -63,14 +62,6 @@ export class BoardsServiceImpl
 
   async getState(): Promise<AvailablePorts> {
     return this.boardDiscovery.availablePorts;
-  }
-
-  async getAttachedBoards(): Promise<Board[]> {
-    return this.boardDiscovery.getAttachedBoards();
-  }
-
-  async getAvailablePorts(): Promise<Port[]> {
-    return this.boardDiscovery.getAvailablePorts();
   }
 
   async getBoardDetails(options: {

--- a/arduino-ide-extension/src/node/core-service-impl.ts
+++ b/arduino-ide-extension/src/node/core-service-impl.ts
@@ -25,7 +25,7 @@ import {
 import { ResponseService } from '../common/protocol/response-service';
 import { OutputMessage, Port, Status } from '../common/protocol';
 import { ArduinoCoreServiceClient } from './cli-protocol/cc/arduino/cli/commands/v1/commands_grpc_pb';
-import { Port as GrpcPort } from './cli-protocol/cc/arduino/cli/commands/v1/port_pb';
+import { Port as RpcPort } from './cli-protocol/cc/arduino/cli/commands/v1/port_pb';
 import { ApplicationError, CommandService, Disposable, nls } from '@theia/core';
 import { MonitorManager } from './monitor-manager';
 import { AutoFlushingBuffer } from './utils/buffers';
@@ -411,15 +411,20 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
     }
   }
 
-  private createPort(port: Port | undefined): GrpcPort {
-    const grpcPort = new GrpcPort();
+  private createPort(port: Port | undefined): RpcPort {
+    const rpcPort = new RpcPort();
     if (port) {
-      grpcPort.setAddress(port.address);
-      grpcPort.setLabel(port.addressLabel);
-      grpcPort.setProtocol(port.protocol);
-      grpcPort.setProtocolLabel(port.protocolLabel);
+      rpcPort.setAddress(port.address);
+      rpcPort.setLabel(port.addressLabel);
+      rpcPort.setProtocol(port.protocol);
+      rpcPort.setProtocolLabel(port.protocolLabel);
+      if (port.properties) {
+        for (const [key, value] of Object.entries(port.properties)) {
+          rpcPort.getPropertiesMap().set(key, value);
+        }
+      }
     }
-    return grpcPort;
+    return rpcPort;
   }
 }
 type StreamingResponse =

--- a/arduino-ide-extension/src/node/monitor-service.ts
+++ b/arduino-ide-extension/src/node/monitor-service.ts
@@ -12,7 +12,7 @@ import {
 } from './cli-protocol/cc/arduino/cli/commands/v1/monitor_pb';
 import { CoreClientAware } from './core-client-provider';
 import { WebSocketProvider } from './web-socket/web-socket-provider';
-import { Port as gRPCPort } from 'arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/port_pb';
+import { Port as RpcPort } from 'arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/port_pb';
 import {
   MonitorSettings,
   PluggableMonitorSettings,
@@ -193,10 +193,10 @@ export class MonitorService extends CoreClientAware implements Disposable {
       monitorRequest.setFqbn(this.board.fqbn);
     }
     if (this.port?.address && this.port?.protocol) {
-      const port = new gRPCPort();
-      port.setAddress(this.port.address);
-      port.setProtocol(this.port.protocol);
-      monitorRequest.setPort(port);
+      const rpcPort = new RpcPort();
+      rpcPort.setAddress(this.port.address);
+      rpcPort.setProtocol(this.port.protocol);
+      monitorRequest.setPort(rpcPort);
     }
     const config = new MonitorPortConfiguration();
     for (const id in this.settings.pluggableMonitorSettings) {

--- a/arduino-ide-extension/src/test/browser/fixtures/boards.ts
+++ b/arduino-ide-extension/src/test/browser/fixtures/boards.ts
@@ -5,7 +5,6 @@ export const aBoard: Board = {
   fqbn: 'some:board:fqbn',
   name: 'Some Arduino Board',
   port: {
-    id: '/lol/port1234|serial',
     address: '/lol/port1234',
     addressLabel: '/lol/port1234',
     protocol: 'serial',
@@ -13,7 +12,6 @@ export const aBoard: Board = {
   },
 };
 export const aPort: Port = {
-  id: aBoard.port!.id,
   address: aBoard.port!.address,
   addressLabel: aBoard.port!.addressLabel,
   protocol: aBoard.port!.protocol,
@@ -27,7 +25,6 @@ export const anotherBoard: Board = {
   fqbn: 'another:board:fqbn',
   name: 'Another Arduino Board',
   port: {
-    id: '/kek/port5678|serial',
     address: '/kek/port5678',
     addressLabel: '/kek/port5678',
     protocol: 'serial',
@@ -35,7 +32,6 @@ export const anotherBoard: Board = {
   },
 };
 export const anotherPort: Port = {
-  id: anotherBoard.port!.id,
   address: anotherBoard.port!.address,
   addressLabel: anotherBoard.port!.addressLabel,
   protocol: anotherBoard.port!.protocol,


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To show the `hostname` of the `network` port in the boards dropdown and `Tools` > `Ports` menu (#1331)
To fix the upload caused by missing port `properties` (#740) 

### Change description
<!-- What does your code do? -->

 - Removed unnecessary `id` from the `Port` type. It can be derived from the `address` and `protocol`.
 - Introduced a shared `Unknown` i18n string.
 - Removed the deprecated `getAttacheBoards`/`getAvailablePorts` service APIs.
 - Use the `addressLabel` instead of the `address` in the boards dropdown and `Tools` > `Ports` menu. (#1331)
 - Introduced an optional `properties` on the `Port` type. (#740)
 - Use the `Port#properties` for the upload. (#740)
 - Better type guard for the `Port` type.
 - Refactored the board discovery and added better typing for the gRPC `DetectedPort`.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1331
Closes #740

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)