### PR TITLE
Use more relevant page for "Help > Environment" menu item target

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/help.ts
+++ b/arduino-ide-extension/src/browser/contributions/help.ts
@@ -41,7 +41,9 @@ export class Help extends Contribution {
     );
     registry.registerCommand(
       Help.Commands.ENVIRONMENT,
-      createOpenHandler('https://www.arduino.cc/en/Guide/Environment')
+      createOpenHandler(
+        'https://docs.arduino.cc/software/ide-v2/tutorials/getting-started-ide-v2'
+      )
     );
     registry.registerCommand(
       Help.Commands.TROUBLESHOOTING,


### PR DESCRIPTION
Selecting **Help > Environment** from the Arduino IDE menus opens a page containing usage information for the Arduino IDE application in the browser.

Previously, the URL used was the same as that in [Arduino IDE 1.x](https://github.com/arduino/Arduino):

https://www.arduino.cc/en/Guide/Environment

### Motivation

The documentation from that page was written for Arduino IDE 1.x. Even though the UI of the two versions is aligned for the most part, advancements made for the 2.x major version series resulted in some differences. This means that documentation targeted at Arduino IDE 1.x is not always applicable to Arduino IDE 2.x.

### Change description

Fortunately, documentation is now available for each major version series of the IDE. So resolution is only a matter of pointing the menu item at the correct URL:

https://docs.arduino.cc/software/ide-v2/tutorials/getting-started-ide-v2

### Other information

Originally reported by @sterretjeToo at https://forum.arduino.cc/t/rc9-2-help-environment/1023929

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)