### PR TITLE
Add missing i18n for UI strings

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-config.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-config.tsx
@@ -306,7 +306,10 @@ export class BoardsConfig extends React.Component<
             type="search"
             value={query}
             className="theia-input"
-            placeholder="SEARCH BOARD"
+            placeholder={nls.localize(
+              'arduino/board/searchBoard',
+              'SEARCH BOARD'
+            )}
             onChange={this.updateBoards}
             ref={this.focusNodeSet}
           />
@@ -344,7 +347,9 @@ export class BoardsConfig extends React.Component<
       });
     }
     return !ports.length ? (
-      <div className="loading noselect">No ports discovered</div>
+      <div className="loading noselect">
+        {nls.localize('arduino/board/noPortsDiscovered', 'No ports discovered')}
+      </div>
     ) : (
       <div className="ports list">
         {ports.map((port) => (

--- a/arduino-ide-extension/src/browser/boards/boards-config.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-config.tsx
@@ -308,7 +308,7 @@ export class BoardsConfig extends React.Component<
             className="theia-input"
             placeholder={nls.localize(
               'arduino/board/searchBoard',
-              'SEARCH BOARD'
+              'Search board'
             )}
             onChange={this.updateBoards}
             ref={this.focusNodeSet}

--- a/arduino-ide-extension/src/browser/dialogs/user-fields/user-fields-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/user-fields/user-fields-component.tsx
@@ -65,7 +65,11 @@ export const UserFieldsComponent = ({
                     type={field.secret ? 'password' : 'text'}
                     value={field.value}
                     className="theia-input"
-                    placeholder={'Enter ' + field.label}
+                    placeholder={nls.localize(
+                      'arduino/userFields/enterField',
+                      'Enter {0}',
+                      field.label
+                    )}
                     onChange={updateUserField(index)}
                   />
                 </div>

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -42,6 +42,7 @@ import {
 } from './cli-protocol/cc/arduino/cli/commands/v1/upload_pb';
 import { ExecuteWithProgress } from './grpc-progressible';
 import { ServiceError } from './service-error';
+import { nls } from '@theia/core/lib/common';
 
 @injectable()
 export class BoardsServiceImpl
@@ -319,7 +320,10 @@ export class BoardsServiceImpl
           .join(', '),
         installable: true,
         deprecated: platform.getDeprecated(),
-        summary: 'Boards included in this package:',
+        summary: nls.localize(
+          'arduino/component/boardsIncluded',
+          'Boards included in this package:'
+        ),
         installedVersion,
         boards: platform
           .getBoardsList()

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -17,6 +17,7 @@
       "installManually": "Install Manually",
       "installNow": "The \"{0} {1}\" core has to be installed for the currently selected \"{2}\" board. Do you want to install it now?",
       "noFQBN": "The FQBN is not available for the selected board \"{0}\". Do you have the corresponding core installed?",
+      "noPortsDiscovered": "No ports discovered",
       "noPortsSelected": "No ports selected for board: '{0}'.",
       "noneSelected": "No boards selected.",
       "openBoardsConfig": "Select other board and port…",
@@ -26,6 +27,7 @@
       "portLabel": "Port: {0}",
       "programmer": "Programmer",
       "reselectLater": "Reselect later",
+      "searchBoard": "SEARCH BOARD",
       "selectBoard": "Select Board",
       "selectBoardForInfo": "Please select a board to obtain board info.",
       "selectPortForInfo": "Please select a port to obtain board info.",
@@ -115,6 +117,7 @@
       "error": "Compilation error: {0}"
     },
     "component": {
+      "boardsIncluded": "Boards included in this package:",
       "by": "by",
       "filterSearch": "Filter your search...",
       "install": "INSTALL",
@@ -344,6 +347,7 @@
     },
     "userFields": {
       "cancel": "Cancel",
+      "enterField": "Enter {0}",
       "upload": "Upload"
     }
   },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -27,7 +27,7 @@
       "portLabel": "Port: {0}",
       "programmer": "Programmer",
       "reselectLater": "Reselect later",
-      "searchBoard": "SEARCH BOARD",
+      "searchBoard": "Search board",
       "selectBoard": "Select Board",
       "selectBoardForInfo": "Please select a board to obtain board info.",
       "selectPortForInfo": "Please select a port to obtain board info.",


### PR DESCRIPTION
The text of the Arduino IDE user interface has been localized to 12 languages.

Before localization can be accomplished, internationalization must be done in the application's codebase:

- Set up infrastructure to export localization data
- Pass all target strings to that infrastructure

### Motivation

While the first of these tasks is completed, the second was not completed for several strings which are part of the user interface.

### Change description

Those outstanding strings are internationalized and will be made available for localization.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)