### PR TITLE
Align functional max-min of scale stepper to actual max-min zoom level

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
@@ -23,8 +23,8 @@ import {
 } from '@theia/core/lib/common/i18n/localization';
 import SettingsStepInput from './settings-step-input';
 
-const maxScale = 200;
-const minScale = -100;
+const maxScale = 280;
+const minScale = -60;
 const scaleStep = 20;
 
 const maxFontSize = 72;


### PR DESCRIPTION
### Motivation
Small fix for correctness. we are yet to decide whether or not to impose a specific max/min level of zoom in the IDE, in the meantime, to avoid confusion we should ensure the max-min zoom of the scale stepper reflects the actual max-min zoom of the application.

### Change description
Changes hard coded max-min values used by the scale stepper.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)