### PR TITLE
Install Arduino CLI build dependencies in all dependent workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,8 @@ on:
     - cron: '0 3 * * *' # run every day at 3AM (https://docs.github.com/en/actions/reference/events-that-trigger-workflows#scheduled-events-schedule)
 
 env:
+  # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
+  GO_VERSION: "1.17"
   JOB_TRANSFER_ARTIFACT: build-artifacts
   CHANGELOG_ARTIFACTS: changelog
 
@@ -65,6 +67,11 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1

--- a/.github/workflows/check-i18n-task.yml
+++ b/.github/workflows/check-i18n-task.yml
@@ -1,5 +1,9 @@
 name: Check Internationalization
 
+env:
+  # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
+  GO_VERSION: "1.17"
+
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   push:
@@ -30,6 +34,11 @@ jobs:
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Taskfile
         uses: arduino/setup-task@v1

--- a/.github/workflows/i18n-nightly-push.yml
+++ b/.github/workflows/i18n-nightly-push.yml
@@ -1,5 +1,9 @@
 name: i18n-nightly-push
 
+env:
+  # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
+  GO_VERSION: "1.17"
+
 on:
   schedule:
     # run every day at 1AM
@@ -17,6 +21,17 @@ jobs:
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/i18n-weekly-pull.yml
+++ b/.github/workflows/i18n-weekly-pull.yml
@@ -1,5 +1,9 @@
 name: i18n-weekly-pull
 
+env:
+  # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
+  GO_VERSION: "1.17"
+
 on:
   schedule:
     # run every monday at 2AM
@@ -17,6 +21,17 @@ jobs:
         with:
           node-version: '14.x'
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
 
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/themes-weekly-pull.yml
+++ b/.github/workflows/themes-weekly-pull.yml
@@ -7,6 +7,8 @@ on:
   workflow_dispatch:
 
 env:
+  # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
+  GO_VERSION: "1.17"
   NODE_VERSION: 14.x
 
 jobs:
@@ -21,6 +23,17 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Task
+        uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
### Motivation

[**Arduino CLI**](https://github.com/arduino/arduino-cli) is a tool dependency of Arduino IDE. For this reason, the necessary Arduino CLI build is acquired whenever running the `yarn` command in the repository.

The way the **Arduino CLI** build is acquired depends on the type of version specified as dependency in [the `arduino.cli.version` field of the **arduino-ide-extension** package metadata](https://github.com/arduino/arduino-ide/blob/ca47e8a09af514926da28e6b2b09603b02476df4/arduino-ide-extension/package.json#L163):

- [Release/nightly: download pre-built standard distribution](https://github.com/arduino/arduino-ide/blob/ca47e8a09af514926da28e6b2b09603b02476df4/arduino-ide-extension/scripts/download-cli.js#L68-L80)
- [Git ref: build from source](https://github.com/arduino/arduino-ide/blob/ca47e8a09af514926da28e6b2b09603b02476df4/arduino-ide-extension/scripts/download-cli.js#L85)

This means that, in the latter case, all build dependencies of Arduino CLI must be present. While the **Go** module dependencies are automatically installed during the build, the build tool dependencies must be installed in advance:

- [**Go** programming language](https://go.dev/)
- [**Task** task runner](https://taskfile.dev/)

Arduino IDE's infrastructure was recently changed to use the Task tool to build Arduino CLI in [the standard manner](https://arduino.github.io/arduino-cli/dev/CONTRIBUTING/#building-the-source-code) (https://github.com/arduino/arduino-ide/pull/1315). A step to install **Task** was not added to some of the workflows that run `yarn`, which caused them to fail when a non-release version of Arduino CLI was used as a dependency:

https://github.com/arduino/arduino-ide/runs/7985963886?check_suite_focus=true#step:4:52

```text
arduino-ide-extension: >>> Building the CLI...
arduino-ide-extension: /bin/sh: 1: task: not found
arduino-ide-extension: error Command failed with exit code 1.
```

### Change description

Add a step for the missing tool dependency to those workflows.

The lack of an explicit installation of the other dependency, **Go** did not result in an error because [**Go** is pre-installed on the GitHub Actions runner](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu1804-Readme.md#go). However, the installed version may not match the version Arduino CLI is intended to be [built with](https://github.com/arduino/arduino-cli/blob/f43c9ec042d03390767689348922082173d4611f/DistTasks.yml#L22) and [validated for](https://github.com/arduino/arduino-cli/blob/f43c9ec042d03390767689348922082173d4611f/.github/workflows/test-go-task.yml#L6), and the version provided by the runner may change at any time. For this reason, it will be safest to explicitly set up the appropriate version of Go in the workflows.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)