### PR TITLE
Error message if upload is not possible

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/contribution.ts
+++ b/arduino-ide-extension/src/browser/contributions/contribution.ts
@@ -222,6 +222,14 @@ export abstract class CoreServiceContribution extends SketchContribution {
       } catch {}
     }
     if (message) {
+      if (
+        message.includes(
+          'Compilation error: Missing FQBN (Fully Qualified Board Name)'
+        )
+      ) {
+        message =
+          'No board selected. Please select your Arduino board from the Tools > Board menu.';
+      }
       const copyAction = nls.localize(
         'arduino/coreContribution/copyError',
         'Copy error messages'

--- a/arduino-ide-extension/src/browser/contributions/contribution.ts
+++ b/arduino-ide-extension/src/browser/contributions/contribution.ts
@@ -223,8 +223,10 @@ export abstract class CoreServiceContribution extends SketchContribution {
     }
     if (message) {
       if (message.includes('Missing FQBN (Fully Qualified Board Name)')) {
-        message =
-          'No board selected. Please select your Arduino board from the Tools > Board menu.';
+        message = nls.localize(
+          'arduino/coreContribution/noBoardSelected',
+          'No board selected. Please select your Arduino board from the Tools > Board menu.'
+        );
       }
       const copyAction = nls.localize(
         'arduino/coreContribution/copyError',

--- a/arduino-ide-extension/src/browser/contributions/contribution.ts
+++ b/arduino-ide-extension/src/browser/contributions/contribution.ts
@@ -222,11 +222,7 @@ export abstract class CoreServiceContribution extends SketchContribution {
       } catch {}
     }
     if (message) {
-      if (
-        message.includes(
-          'Compilation error: Missing FQBN (Fully Qualified Board Name)'
-        )
-      ) {
+      if (message.includes('Missing FQBN (Fully Qualified Board Name)')) {
         message =
           'No board selected. Please select your Arduino board from the Tools > Board menu.';
       }

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -61,7 +61,11 @@ export class UploadSketch extends CoreServiceContribution {
     registry.registerCommand(UploadSketch.Commands.UPLOAD_SKETCH, {
       execute: async () => {
         const key = this.selectedFqbnAddress();
-        if (this.boardRequiresUserFields && !this.cachedUserFields.has(key)) {
+        if (
+          this.boardRequiresUserFields &&
+          key &&
+          !this.cachedUserFields.has(key)
+        ) {
           // Deep clone the array of board fields to avoid editing the cached ones
           this.userFieldsDialog.value = (
             await this.boardsServiceProvider.selectedBoardUserFields()

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -61,9 +61,6 @@ export class UploadSketch extends CoreServiceContribution {
     registry.registerCommand(UploadSketch.Commands.UPLOAD_SKETCH, {
       execute: async () => {
         const key = this.selectedFqbnAddress();
-        if (!key) {
-          return;
-        }
         if (this.boardRequiresUserFields && !this.cachedUserFields.has(key)) {
           // Deep clone the array of board fields to avoid editing the cached ones
           this.userFieldsDialog.value = (

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -132,7 +132,8 @@
       "replaceTitle": "Replace"
     },
     "coreContribution": {
-      "copyError": "Copy error messages"
+      "copyError": "Copy error messages",
+      "noBoardSelected": "No board selected. Please select your Arduino board from the Tools > Board menu."
     },
     "daemon": {
       "restart": "Restart Daemon",


### PR DESCRIPTION
### Motivation
If the user presses the upload button and no board is selected, a message should appear warning what went wrong while uploading. Since verify takes place before upload, the same message that is given when the user tries to compile a sketch without selecting a board should be shown. On the other hand, this message is not very clear, so it should be updated.

### Change description
Communicate to user when upload is impossible due to no board selection.
Make error message from compiling without board selected more user friendly.

### Other information
Closes #845.
Closes #62.

This fix depends on the changes made here: https://github.com/arduino/arduino-cli/pull/1848. Without it it is not possible to verify that #62 is resolved.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)