### PR TITLE
#1055 Install the `Arduino_BuiltIn` to built-in location

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -160,11 +160,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": {
-        "owner": "cmaglie",
-        "repo": "arduino-cli",
-        "commitish": "byebye_bundles"
-      }
+      "version": "0.27.0-rc.1"
     },
     "fwuploader": {
       "version": "2.2.0"

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -161,9 +161,9 @@
   "arduino": {
     "cli": {
       "version": {
-        "owner": "arduino",
+        "owner": "cmaglie",
         "repo": "arduino-cli",
-        "commitish": "05d1446"
+        "commitish": "byebye_bundles"
       }
     },
     "fwuploader": {

--- a/arduino-ide-extension/src/browser/contributions/first-startup-installer.ts
+++ b/arduino-ide-extension/src/browser/contributions/first-startup-installer.ts
@@ -1,6 +1,10 @@
 import { LocalStorageService } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { BoardsService, LibraryService } from '../../common/protocol';
+import {
+  BoardsService,
+  LibraryLocation,
+  LibraryService,
+} from '../../common/protocol';
 import { Contribution } from './contribution';
 
 @injectable()
@@ -57,6 +61,7 @@ export class FirstStartupInstaller extends Contribution {
             item: builtInLibrary,
             installDependencies: true,
             noOverwrite: true, // We don't want to automatically replace custom libraries the user might already have in place
+            installLocation: LibraryLocation.BUILTIN,
           });
         } catch (e) {
           // There's no error code, I need to parse the error message: https://github.com/arduino/arduino-cli/commit/2ea3608453b17b1157f8a1dc892af2e13e40f4f0#diff-1de7569144d4e260f8dde0e0d00a4e2a218c57966d583da1687a70d518986649R95

--- a/arduino-ide-extension/src/common/protocol/library-service.ts
+++ b/arduino-ide-extension/src/common/protocol/library-service.ts
@@ -28,6 +28,7 @@ export interface LibraryService
     version?: Installable.Version;
     installDependencies?: boolean;
     noOverwrite?: boolean;
+    installLocation?: LibraryLocation.BUILTIN | LibraryLocation.USER;
   }): Promise<void>;
   installZip(options: {
     zipUri: string;
@@ -141,7 +142,7 @@ export enum LibraryLocation {
   /**
    * In the `libraries` subdirectory of the Arduino IDE installation.
    */
-  IDE_BUILTIN = 0,
+  BUILTIN = 0,
 
   /**
    * In the `libraries` subdirectory of the user directory (sketchbook).

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.d.ts
@@ -82,6 +82,9 @@ export class LibraryInstallRequest extends jspb.Message {
     getNoOverwrite(): boolean;
     setNoOverwrite(value: boolean): LibraryInstallRequest;
 
+    getInstallLocation(): LibraryInstallLocation;
+    setInstallLocation(value: LibraryInstallLocation): LibraryInstallRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): LibraryInstallRequest.AsObject;
@@ -100,6 +103,7 @@ export namespace LibraryInstallRequest {
         version: string,
         noDeps: boolean,
         noOverwrite: boolean,
+        installLocation: LibraryInstallLocation,
     }
 }
 
@@ -962,6 +966,11 @@ export namespace GitLibraryInstallResponse {
     }
 }
 
+export enum LibraryInstallLocation {
+    LIBRARY_INSTALL_LOCATION_USER = 0,
+    LIBRARY_INSTALL_LOCATION_BUILTIN = 1,
+}
+
 export enum LibrarySearchStatus {
     LIBRARY_SEARCH_STATUS_FAILED = 0,
     LIBRARY_SEARCH_STATUS_SUCCESS = 1,
@@ -973,7 +982,7 @@ export enum LibraryLayout {
 }
 
 export enum LibraryLocation {
-    LIBRARY_LOCATION_IDE_BUILTIN = 0,
+    LIBRARY_LOCATION_BUILTIN = 0,
     LIBRARY_LOCATION_USER = 1,
     LIBRARY_LOCATION_PLATFORM_BUILTIN = 2,
     LIBRARY_LOCATION_REFERENCED_PLATFORM_BUILTIN = 3,

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.js
@@ -26,6 +26,7 @@ goog.exportSymbol('proto.cc.arduino.cli.commands.v1.LibraryDependency', null, gl
 goog.exportSymbol('proto.cc.arduino.cli.commands.v1.LibraryDependencyStatus', null, global);
 goog.exportSymbol('proto.cc.arduino.cli.commands.v1.LibraryDownloadRequest', null, global);
 goog.exportSymbol('proto.cc.arduino.cli.commands.v1.LibraryDownloadResponse', null, global);
+goog.exportSymbol('proto.cc.arduino.cli.commands.v1.LibraryInstallLocation', null, global);
 goog.exportSymbol('proto.cc.arduino.cli.commands.v1.LibraryInstallRequest', null, global);
 goog.exportSymbol('proto.cc.arduino.cli.commands.v1.LibraryInstallResponse', null, global);
 goog.exportSymbol('proto.cc.arduino.cli.commands.v1.LibraryLayout', null, global);
@@ -1012,7 +1013,8 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.toObject = function(inclu
     name: jspb.Message.getFieldWithDefault(msg, 2, ""),
     version: jspb.Message.getFieldWithDefault(msg, 3, ""),
     noDeps: jspb.Message.getBooleanFieldWithDefault(msg, 4, false),
-    noOverwrite: jspb.Message.getBooleanFieldWithDefault(msg, 5, false)
+    noOverwrite: jspb.Message.getBooleanFieldWithDefault(msg, 5, false),
+    installLocation: jspb.Message.getFieldWithDefault(msg, 6, 0)
   };
 
   if (includeInstance) {
@@ -1069,6 +1071,10 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.deserializeBinaryFromRead
     case 5:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setNoOverwrite(value);
+      break;
+    case 6:
+      var value = /** @type {!proto.cc.arduino.cli.commands.v1.LibraryInstallLocation} */ (reader.readEnum());
+      msg.setInstallLocation(value);
       break;
     default:
       reader.skipField();
@@ -1132,6 +1138,13 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.serializeBinaryToWriter =
   if (f) {
     writer.writeBool(
       5,
+      f
+    );
+  }
+  f = message.getInstallLocation();
+  if (f !== 0.0) {
+    writer.writeEnum(
+      6,
       f
     );
   }
@@ -1244,6 +1257,24 @@ proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.getNoOverwrite 
  */
 proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.setNoOverwrite = function(value) {
   return jspb.Message.setProto3BooleanField(this, 5, value);
+};
+
+
+/**
+ * optional LibraryInstallLocation install_location = 6;
+ * @return {!proto.cc.arduino.cli.commands.v1.LibraryInstallLocation}
+ */
+proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.getInstallLocation = function() {
+  return /** @type {!proto.cc.arduino.cli.commands.v1.LibraryInstallLocation} */ (jspb.Message.getFieldWithDefault(this, 6, 0));
+};
+
+
+/**
+ * @param {!proto.cc.arduino.cli.commands.v1.LibraryInstallLocation} value
+ * @return {!proto.cc.arduino.cli.commands.v1.LibraryInstallRequest} returns this
+ */
+proto.cc.arduino.cli.commands.v1.LibraryInstallRequest.prototype.setInstallLocation = function(value) {
+  return jspb.Message.setProto3EnumField(this, 6, value);
 };
 
 
@@ -7060,6 +7091,14 @@ proto.cc.arduino.cli.commands.v1.GitLibraryInstallResponse.prototype.hasTaskProg
 /**
  * @enum {number}
  */
+proto.cc.arduino.cli.commands.v1.LibraryInstallLocation = {
+  LIBRARY_INSTALL_LOCATION_USER: 0,
+  LIBRARY_INSTALL_LOCATION_BUILTIN: 1
+};
+
+/**
+ * @enum {number}
+ */
 proto.cc.arduino.cli.commands.v1.LibrarySearchStatus = {
   LIBRARY_SEARCH_STATUS_FAILED: 0,
   LIBRARY_SEARCH_STATUS_SUCCESS: 1
@@ -7077,7 +7116,7 @@ proto.cc.arduino.cli.commands.v1.LibraryLayout = {
  * @enum {number}
  */
 proto.cc.arduino.cli.commands.v1.LibraryLocation = {
-  LIBRARY_LOCATION_IDE_BUILTIN: 0,
+  LIBRARY_LOCATION_BUILTIN: 0,
   LIBRARY_LOCATION_USER: 1,
   LIBRARY_LOCATION_PLATFORM_BUILTIN: 2,
   LIBRARY_LOCATION_REFERENCED_PLATFORM_BUILTIN: 3,

--- a/arduino-ide-extension/src/node/library-service-impl.ts
+++ b/arduino-ide-extension/src/node/library-service-impl.ts
@@ -21,6 +21,7 @@ import {
   ZipLibraryInstallRequest,
   LibrarySearchRequest,
   LibrarySearchResponse,
+  LibraryInstallLocation,
 } from './cli-protocol/cc/arduino/cli/commands/v1/lib_pb';
 import { Installable } from '../common/protocol/installable';
 import { ILogger, notEmpty } from '@theia/core';
@@ -231,8 +232,8 @@ export class LibraryServiceImpl
 
   private mapLocation(location: GrpcLibraryLocation): LibraryLocation {
     switch (location) {
-      case GrpcLibraryLocation.LIBRARY_LOCATION_IDE_BUILTIN:
-        return LibraryLocation.IDE_BUILTIN;
+      case GrpcLibraryLocation.LIBRARY_LOCATION_BUILTIN:
+        return LibraryLocation.BUILTIN;
       case GrpcLibraryLocation.LIBRARY_LOCATION_USER:
         return LibraryLocation.USER;
       case GrpcLibraryLocation.LIBRARY_LOCATION_PLATFORM_BUILTIN:
@@ -290,6 +291,7 @@ export class LibraryServiceImpl
     version?: Installable.Version;
     installDependencies?: boolean;
     noOverwrite?: boolean;
+    installLocation?: LibraryLocation.BUILTIN | LibraryLocation.USER;
   }): Promise<void> {
     const item = options.item;
     const version = !!options.version
@@ -304,6 +306,15 @@ export class LibraryServiceImpl
     req.setVersion(version);
     req.setNoDeps(!options.installDependencies);
     req.setNoOverwrite(Boolean(options.noOverwrite));
+    if (options.installLocation === LibraryLocation.BUILTIN) {
+      req.setInstallLocation(
+        LibraryInstallLocation.LIBRARY_INSTALL_LOCATION_BUILTIN
+      );
+    } else if (options.installLocation === LibraryLocation.USER) {
+      req.setInstallLocation(
+        LibraryInstallLocation.LIBRARY_INSTALL_LOCATION_USER
+      );
+    }
 
     console.info('>>> Starting library package installation...', item);
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Use a dedicated install location for the `Arduino_BuiltIn` lib on the first IDE2 start.

### Change description
From now on, the built-in lib will be installed into the `built-in` location of the CLI.

Closes #1055.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)