### PR TITLE
#1365 Show ports if has recognized board attached to it

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-config.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-config.tsx
@@ -337,14 +337,9 @@ export class BoardsConfig extends React.Component<
     if (this.state.showAllPorts) {
       ports = this.state.knownPorts;
     } else {
-      ports = this.state.knownPorts.filter((port) => {
-        if (port.protocol === 'serial' || port.protocol === 'network') {
-          // Allow all `serial` and `network` boards.
-          // IDE2 must support better label for unrecognized `network` boards: https://github.com/arduino/arduino-ide/issues/1331
-          return true;
-        }
-        return false;
-      });
+      ports = this.state.knownPorts.filter(
+        Port.visiblePorts(this.availableBoards)
+      );
     }
     return !ports.length ? (
       <div className="loading noselect">

--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -528,14 +528,9 @@ export class BoardsServiceProvider implements FrontendApplicationContribution {
     const currentAvailableBoards = this._availableBoards;
     const availableBoards: AvailableBoard[] = [];
     const attachedBoards = this._attachedBoards.filter(({ port }) => !!port);
-    const availableBoardPorts = availablePorts.filter((port) => {
-      if (port.protocol === 'serial' || port.protocol === 'network') {
-        // Allow all `serial` and `network` boards.
-        // IDE2 must support better label for unrecognized `network` boards: https://github.com/arduino/arduino-ide/issues/1331
-        return true;
-      }
-      return false;
-    });
+    const availableBoardPorts = availablePorts.filter(
+      Port.visiblePorts(attachedBoards)
+    );
 
     for (const boardPort of availableBoardPorts) {
       const board = attachedBoards.find(({ port }) =>

--- a/arduino-ide-extension/src/common/protocol/boards-service.ts
+++ b/arduino-ide-extension/src/common/protocol/boards-service.ts
@@ -259,6 +259,32 @@ export namespace Port {
     }
     return false;
   }
+  // See https://github.com/arduino/arduino-ide/commit/79ea0fa9a6ad2b01eaac22cef2f494d3b68284e6#diff-fb37f20bea00881acee3aafddb1ecefcecf41ce59845ca1510da79e918ee0837L338-L348
+  // See https://github.com/arduino/arduino-ide/commit/79ea0fa9a6ad2b01eaac22cef2f494d3b68284e6#diff-e42c82bb67e277cfa4598239952afd65db44dba55dc7d68df619dfccfa648279L441-L455
+  // See https://github.com/arduino/arduino-ide/commit/74bfdc4c56d7a1577a4e800a378c21b82c1da5f8#diff-e42c82bb67e277cfa4598239952afd65db44dba55dc7d68df619dfccfa648279L405-R424
+  /**
+   * All ports with `'serial'` or `'network'` `protocol`, or any other port `protocol` that has at least one recognized board connected to.
+   */
+  export function visiblePorts(
+    boardsHaystack: ReadonlyArray<Board>
+  ): (port: Port) => boolean {
+    return (port: Port) => {
+      if (port.protocol === 'serial' || port.protocol === 'network') {
+        // Allow all `serial` and `network` boards.
+        // IDE2 must support better label for unrecognized `network` boards: https://github.com/arduino/arduino-ide/issues/1331
+        return true;
+      }
+      // All other ports with different protocol are
+      // only shown if there is a recognized board
+      // connected
+      for (const board of boardsHaystack) {
+        if (board.port?.address === port.address) {
+          return true;
+        }
+      }
+      return false;
+    };
+  }
 }
 
 export interface BoardsPackage extends ArduinoComponent {


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Avoid filtering ports and the boards connected to them if the `protocol` is neither `'serial'` nor `'network`', but the associated boards are recognized.

### Change description
Single sourced the port filtering.

### Other information

Closes #1365

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)