### PR TITLE
Move primary buttons on the right of the dialogs

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-dialog.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-dialog.tsx
@@ -181,10 +181,10 @@ export class AdditionalUrlsDialog extends AbstractDialog<string[]> {
     );
     this.contentNode.appendChild(anchor);
 
-    this.appendAcceptButton(nls.localize('vscode/issueMainService/ok', 'OK'));
     this.appendCloseButton(
       nls.localize('vscode/issueMainService/cancel', 'Cancel')
     );
+    this.appendAcceptButton(nls.localize('vscode/issueMainService/ok', 'OK'));
   }
 
   get value(): string[] {

--- a/arduino-ide-extension/src/browser/library/library-list-widget.ts
+++ b/arduino-ide-extension/src/browser/library/library-list-widget.ts
@@ -202,7 +202,7 @@ class MessageBoxDialog extends AbstractDialog<MessageBoxDialog.Result> {
     ).forEach((text, index) => {
       const button = this.createButton(text);
       const isPrimaryButton =
-        index === (options.buttons ? options.buttons?.length - 1 : 0);
+        index === (options.buttons ? options.buttons.length - 1 : 0);
       button.classList.add(isPrimaryButton ? 'main' : 'secondary');
       this.controlPanel.appendChild(button);
       this.toDisposeOnDetach.push(

--- a/arduino-ide-extension/src/browser/library/library-list-widget.ts
+++ b/arduino-ide-extension/src/browser/library/library-list-widget.ts
@@ -201,8 +201,9 @@ class MessageBoxDialog extends AbstractDialog<MessageBoxDialog.Result> {
       options.buttons || [nls.localize('vscode/issueMainService/ok', 'OK')]
     ).forEach((text, index) => {
       const button = this.createButton(text);
-      const i = options.buttons ? options.buttons?.length - 1 : 0;
-      button.classList.add(index === i ? 'main' : 'secondary');
+      const isPrimaryButton =
+        index === (options.buttons ? options.buttons?.length - 1 : 0);
+      button.classList.add(isPrimaryButton ? 'main' : 'secondary');
       this.controlPanel.appendChild(button);
       this.toDisposeOnDetach.push(
         addEventListener(button, 'click', () => {

--- a/arduino-ide-extension/src/browser/library/library-list-widget.ts
+++ b/arduino-ide-extension/src/browser/library/library-list-widget.ts
@@ -126,13 +126,13 @@ export class LibraryListWidget extends ListWidget<
         ),
         message,
         buttons: [
-          nls.localize('arduino/library/installAll', 'Install all'),
+          nls.localize('vscode/issueMainService/cancel', 'Cancel'),
           nls.localize(
             'arduino/library/installOnly',
             'Install {0} only',
             item.name
           ),
-          nls.localize('vscode/issueMainService/cancel', 'Cancel'),
+          nls.localize('arduino/library/installAll', 'Install all'),
         ],
         maxWidth: 740, // Aligned with `settings-dialog.css`.
       }).open();
@@ -201,7 +201,8 @@ class MessageBoxDialog extends AbstractDialog<MessageBoxDialog.Result> {
       options.buttons || [nls.localize('vscode/issueMainService/ok', 'OK')]
     ).forEach((text, index) => {
       const button = this.createButton(text);
-      button.classList.add(index === 0 ? 'main' : 'secondary');
+      const i = options.buttons ? options.buttons?.length - 1 : 0;
+      button.classList.add(index === i ? 'main' : 'secondary');
       this.controlPanel.appendChild(button);
       this.toDisposeOnDetach.push(
         addEventListener(button, 'click', () => {

--- a/arduino-ide-extension/src/browser/style/settings-dialog.css
+++ b/arduino-ide-extension/src/browser/style/settings-dialog.css
@@ -93,4 +93,5 @@
 
 .p-Widget.dialogOverlay .dialogBlock .dialogContent.additional-urls-dialog {
     display: block;
+    overflow: hidden;
 }

--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-input-dialog.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-input-dialog.ts
@@ -47,7 +47,7 @@ export class WorkspaceInputDialog extends TheiaWorkspaceInputDialog {
     this.closeButton = this.createButton(text);
     this.controlPanel.insertBefore(
       this.closeButton,
-      this.controlPanel.firstChild
+      this.controlPanel.lastChild
     );
     this.closeButton.classList.add('secondary');
     return this.closeButton;

--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-input-dialog.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-input-dialog.ts
@@ -14,12 +14,17 @@ export class WorkspaceInputDialog extends TheiaWorkspaceInputDialog {
   constructor(
     @inject(WorkspaceInputDialogProps)
     protected override readonly props: WorkspaceInputDialogProps,
-    @inject(LabelProvider) protected override readonly labelProvider: LabelProvider
+    @inject(LabelProvider)
+    protected override readonly labelProvider: LabelProvider
   ) {
     super(props, labelProvider);
-    this.appendCloseButton(
-      nls.localize('vscode/issueMainService/cancel', 'Cancel')
-    );
+    if (this.acceptButton) {
+      this.controlPanel.removeChild(this.acceptButton);
+      this.appendCloseButton(
+        nls.localize('vscode/issueMainService/cancel', 'Cancel')
+      );
+      this.appendAcceptButton();
+    }
   }
 
   protected override appendParentPath(): void {

--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-input-dialog.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-input-dialog.ts
@@ -18,13 +18,9 @@ export class WorkspaceInputDialog extends TheiaWorkspaceInputDialog {
     protected override readonly labelProvider: LabelProvider
   ) {
     super(props, labelProvider);
-    if (this.acceptButton) {
-      this.controlPanel.removeChild(this.acceptButton);
-      this.appendCloseButton(
-        nls.localize('vscode/issueMainService/cancel', 'Cancel')
-      );
-      this.appendAcceptButton();
-    }
+    this.appendCloseButton(
+      nls.localize('vscode/issueMainService/cancel', 'Cancel')
+    );
   }
 
   protected override appendParentPath(): void {
@@ -45,5 +41,15 @@ export class WorkspaceInputDialog extends TheiaWorkspaceInputDialog {
     if (this.wasTouched) {
       this.errorMessageNode.innerText = DialogError.getMessage(error);
     }
+  }
+
+  protected override appendCloseButton(text: string): HTMLButtonElement {
+    this.closeButton = this.createButton(text);
+    this.controlPanel.insertBefore(
+      this.closeButton,
+      this.controlPanel.firstChild
+    );
+    this.closeButton.classList.add('secondary');
+    return this.closeButton;
   }
 }


### PR DESCRIPTION
### Motivation
In some dialogs, the primary button is not on the right.

### Change description
Move all primary buttons in dialogs to the right.

![Screenshot 2022-09-01 142402](https://user-images.githubusercontent.com/94986937/187913950-e8d27e68-5d74-4b07-8c94-0847ecce1150.png)

![Screenshot 2022-09-01 142929](https://user-images.githubusercontent.com/94986937/187913991-4d63e85f-2115-4a69-bd6a-c1cf609c09f5.png)

![Screenshot 2022-09-02 114253](https://user-images.githubusercontent.com/94986937/188149433-7f0b169e-2cfc-40c9-b583-11feed541c00.png)


### Other information
Closes #1368.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)