### PR TITLE
#572 Can send message to the monitor with `Enter`

### DIFF
--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-input.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-input.tsx
@@ -1,7 +1,6 @@
 import * as React from '@theia/core/shared/react';
 import { Key, KeyCode } from '@theia/core/lib/browser/keys';
 import { Board } from '../../../common/protocol/boards-service';
-import { isOSX } from '@theia/core/lib/common/os';
 import { DisposableCollection, nls } from '@theia/core/lib/common';
 import { BoardsServiceProvider } from '../../boards/boards-service-provider';
 import { MonitorModel } from '../../monitor-model';
@@ -81,8 +80,7 @@ export class SerialMonitorSendInput extends React.Component<
     const port = this.props.boardsServiceProvider.boardsConfig.selectedPort;
     return nls.localize(
       'arduino/serial/message',
-      "Message ({0} + Enter to send message to '{1}' on '{2}')",
-      isOSX ? '⌘' : nls.localize('vscode/keybindingLabels/ctrlKey', 'Ctrl'),
+      "Message (Enter to send message to '{0}' on '{1}')",
       board
         ? Board.toString(board, {
             useFqbn: false,
@@ -110,8 +108,8 @@ export class SerialMonitorSendInput extends React.Component<
   protected onKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
     const keyCode = KeyCode.createKeyCode(event.nativeEvent);
     if (keyCode) {
-      const { key, meta, ctrl } = keyCode;
-      if (key === Key.ENTER && ((isOSX && meta) || (!isOSX && ctrl))) {
+      const { key } = keyCode;
+      if (key === Key.ENTER) {
         this.onSend();
       }
     }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -336,7 +336,7 @@
     "serial": {
       "autoscroll": "Autoscroll",
       "carriageReturn": "Carriage Return",
-      "message": "Message ({0} + Enter to send message to '{1}' on '{2}')",
+      "message": "Message (Enter to send message to '{0}' on '{1}')",
       "newLine": "New Line",
       "newLineCarriageReturn": "Both NL & CR",
       "noLineEndings": "No Line Ending",


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Can send message to monitor with <kbd>Enter</kbd> instead of <kbd>Ctrl</kbd>/<kbd>⌘</kbd>+<kbd>Enter</kbd>.

I checked the Theia code, [it should work](https://github.com/eclipse-theia/theia/blob/9e5db7756755fe2cc4155f59fda27f32b3d5bbe4/packages/core/src/common/keys.ts#L659) with _Numpad Enter_ but it would be great if somebody could verify it. Thank you!

### Change description
<!-- What does your code do? -->

Closes #572

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)