### PR TITLE
fix board selection and workspace input dialogs width and height

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-config-dialog.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-config-dialog.ts
@@ -34,6 +34,7 @@ export class BoardsConfigDialog extends AbstractDialog<BoardsConfig.Config> {
   ) {
     super({ ...props, maxWidth: 500 });
 
+    this.node.id = 'select-board-dialog-container';
     this.contentNode.classList.add('select-board-dialog');
     this.contentNode.appendChild(this.createDescription());
 

--- a/arduino-ide-extension/src/browser/style/boards-config-dialog.css
+++ b/arduino-ide-extension/src/browser/style/boards-config-dialog.css
@@ -1,3 +1,8 @@
+#select-board-dialog-container > .dialogBlock {
+  width: 640px;
+  height: 500px;
+}
+
 div#select-board-dialog {
   margin: 5px;
 }

--- a/arduino-ide-extension/src/browser/style/dialogs.css
+++ b/arduino-ide-extension/src/browser/style/dialogs.css
@@ -85,3 +85,8 @@
         max-height: 400px;
     }
 }
+
+
+.p-Widget.dialogOverlay.workspace-input-dialog .dialogBlock  {
+    width: 480px;
+}

--- a/arduino-ide-extension/src/browser/theia/workspace/workspace-input-dialog.ts
+++ b/arduino-ide-extension/src/browser/theia/workspace/workspace-input-dialog.ts
@@ -14,9 +14,11 @@ export class WorkspaceInputDialog extends TheiaWorkspaceInputDialog {
   constructor(
     @inject(WorkspaceInputDialogProps)
     protected override readonly props: WorkspaceInputDialogProps,
-    @inject(LabelProvider) protected override readonly labelProvider: LabelProvider
+    @inject(LabelProvider)
+    protected override readonly labelProvider: LabelProvider
   ) {
     super(props, labelProvider);
+    this.node.classList.add('workspace-input-dialog');
     this.appendCloseButton(
       nls.localize('vscode/issueMainService/cancel', 'Cancel')
     );


### PR DESCRIPTION
### Motivation
Some dialogs have unexpected behaviours as described in #1350 

### Change description
fixed width and height of workspace input dialog and board selection dialog

### Other information
Closes #1350

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)