### PR TITLE
Add instructions for accessing IDE's advanced settings

### DIFF
--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -1,0 +1,14 @@
+# Advanced usage
+
+## Advanced settings
+
+The Arduino IDE's primary settings are accessible via the **File > Preferences** menu item. These provide all the configuration capability required by the average user to develop sketches.
+
+Arduino IDE has some additional settings which may be of interest to advanced users who want to do things such as fine tune the behavior of the application or increase log output while investigating a problem.
+
+These advanced settings can be accessed by the following procedure:
+
+1. Press the <kbd>**Ctrl**</kbd>+<kbd>**Shift**</kbd>+<kbd>**P**</kbd> keyboard shortcut (<kbd>**Command**</kbd>+<kbd>**Shift**</kbd>+<kbd>**P**</kbd> for macOS users) to open the "**Command Palette**".
+1. Select the "**Preferences: Open Settings (UI)**" command from the menu.
+
+This will open a "**Preferences**" view in the IDE. Once you are finished adjusting settings, it can be closed by clicking the **X** icon on the "**Preferences**" tab.


### PR DESCRIPTION
### Motivation

Although the Arduino IDE's primary preferences interface provides all required configuration capabilities, advanced users may wish to fine tune the behavior of the application or temporarily enable additional log output to use for troubleshooting problems with the IDE.

The IDE provides such settings in a separate interface.

The existence and access procedure for these settings is undocumented.

### Change description
<!-- What does your code do? -->
Provide instructions for accessing the advanced settings.

Since this is an advanced capability, the documentation is not appropriate for inclusion with the standard user
documentation on arduino.cc. A file here in the Arduino IDE is used instead. This file will serve as a container for all
such user-targeted documentation.
### Other information
<!-- Any additional information that could help the review process -->

Resolves https://github.com/arduino/arduino-ide/issues/1367
### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)