### PR TITLE
Prepare 2.0.0-rc9.4

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide-extension",
-  "version": "2.0.0-rc9.3",
+  "version": "2.0.0-rc9.4",
   "description": "An extension for Theia building the Arduino IDE",
   "license": "AGPL-3.0-or-later",
   "scripts": {
@@ -160,7 +160,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.27.0-rc.1"
+      "version": "0.27.1"
     },
     "fwuploader": {
       "version": "2.2.0"

--- a/browser-app/package.json
+++ b/browser-app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "browser-app",
-  "version": "2.0.0-rc9.3",
+  "version": "2.0.0-rc9.4",
   "license": "AGPL-3.0-or-later",
   "dependencies": {
     "@theia/core": "1.25.0",
@@ -19,7 +19,7 @@
     "@theia/process": "1.25.0",
     "@theia/terminal": "1.25.0",
     "@theia/workspace": "1.25.0",
-    "arduino-ide-extension": "2.0.0-rc9.3"
+    "arduino-ide-extension": "2.0.0-rc9.4"
   },
   "devDependencies": {
     "@theia/cli": "1.25.0"

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "electron-app",
-  "version": "2.0.0-rc9.3",
+  "version": "2.0.0-rc9.4",
   "license": "AGPL-3.0-or-later",
   "main": "src-gen/frontend/electron-main.js",
   "dependencies": {
@@ -21,7 +21,7 @@
     "@theia/process": "1.25.0",
     "@theia/terminal": "1.25.0",
     "@theia/workspace": "1.25.0",
-    "arduino-ide-extension": "2.0.0-rc9.3"
+    "arduino-ide-extension": "2.0.0-rc9.4"
   },
   "devDependencies": {
     "@theia/cli": "1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide",
-  "version": "2.0.0-rc9.3",
+  "version": "2.0.0-rc9.4",
   "description": "Arduino IDE",
   "repository": "https://github.com/arduino/arduino-ide.git",
   "author": "Arduino SA",


### PR DESCRIPTION
### Motivation
Increase Arduino IDE version to release 2.0.0-rc9.4
Upgrade arduino-cli to [0.27.1](https://github.com/arduino/arduino-cli/releases/tag/0.27.1)

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)