### PR TITLE
fallback to port.address if addressLabel is false

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-toolbar-item.tsx
@@ -138,7 +138,7 @@ export class BoardsDropDown extends React.Component<BoardsDropDown.Props> {
             {boardLabel}
           </div>
           <div className="arduino-boards-dropdown-item--port-label noWrapInfo noselect">
-            {port.addressLabel}
+            {port.addressLabel || port.address}
           </div>
         </div>
         {selected ? <div className="fa fa-check" /> : ''}


### PR DESCRIPTION
### Motivation
Reported that upon opening a new sketch port labels can go missing for "Unknown board ports"

### Change description
Falls back to port.address in the JSX if port.addressLabel is falsey.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)