### PR TITLE
Time format in Serial Monitor changed. Fixes #580

### DIFF
--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -109,7 +109,7 @@ const _Row = ({
 }) => {
   const timestamp =
     (data.timestamp &&
-      `${dateFormat(data.lines[index].timestamp, 'H:M:ss.l')} -> `) ||
+      `${dateFormat(data.lines[index].timestamp, 'HH:MM:ss.l')} -> `) ||
     '';
   return (
     (data.lines[index].lineLen && (


### PR DESCRIPTION
### Motivation
Misalignment of output observed in Serial Monitor due to trimming of leading zeros in the datetime format

### Change description
Datetime format modified to contain leading zeros i.e. 22:8:7.353 will now be printed as 22:08:07.353

### Other information
Fixes #580

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)