### PR TITLE
Remove table of nightly build links from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,32 +14,7 @@ The Arduino IDE 2.x is a major rewrite, sharing no code with the IDE 1.x. It is 
 
 ## Download
 
-You can download the latest version from the [software download page on the Arduino website](https://www.arduino.cc/en/software#experimental-software).
-
-### Nightly builds
-
-These builds are generated every day at 03:00 GMT from the `main` branch and
-should be considered unstable:
-
-| Platform  | 32 bit                   | 64 bit                                                                                                 |
-| --------- | ------------------------ | ------------------------------------------------------------------------------------------------------ |
-| Linux     |                          | [Nightly Linux AppImage 64 bit]<br />[Nightly Linux ZIP file 64 bit]                                   |
-| Linux ARM | [🚧 Work in progress...] | [🚧 Work in progress...]                                                                               |
-| Windows   |                          | [Nightly Windows 64 bit installer]<br />[Nightly Windows 64 bit MSI]<br />[Nightly Windows 64 bit ZIP] |
-| macOS     |                          | [Nightly macOS 64 bit]                                                                                 |
-
-[🚧 work in progress...]: https://github.com/arduino/arduino-ide/issues/107
-[nightly linux appimage 64 bit]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Linux_64bit.AppImage
-[nightly linux zip file 64 bit]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Linux_64bit.zip
-[nightly windows 64 bit installer]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Windows_64bit.exe
-[nightly windows 64 bit msi]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Windows_64bit.msi
-[nightly windows 64 bit zip]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_Windows_64bit.zip
-[nightly macos 64 bit]: https://downloads.arduino.cc/arduino-ide/nightly/arduino-ide_nightly-latest_macOS_64bit.dmg
-
-> These links return an HTTP `302: Found` response, redirecting to latest
-> generated builds by replacing `latest` with the latest available build
-> date, using the format YYYYMMDD (i.e for 2019/Aug/06 `latest` is
-> replaced with `20190806`)
+You can download the latest release version and nightly builds from the [software download page on the Arduino website](https://www.arduino.cc/en/software#experimental-software).
 
 ## Support
 


### PR DESCRIPTION
### Motivation

During the early phase of development, the download links for the nightly build were only available from the table in the project readme.

Since that time, download links were also added to [the "**Software**" page on arduino.cc](https://www.arduino.cc/en/software), which is already linked to from the readme. This means the nightly build link table is superfluous and only harms the readability of the readme.

### Change description
Remove the superfluous table from the readme.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)