### PR TITLE
Remove obsolete fragment identifier from IDE manual download link

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-dialog.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/ide-updater/ide-updater-dialog.tsx
@@ -20,8 +20,7 @@ import {
 import { LocalStorageService } from '@theia/core/lib/browser';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 
-const DOWNLOAD_PAGE_URL =
-  'https://www.arduino.cc/en/software#experimental-software';
+const DOWNLOAD_PAGE_URL = 'https://www.arduino.cc/en/software';
 
 @injectable()
 export class IDEUpdaterDialogWidget extends ReactWidget {


### PR DESCRIPTION
The Arduino IDE has an auto update capability (https://github.com/arduino/arduino-ide/pull/797). A new version is checked for on every startup, and if available the user is offered an update.

Although this update can usually be done automatically by the IDE, under some conditions this is not possible. For example:

- The IDE package in use does not support auto update (i.e., Linux ZIP package)
- The file could not be downloaded due to a transient network service outage

In this case, the user is presented with a friendly dialog that explains the situation and links to [the "**Software**" page](https://www.arduino.cc/en/software) on arduino.cc, where the user can manually download and install the new version:

![image](https://user-images.githubusercontent.com/8572152/190117718-2b240203-2623-4e4b-b19d-8bef10632ce1.png)

### Motivation

During the pre-release development phase of the project, the download links for Arduino IDE 2.x were on a sub-section of the "**Software**" page. For this reason, the linked URL included the [fragment identifier](https://en.wikipedia.org/wiki/URI_fragment) `#experimental-software` so that the page would load scrolled down to the anchor at that section of the page.

With [the 2.0.0 release](https://github.com/arduino/arduino-ide/releases/tag/2.0.0), the Arduino IDE 2.x project has graduated to a production development phase. For this reason, the download links have been moved to the top of the "**Software**" page and the now inaccurate `experimental-software` anchor removed from the page.

The previous link with that fragment is still perfectly functional, but the fragment to a non-existent anchor serves no purpose and also miscommunicates the project status to users who notice the URL that was loaded.

### Change description

Remove the obsolete fragment identifier from the software page URL.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)