### PR TITLE
Serial Monitor autoscroll only makes bottom line partially visible #972

### DIFF
--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -114,7 +114,7 @@ const _Row = ({
   return (
     (data.lines[index].lineLen && (
       <div style={style}>
-        <pre>
+        <pre style={{ margin: 0 }}>
           {timestamp}
           {data.lines[index].message}
         </pre>

--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -114,7 +114,7 @@ const _Row = ({
   return (
     (data.lines[index].lineLen && (
       <div style={style}>
-        <pre style={{ margin: 0 }}>
+        <pre>
           {timestamp}
           {data.lines[index].message}
         </pre>

--- a/arduino-ide-extension/src/browser/style/monitor.css
+++ b/arduino-ide-extension/src/browser/style/monitor.css
@@ -14,6 +14,10 @@
     font-family: monospace
 }
 
+.serial-monitor-messages pre {
+    margin: 0px;
+}
+
 .serial-monitor .head {
     display: flex;
     padding: 5px;


### PR DESCRIPTION
### Motivation
A fix for Issue #972

### Change description
Fixed margin of `<pre></pre>` tag used to display each line of text

### Other information
N/A<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)