### PR TITLE
#1445 Ensure `directories.user` exists.

### DIFF
--- a/arduino-ide-extension/src/node/config-service-impl.ts
+++ b/arduino-ide-extension/src/node/config-service-impl.ts
@@ -56,7 +56,10 @@ export class ConfigServiceImpl
     this.loadCliConfig().then(async (cliConfig) => {
       this.cliConfig = cliConfig;
       if (this.cliConfig) {
-        const config = await this.mapCliConfigToAppConfig(this.cliConfig);
+        const [config] = await Promise.all([
+          this.mapCliConfigToAppConfig(this.cliConfig),
+          this.ensureUserDirExists(this.cliConfig),
+        ]);
         if (config) {
           this.config = config;
           this.ready.resolve();
@@ -262,5 +265,12 @@ export class ConfigServiceImpl
       `localhost:${port}`,
       grpc.credentials.createInsecure()
     ) as SettingsServiceClient;
+  }
+
+  // #1445
+  private async ensureUserDirExists(
+    cliConfig: DefaultCliConfig
+  ): Promise<void> {
+    await fs.mkdir(cliConfig.directories.user, { recursive: true });
   }
 }


### PR DESCRIPTION
### Motivation
IDE2 creates the sketchbook folder (`directories.user`) on startup if it's missing.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Closes #1445


### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)