### PR TITLE
#1343 Disabled the tokenizer after 500 chars.

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -48,6 +48,7 @@
             "comments": false,
             "strings": false
           },
+          "editor.maxTokenizationLineLength": 500,
           "breadcrumbs.enabled": false,
           "workbench.tree.renderIndentGuides": "none",
           "explorer.compactFolders": false


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To fix unresponsive IDE2 issue due to tokenizer.

### Change description
<!-- What does your code do? -->

Set the `editor.maxTokenizationLineLength` to `500` characters.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1343.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)