### PR TITLE
Retain Library/Boards Manager installation interface using version menu

### DIFF
--- a/arduino-ide-extension/src/browser/style/list-widget.css
+++ b/arduino-ide-extension/src/browser/style/list-widget.css
@@ -131,7 +131,7 @@
     flex-direction: column-reverse;
 }
 
-.component-list-item:hover .footer > * {
+.component-list-item .footer > * {
     display: inline-block;
     margin: 5px 0px 0px 10px;
 }

--- a/arduino-ide-extension/src/browser/widgets/component-list/component-list-item.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/component-list-item.tsx
@@ -15,6 +15,7 @@ export class ComponentListItem<
       this.state = {
         selectedVersion: version,
         focus: false,
+        versionUpdate: false,
       };
     }
   }
@@ -33,7 +34,9 @@ export class ComponentListItem<
     return (
       <div
         onMouseEnter={() => this.setState({ focus: true })}
-        onMouseLeave={() => this.setState({ focus: false })}
+        onMouseLeave={() => {
+          if (!this.state.versionUpdate) this.setState({ focus: false });
+        }}
       >
         {itemRenderer.renderItem(
           Object.assign(this.state, { item }),
@@ -52,6 +55,7 @@ export class ComponentListItem<
     )[0];
     this.setState({
       selectedVersion: version,
+      versionUpdate: false,
     });
     try {
       await this.props.install(item, toInstall);
@@ -67,7 +71,7 @@ export class ComponentListItem<
   }
 
   private onVersionChange(version: Installable.Version): void {
-    this.setState({ selectedVersion: version });
+    this.setState({ selectedVersion: version, versionUpdate: true });
   }
 }
 
@@ -83,5 +87,6 @@ export namespace ComponentListItem {
   export interface State {
     selectedVersion?: Installable.Version;
     focus: boolean;
+    versionUpdate: boolean;
   }
 }


### PR DESCRIPTION
### Motivation
If the version selected from the drop-down menu overlaps the next element, the focus on the current element is lost and the "INSTALL" button is no longer visible. Details [here](https://github.com/arduino/arduino-ide/issues/1425).

### Change description
Keep the footer visible until installation is performed. (NOTE: The selection from the drop-down menu is not visible in the video because it wasn't captured by the screen recorder).

https://user-images.githubusercontent.com/94986937/194260064-b45b8e55-3897-4c11-b101-1b825fe12e70.mp4

### Other information
Closes #1425.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)