### PR TITLE
Avoid new line if 3rd party URLs text is too long

### DIFF
--- a/arduino-ide-extension/src/browser/style/settings-dialog.css
+++ b/arduino-ide-extension/src/browser/style/settings-dialog.css
@@ -89,6 +89,7 @@
 
 .additional-urls-dialog textarea {
     resize: none;
+    white-space: nowrap;
 }
 
 .p-Widget.dialogOverlay .dialogBlock .dialogContent.additional-urls-dialog {


### PR DESCRIPTION
### Motivation
In the "Additional Boards Manager URLs" dialog, if the text of a 3rd party URL is too long, it is returned in a new line. See description [here](https://github.com/arduino/arduino-ide/issues/1470).

### Change description
Avoid new line adding `white-space: nowrap;` CSS rule.

Result:

https://user-images.githubusercontent.com/94986937/191464446-daf7f98c-c26c-4258-a166-40e1fc674749.mp4

### Other information
Closes #1470.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)