### PR TITLE
Avoid intellisense widgets being covered by the bottom panel

### DIFF
--- a/arduino-ide-extension/src/browser/style/main.css
+++ b/arduino-ide-extension/src/browser/style/main.css
@@ -2,10 +2,14 @@
     background: var(--theia-editorGroupHeader-tabsBackground);
 }
 
-/* Negative values to lower the priority in order to avoid the problem that
-   the Intellisense widget may be cover by the bottom panel partially. */
-#theia-bottom-content-panel {
-   z-index: -1;
+/* Avoid the Intellisense widget may be cover by the bottom panel partially.
+   TODO: This issue may be resolved after monaco-editor upgrade */
+#theia-main-content-panel {
+    z-index: auto
+}
+
+#theia-main-content-panel div[id^="code-editor-opener"] {
+    z-index: auto;
 }
     
 .p-TabBar-toolbar .item.arduino-tool-item {

--- a/arduino-ide-extension/src/browser/style/main.css
+++ b/arduino-ide-extension/src/browser/style/main.css
@@ -2,6 +2,12 @@
     background: var(--theia-editorGroupHeader-tabsBackground);
 }
 
+/* Negative values to lower the priority in order to avoid the problem that
+   the Intellisense widget may be cover by the bottom panel partially. */
+#theia-bottom-content-panel {
+   z-index: -1;
+}
+    
 .p-TabBar-toolbar .item.arduino-tool-item {
     margin-left: 0;
 }


### PR DESCRIPTION
### Motivation
Avoid the problem that the Intellisense widget may be cover by the bottom(Output) panel partially.

### Change description
from: 
![image](https://user-images.githubusercontent.com/30739857/191543229-f999a7b7-1bb7-467e-8032-43831bec27ed.png)

to: 
![image](https://user-images.githubusercontent.com/30739857/191541944-760fc791-d22b-48df-960f-012c760abf47.png)



### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)