### PR TITLE
#1442 Link resolver for lib/boards manager

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -334,6 +334,7 @@ import { DeleteSketch } from './contributions/delete-sketch';
 import { UserFields } from './contributions/user-fields';
 import { UpdateIndexes } from './contributions/update-indexes';
 import { InterfaceScale } from './contributions/interface-scale';
+import { OpenHandler } from '@theia/core/lib/browser/opener-service';
 
 const registerArduinoThemes = () => {
   const themes: MonacoThemeJson[] = [
@@ -398,6 +399,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(FrontendApplicationContribution).toService(
     LibraryListWidgetFrontendContribution
   );
+  bind(OpenHandler).toService(LibraryListWidgetFrontendContribution);
 
   // Sketch list service
   bind(SketchesService)
@@ -464,6 +466,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(FrontendApplicationContribution).toService(
     BoardsListWidgetFrontendContribution
   );
+  bind(OpenHandler).toService(BoardsListWidgetFrontendContribution);
 
   // Board select dialog
   bind(BoardsConfigDialogWidget).toSelf().inSingletonScope();

--- a/arduino-ide-extension/src/browser/boards/boards-widget-frontend-contribution.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-widget-frontend-contribution.ts
@@ -1,10 +1,11 @@
 import { injectable } from '@theia/core/shared/inversify';
-import { BoardsListWidget } from './boards-list-widget';
-import type {
+import {
   BoardSearch,
   BoardsPackage,
 } from '../../common/protocol/boards-service';
+import { URI } from '../contributions/contribution';
 import { ListWidgetFrontendContribution } from '../widgets/component-list/list-widget-frontend-contribution';
+import { BoardsListWidget } from './boards-list-widget';
 
 @injectable()
 export class BoardsListWidgetFrontendContribution extends ListWidgetFrontendContribution<
@@ -24,7 +25,16 @@ export class BoardsListWidgetFrontendContribution extends ListWidgetFrontendCont
     });
   }
 
-  override async initializeLayout(): Promise<void> {
-    this.openView();
+  protected canParse(uri: URI): boolean {
+    try {
+      BoardSearch.UriParser.parse(uri);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  protected parse(uri: URI): BoardSearch | undefined {
+    return BoardSearch.UriParser.parse(uri);
   }
 }

--- a/arduino-ide-extension/src/browser/library/library-widget-frontend-contribution.ts
+++ b/arduino-ide-extension/src/browser/library/library-widget-frontend-contribution.ts
@@ -1,16 +1,17 @@
-import { injectable } from '@theia/core/shared/inversify';
-import { FrontendApplicationContribution } from '@theia/core/lib/browser/frontend-application';
-import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
-import { MenuModelRegistry } from '@theia/core';
-import { LibraryListWidget } from './library-list-widget';
-import { ArduinoMenus } from '../menu/arduino-menus';
 import { nls } from '@theia/core/lib/common';
+import { MenuModelRegistry } from '@theia/core/lib/common/menu';
+import { injectable } from '@theia/core/shared/inversify';
+import { LibraryPackage, LibrarySearch } from '../../common/protocol';
+import { URI } from '../contributions/contribution';
+import { ArduinoMenus } from '../menu/arduino-menus';
+import { ListWidgetFrontendContribution } from '../widgets/component-list/list-widget-frontend-contribution';
+import { LibraryListWidget } from './library-list-widget';
 
 @injectable()
-export class LibraryListWidgetFrontendContribution
-  extends AbstractViewContribution<LibraryListWidget>
-  implements FrontendApplicationContribution
-{
+export class LibraryListWidgetFrontendContribution extends ListWidgetFrontendContribution<
+  LibraryPackage,
+  LibrarySearch
+> {
   constructor() {
     super({
       widgetId: LibraryListWidget.WIDGET_ID,
@@ -24,10 +25,6 @@ export class LibraryListWidgetFrontendContribution
     });
   }
 
-  async initializeLayout(): Promise<void> {
-    this.openView();
-  }
-
   override registerMenus(menus: MenuModelRegistry): void {
     if (this.toggleCommand) {
       menus.registerMenuAction(ArduinoMenus.TOOLS__MAIN_GROUP, {
@@ -39,5 +36,18 @@ export class LibraryListWidgetFrontendContribution
         order: '3',
       });
     }
+  }
+
+  protected canParse(uri: URI): boolean {
+    try {
+      LibrarySearch.UriParser.parse(uri);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  protected parse(uri: URI): LibrarySearch | undefined {
+    return LibrarySearch.UriParser.parse(uri);
   }
 }

--- a/arduino-ide-extension/src/browser/widgets/component-list/list-widget-frontend-contribution.ts
+++ b/arduino-ide-extension/src/browser/widgets/component-list/list-widget-frontend-contribution.ts
@@ -1,9 +1,15 @@
-import { injectable } from '@theia/core/shared/inversify';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser/frontend-application';
+import {
+  OpenerOptions,
+  OpenHandler,
+} from '@theia/core/lib/browser/opener-service';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
+import { MenuModelRegistry } from '@theia/core/lib/common/menu';
+import { URI } from '@theia/core/lib/common/uri';
+import { injectable } from '@theia/core/shared/inversify';
+import { Searchable } from '../../../common/protocol';
 import { ArduinoComponent } from '../../../common/protocol/arduino-component';
 import { ListWidget } from './list-widget';
-import { Searchable } from '../../../common/protocol';
 
 @injectable()
 export abstract class ListWidgetFrontendContribution<
@@ -11,14 +17,49 @@ export abstract class ListWidgetFrontendContribution<
     S extends Searchable.Options
   >
   extends AbstractViewContribution<ListWidget<T, S>>
-  implements FrontendApplicationContribution
+  implements FrontendApplicationContribution, OpenHandler
 {
+  readonly id: string = `http-opener-${this.viewId}`;
+
   async initializeLayout(): Promise<void> {
-    // TS requires at least one method from `FrontendApplicationContribution`.
-    // Expected to be empty.
+    this.openView();
   }
 
-  override registerMenus(): void {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  override registerMenus(_: MenuModelRegistry): void {
     // NOOP
   }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  canHandle(uri: URI, _?: OpenerOptions): number {
+    // `500` is the default HTTP opener in Theia. IDE2 has higher priority.
+    // https://github.com/eclipse-theia/theia/blob/b75b6144b0ffea06a549294903c374fa642135e4/packages/core/src/browser/http-open-handler.ts#L39
+    return this.canParse(uri) ? 501 : 0;
+  }
+
+  async open(
+    uri: URI,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _?: OpenerOptions | undefined
+  ): Promise<void> {
+    const searchOptions = this.parse(uri);
+    if (!searchOptions) {
+      console.warn(
+        `Failed to parse URI into a search options. URI: ${uri.toString()}`
+      );
+      return;
+    }
+    const widget = await this.openView({
+      activate: true,
+      reveal: true,
+    });
+    if (!widget) {
+      console.warn(`Failed to open view for URI: ${uri.toString()}`);
+      return;
+    }
+    widget.refresh(searchOptions);
+  }
+
+  protected abstract canParse(uri: URI): boolean;
+  protected abstract parse(uri: URI): S | undefined;
 }

--- a/arduino-ide-extension/src/common/protocol/searchable.ts
+++ b/arduino-ide-extension/src/common/protocol/searchable.ts
@@ -1,3 +1,5 @@
+import URI from '@theia/core/lib/common/uri';
+
 export interface Searchable<T, O extends Searchable.Options> {
   search(options: O): Promise<T[]>;
 }
@@ -7,5 +9,25 @@ export namespace Searchable {
      * Defaults to empty an empty string.
      */
     readonly query?: string;
+  }
+  export namespace UriParser {
+    /**
+     * Parses the `URI#fragment` into a query term.
+     */
+    export function parseQuery(uri: URI): { query: string } {
+      return { query: uri.fragment };
+    }
+    /**
+     * Splits the `URI#path#toString` on the `/` POSIX separator into decoded segments. The first, empty segment representing the root is omitted.
+     * Examples:
+     *  - `/` -> `['']`
+     *  - `/All` -> `['All']`
+     *  - `/All/Device%20Control` -> `['All', 'Device Control']`
+     *  - `/All/Display` -> `['All', 'Display']`
+     *  - `/Updatable/Signal%20Input%2FOutput` -> `['Updatable', 'Signal Input', 'Output']` (**caveat**!)
+     */
+    export function normalizedSegmentsOf(uri: URI): string[] {
+      return uri.path.toString().split('/').slice(1).map(decodeURIComponent);
+    }
   }
 }

--- a/arduino-ide-extension/src/test/common/searchable.test.ts
+++ b/arduino-ide-extension/src/test/common/searchable.test.ts
@@ -1,0 +1,136 @@
+import URI from '@theia/core/lib/common/uri';
+import { expect } from 'chai';
+import { BoardSearch, LibrarySearch, Searchable } from '../../common/protocol';
+
+interface Expectation<S extends Searchable.Options> {
+  readonly uri: string;
+  readonly expected: S | undefined | string;
+}
+
+describe('searchable', () => {
+  describe('parse', () => {
+    describe(BoardSearch.UriParser.authority, () => {
+      (
+        [
+          {
+            uri: 'http://boardsmanager#SAMD',
+            expected: { query: 'SAMD', type: 'All' },
+          },
+          {
+            uri: 'http://boardsmanager/Arduino%40Heart#littleBits',
+            expected: { query: 'littleBits', type: 'Arduino@Heart' },
+          },
+          {
+            uri: 'http://boardsmanager/too/many/segments#invalidPath',
+            expected: undefined,
+          },
+          {
+            uri: 'http://boardsmanager/random#invalidPath',
+            expected: undefined,
+          },
+          {
+            uri: 'https://boardsmanager/#invalidScheme',
+            expected: `Invalid 'scheme'. Expected 'http'. URI was: https://boardsmanager/#invalidScheme.`,
+          },
+          {
+            uri: 'http://librarymanager/#invalidAuthority',
+            expected: `Invalid 'authority'. Expected: 'boardsmanager'. URI was: http://librarymanager/#invalidAuthority.`,
+          },
+        ] as Expectation<BoardSearch>[]
+      ).map((expectation) => toIt(expectation, BoardSearch.UriParser.parse));
+    });
+    describe(LibrarySearch.UriParser.authority, () => {
+      (
+        [
+          {
+            uri: 'http://librarymanager#WiFiNINA',
+            expected: { query: 'WiFiNINA', type: 'All', topic: 'All' },
+          },
+          {
+            uri: 'http://librarymanager/All/Device%20Control#Servo',
+            expected: {
+              query: 'Servo',
+              type: 'All',
+              topic: 'Device Control',
+            },
+          },
+          {
+            uri: 'http://librarymanager/All/Display#SparkFun',
+            expected: {
+              query: 'SparkFun',
+              type: 'All',
+              topic: 'Display',
+            },
+          },
+          {
+            uri: 'http://librarymanager/Updatable/Display#SparkFun',
+            expected: {
+              query: 'SparkFun',
+              type: 'Updatable',
+              topic: 'Display',
+            },
+          },
+          {
+            uri: 'http://librarymanager/All/Signal%20Input%2FOutput#debouncer',
+            expected: {
+              query: 'debouncer',
+              type: 'All',
+              topic: 'Signal Input/Output',
+            },
+          },
+          {
+            uri: 'http://librarymanager/too/many/segments#invalidPath',
+            expected: undefined,
+          },
+          {
+            uri: 'http://librarymanager/absent/invalid#invalidPath',
+            expected: undefined,
+          },
+          {
+            uri: 'https://librarymanager/#invalidScheme',
+            expected: `Invalid 'scheme'. Expected 'http'. URI was: https://librarymanager/#invalidScheme.`,
+          },
+          {
+            uri: 'http://boardsmanager/#invalidAuthority',
+            expected: `Invalid 'authority'. Expected: 'librarymanager'. URI was: http://boardsmanager/#invalidAuthority.`,
+          },
+        ] as Expectation<LibrarySearch>[]
+      ).map((expectation) => toIt(expectation, LibrarySearch.UriParser.parse));
+    });
+  });
+});
+
+function toIt<S extends Searchable.Options>(
+  { uri, expected }: Expectation<S>,
+  run: (uri: URI) => Searchable.Options | undefined
+): Mocha.Test {
+  return it(`should ${
+    typeof expected === 'string'
+      ? `fail to parse '${uri}'`
+      : !expected
+      ? `not parse '${uri}'`
+      : `parse '${uri}' to ${JSON.stringify(expected)}`
+  }`, () => {
+    if (typeof expected === 'string') {
+      try {
+        run(new URI(uri));
+        expect.fail(
+          `Expected an error with message '${expected}' when parsing URI: ${uri}.`
+        );
+      } catch (err) {
+        expect(err).to.be.instanceOf(Error);
+        expect(err.message).to.be.equal(expected);
+      }
+    } else {
+      const actual = run(new URI(uri));
+      if (!expected) {
+        expect(actual).to.be.undefined;
+      } else {
+        expect(actual).to.be.deep.equal(
+          expected,
+          `Was: ${JSON.stringify(actual)}`
+        );
+      }
+    }
+  });
+}


### PR DESCRIPTION
~**This PR depends on #1530**~ ✅ 

-----

### Motivation
<!-- Why this pull request? -->

To search in lib/boards manager from a particular URL.

In action:

https://user-images.githubusercontent.com/1405703/191589097-4dd4b82a-d95e-436b-80c1-a240f0289bf3.mp4

Test with:

```cpp
void setup() {}
void loop() {}
// Additional Board Manager URL:
// https://raw.githubusercontent.com/sparkfun/Arduino_Apollo3/main/package_sparkfun_apollo3_index.json
//
// http://boardsmanager/All#SparkFun_Apollo3
// ~http://boardsmanager/All#SparkFun%20Apollo3~ UNSUPPORTED. Use underscore (_) instead of `%20` (URL encoded space)
// http://librarymanager/All#SparkFun_u-blox_GNSS
// ~http://librarymanager/All#SparkFun%20u-blox%20GNSS~ UNSUPPORTED. Use underscore (_) instead of `%20` (URL encoded space)
// http://librarymanager/All/Display#SparkFun
// http://librarymanager/All/Sensors#SparkFun
// http://librarymanager/#SparkFun
// http://librarymanager/Updatable/Display#SparkFun
// http://librarymanager/All#SparkFun_u-blox_GNS
// http://boardsmanager#SAMD
// http://boardsmanager/Arduino%40Heart#littleBits
// http://librarymanager#WiFiNINA
// http://librarymanager/All#SparkFun_u-blox_GNSS
// http://librarymanager/All/Device%20Control#Servo
// http://librarymanager/All/Signal%20Input%2FOutput#debouncer
```

See the [specs](https://arduino.github.io/arduino-cli/dev/sketch-specification/#libraryboards-manager-links) and #1442 how it works.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Closes #1442

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)