### PR TITLE
Initialise the IDE updater even when 'checkForUpdates' preference is false

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/check-for-ide-updates.ts
+++ b/arduino-ide-extension/src/browser/contributions/check-for-ide-updates.ts
@@ -37,16 +37,17 @@ export class CheckForIDEUpdates extends Contribution {
   }
 
   override onReady(): void {
-    const checkForUpdates = this.preferences['arduino.checkForUpdates'];
-    if (!checkForUpdates) {
-      return;
-    }
     this.updater
       .init(
         this.preferences.get('arduino.ide.updateChannel'),
         this.preferences.get('arduino.ide.updateBaseUrl')
       )
-      .then(() => this.updater.checkForUpdates(true))
+      .then(() => {
+        if (!this.preferences['arduino.checkForUpdates']) {
+          return;
+        }
+        return this.updater.checkForUpdates(true);
+      })
       .then(async (updateInfo) => {
         if (!updateInfo) return;
         const versionToSkip = await this.localStorage.getData<string>(


### PR DESCRIPTION
### Motivation
"Check for Arduino IDE Updates" operation fails when automatic update checks are disabled #1437

The reason is that we're avoiding to initialise the updater properly at start-up if the "Check for Arduino IDE Updates" preference is disabled.

### Change description
Always initialise the updater. Only then we can decide if effectively check for updates or not.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)