### PR TITLE
Bump version metadata to produce correct tester and nightly build precedence

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,7 +9,7 @@ contact_links:
     url: https://forum.arduino.cc/
     about: We can help you out on the Arduino Forum!
   - name: Issue report guide
-    url: https://github.com/arduino/arduino-ide/blob/main/docs/issues.md#issue-report-guide
+    url: https://github.com/arduino/arduino-ide/blob/main/docs/contributor-guide/issues.md#issue-report-guide
     about: Learn about submitting issue reports to this repository.
   - name: Contributor guide
     url: https://github.com/arduino/arduino-ide/blob/main/docs/CONTRIBUTING.md#contributor-guide

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide-extension",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An extension for Theia building the Arduino IDE",
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/docs/internal/release-procedure.md
+++ b/docs/internal/release-procedure.md
@@ -1,6 +1,10 @@
 # Release Procedure
 
-## 1. 🗺️ Merge localization sync PR
+## Steps
+
+The following are the steps to follow to make a release of Arduino IDE:
+
+### 1. 🗺️ Merge localization sync PR
 
 A pull request titled "**Update translation files**" is submitted periodically by the "**github-actions**" bot to pull in the localization data from [**Transifex**](https://www.transifex.com/arduino-1/ide2/dashboard/).
 
@@ -10,26 +14,24 @@ It will be shown in these search results:
 
 https://github.com/arduino/arduino-ide/pulls/app%2Fgithub-actions
 
-## 2. ⚙ Update metadata of packages
+### 2. 👀 Check version of packages
 
-You need to **set the new version in all the `package.json` files** across the app (`./package.json`, `./arduino-ide-extension/package.json`, and `./electron-app/package.json`), create a PR, and merge it on the `main` branch.
+The [`version` field](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#version) of the project's `package.json` metadata files received a patch version bump (e.g., `2.0.1` -> `2.0.2`) at the time of the previous release.
 
-To do so, you can make use of the `update:version` script.
+If this is a patch release, the current metadata values are correct and no action is needed.
 
-For example, if you want to release the version `<YOUR_VERSION>`, you should run the following commands:
+The changes contained in this release might be considered to change the project's "API". If so, a patch version bump will not be appropriate and the version must be adjusted in compliance with the [**Semantic Versioning Specification**](https://semver.org/).
 
-```text
-git checkout main
-git pull
-git checkout -b version-<YOUR_VERSION>
-yarn update:version <YOUR_VERSION>
-git commit -am <YOUR_VERSION>
-git push origin version-<YOUR_VERSION>
-```
+Follow the instructions for updating the version metadata [**here**](#update-version-metadata).
 
-replacing `<YOUR_VERSION>` with the version you want to release. Then create a PR and merge it.
+#### Examples
 
-## 3. 🚢 Create the release on GitHub
+If the version number of the previous release was `2.0.1`:
+
+- If this is considered a minor release (non-breaking changes to the "API"), the `version` values must be changed to `2.1.0`.
+- If this is considered a major release (breaking changes to the "API"), the `version` values must be changed to `3.0.0`.
+
+### 3. 🚢 Create the release on GitHub
 
 Then, you need to **create and push the new tag** and wait for the release to appear on [the "**Releases**" page](https://github.com/arduino/arduino-ide/releases).
 
@@ -44,7 +46,13 @@ git push origin <YOUR_VERSION>
 
 Pushing a tag will trigger a **GitHub Actions** workflow on the `main` branch. Check the "**Arduino IDE**" workflow and see that everything goes right. If the workflow succeeds, a new release will be created automatically and you should see it on the ["**Releases**"](https://github.com/arduino/arduino-ide/releases) page.
 
-## 4. 📄 Create the changelog
+### 4. ⬆️ Bump version metadata of packages
+
+In order for the version number of the tester and nightly builds to have correct precedence compared to the release version, the `version` field of the project's `package.json` files must be given a patch version bump (e.g., `2.0.1` -> `2.0.2`) **after** the creation of the release tag.
+
+Follow the instructions for updating the version metadata [**here**](#update-version-metadata).
+
+### 5. 📄 Create the changelog
 
 **Create GitHub issues for the known issues** that we haven't solved in the current release:
 
@@ -63,7 +71,7 @@ Add a list of mentions of GitHub users who contributed to the release in any of 
 
 Add a "**Known Issues**" section at the bottom of the changelog.
 
-## 5. ✎ Update the "**Software**" Page
+### 6. ✎ Update the "**Software**" Page
 
 Open a PR on the [bcmi-labs/wiki-content](https://github.com/bcmi-labs/wiki-content) repository to update the links and texts.
 
@@ -80,7 +88,7 @@ When the deploy workflow is done, check if links on the "**Software**" page are 
 
 https://www.arduino.cc/en/software#future-version-of-the-arduino-ide
 
-## 6. 😎 Brag about it
+### 7. 😎 Brag about it
 
 - Ask in the `#product_releases` **Slack** channel to write a post for the social media and, if needed, a blog post.
 - Post a message on the forum (ask @per1234).<br />
@@ -99,3 +107,28 @@ https://www.arduino.cc/en/software#future-version-of-the-arduino-ide
   >
   > To see the details, you can take a look at the [Changelog](https://github.com/arduino/arduino-ide/releases/tag/2.0.0-beta.12)
   > If you want to post about it on social media and you need more details feel free to ask us on #team_tooling! :wink:
+
+## Operations
+
+The following are detailed descriptions of operations performed during the release process:
+
+<a id="update-version-metadata"></a>
+
+### ⚙ Update version metadata of packages
+
+You need to **set the new version in all the `package.json` files** across the app (`./package.json`, `./arduino-ide-extension/package.json`, and `./electron-app/package.json`), create a PR, and merge it on the `main` branch.
+
+To do so, you can make use of the `update:version` script.
+
+For example, if you want to update the version to `<YOUR_VERSION>`, you should run the following commands:
+
+```text
+git checkout main
+git pull
+git checkout -b version-<YOUR_VERSION>
+yarn update:version <YOUR_VERSION>
+git commit -am <YOUR_VERSION>
+git push origin version-<YOUR_VERSION>
+```
+
+replacing `<YOUR_VERSION>` with the version you want. Then create a PR and merge it.

--- a/docs/internal/release-procedure.md
+++ b/docs/internal/release-procedure.md
@@ -10,9 +10,9 @@ It will be shown in these search results:
 
 https://github.com/arduino/arduino-ide/pulls/app%2Fgithub-actions
 
-## ⚙ Create the release on GitHub
+## ⚙ Update metadata of packages
 
-First of all, you need to **set the new version in all the `package.json` files** across the app (`./package.json`, `./arduino-ide-extension/package.json`, and `./electron-app/package.json`), create a PR, and merge it on the `main` branch.
+You need to **set the new version in all the `package.json` files** across the app (`./package.json`, `./arduino-ide-extension/package.json`, and `./electron-app/package.json`), create a PR, and merge it on the `main` branch.
 
 To do so, you can make use of the `update:version` script.
 
@@ -28,6 +28,8 @@ git push origin version-<YOUR_VERSION>
 ```
 
 replacing `<YOUR_VERSION>` with the version you want to release. Then create a PR and merge it.
+
+## 🚢 Create the release on GitHub
 
 Then, you need to **create and push the new tag** and wait for the release to appear on [the "**Releases**" page](https://github.com/arduino/arduino-ide/releases).
 

--- a/docs/internal/release-procedure.md
+++ b/docs/internal/release-procedure.md
@@ -1,6 +1,6 @@
 # Release Procedure
 
-## 🗺️ Merge localization sync PR
+## 1. 🗺️ Merge localization sync PR
 
 A pull request titled "**Update translation files**" is submitted periodically by the "**github-actions**" bot to pull in the localization data from [**Transifex**](https://www.transifex.com/arduino-1/ide2/dashboard/).
 
@@ -10,7 +10,7 @@ It will be shown in these search results:
 
 https://github.com/arduino/arduino-ide/pulls/app%2Fgithub-actions
 
-## ⚙ Update metadata of packages
+## 2. ⚙ Update metadata of packages
 
 You need to **set the new version in all the `package.json` files** across the app (`./package.json`, `./arduino-ide-extension/package.json`, and `./electron-app/package.json`), create a PR, and merge it on the `main` branch.
 
@@ -29,7 +29,7 @@ git push origin version-<YOUR_VERSION>
 
 replacing `<YOUR_VERSION>` with the version you want to release. Then create a PR and merge it.
 
-## 🚢 Create the release on GitHub
+## 3. 🚢 Create the release on GitHub
 
 Then, you need to **create and push the new tag** and wait for the release to appear on [the "**Releases**" page](https://github.com/arduino/arduino-ide/releases).
 
@@ -44,7 +44,7 @@ git push origin <YOUR_VERSION>
 
 Pushing a tag will trigger a **GitHub Actions** workflow on the `main` branch. Check the "**Arduino IDE**" workflow and see that everything goes right. If the workflow succeeds, a new release will be created automatically and you should see it on the ["**Releases**"](https://github.com/arduino/arduino-ide/releases) page.
 
-## 📄 Create the changelog
+## 4. 📄 Create the changelog
 
 **Create GitHub issues for the known issues** that we haven't solved in the current release:
 
@@ -63,7 +63,7 @@ Add a list of mentions of GitHub users who contributed to the release in any of 
 
 Add a "**Known Issues**" section at the bottom of the changelog.
 
-## ✎ Update the "**Software**" Page
+## 5. ✎ Update the "**Software**" Page
 
 Open a PR on the [bcmi-labs/wiki-content](https://github.com/bcmi-labs/wiki-content) repository to update the links and texts.
 
@@ -80,7 +80,7 @@ When the deploy workflow is done, check if links on the "**Software**" page are 
 
 https://www.arduino.cc/en/software#future-version-of-the-arduino-ide
 
-## 😎 Brag about it
+## 6. 😎 Brag about it
 
 - Ask in the `#product_releases` **Slack** channel to write a post for the social media and, if needed, a blog post.
 - Post a message on the forum (ask @per1234).<br />

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "electron-app",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "AGPL-3.0-or-later",
   "main": "src-gen/frontend/electron-main.js",
   "dependencies": {
@@ -21,7 +21,7 @@
     "@theia/process": "1.25.0",
     "@theia/terminal": "1.25.0",
     "@theia/workspace": "1.25.0",
-    "arduino-ide-extension": "2.0.0"
+    "arduino-ide-extension": "2.0.1"
   },
   "devDependencies": {
     "@theia/cli": "1.25.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Arduino IDE",
   "repository": "https://github.com/arduino/arduino-ide.git",
   "author": "Arduino SA",


### PR DESCRIPTION
### Motivation

On every startup, the Arduino IDE checks for new versions of the IDE (https://github.com/arduino/arduino-ide/pull/797). If a newer version is available, a notification/dialog is shown offering an update.

"Newer" is determined by comparing the version of the user's IDE to the latest available version on the update channel. This comparison is done according to [semver](https://semver.org/).

In order to facilitate beta testing, builds are generated of the Arduino IDE at the current stage in development. These builds are given an identifying version of the following form:

- `<version>-snapshot-<short hash>` - builds generated for every push and pull request that modifies relevant files
- `<version>-nightly-<YYYYMMDD>` - daily builds of the tip of the default branch

The established project management practices cause the `<version>` component of these to be the version of the most recent release.

During the pre-release phase of the project development, all releases had [a pre-release suffix](https://semver.org/#spec-item-9) (e.g., `2.0.0-rc9.4`). Appending the "snapshot" or "nightly" suffix to that pre-release version caused these builds to have the correct precedence (e.g., `2.0.0-rc9.2.snapshot-20cc34c` > `2.0.0-rc9.2`). This situation has changed now that the project is using production release versions (e.g., `2.0.0-nightly-20220915` < `2.0.0`). This causes users of "snapshot" or "nightly" builds to be presented with a spurious update notification on startup (https://github.com/arduino/arduino-ide/issues/1440).

### Change description

The solution is to do a minor bump of the version metadata after creating the release tag.

- Bump the `version` field in the project's `package.json` metadata files to `2.0.1`
- Update [the release procedure documentation](https://github.com/arduino/arduino-ide/blob/main/docs/internal/release-procedure.md) to include this post-tag version bump as a step in the release process

### Other information

The rendered release procedure document can be previewed here:

https://github.com/per1234/arduino-ide/blob/bump-after-release/docs/internal/release-procedure.md#readme

---

Fixes https://github.com/arduino/arduino-ide/issues/1440

---

The pull request also contains an unrelated fix to the link to the ["**Issue Report Guide**"](https://github.com/arduino/arduino-ide/blob/main/docs/contributor-guide/issues.md) from the [issue template chooser page](https://github.com/arduino/arduino-ide/issues/new/choose), which was previously broken.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)