### PR TITLE
Add a dedicated translator guide document

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,14 +11,14 @@ There are several ways you can get involved:
 | - Support<br/>- Question<br/>- Discussion | Post on the [**Arduino Forum**][forum]                                           |
 | - Bug report<br/>- Feature request        | Issue report (see the guide [**here**][issues])                                  |
 | Testing                                   | Beta testing, PR review (see the guide [**here**][beta-testing])                 |
-| Translation                               | [Transifex project][translate]                                                   |
+| Translation                               | See the guide [**here**][translate]                                              |
 | - Bug fix<br/>- Enhancement               | Pull request (see the guide [**here**][prs])                                     |
 | Monetary                                  | - [Donate][donate]<br/>- [Sponsor][sponsor]<br/>- [Buy official products][store] |
 
 [forum]: https://forum.arduino.cc
 [issues]: contributor-guide/issues.md#issue-report-guide
 [beta-testing]: contributor-guide/beta-testing.md#beta-testing-guide
-[translate]: https://www.transifex.com/arduino-1/ide2/dashboard/
+[translate]: contributor-guide/translation.md#translator-guide
 [prs]: contributor-guide/pull-requests.md#pull-request-guide
 [donate]: https://www.arduino.cc/en/donate/
 [sponsor]: https://github.com/sponsors/arduino

--- a/docs/contributor-guide/translation.md
+++ b/docs/contributor-guide/translation.md
@@ -1,0 +1,33 @@
+# Translator Guide
+
+The text of the Arduino IDE interface is translated into several languages. The language can be selected in the dialog opened via **File > Preferences** in the Arduino IDE menus (**Arduino IDE > Preferences** for macOS users).
+
+Translating text and improving on existing translations is a valuable contribution to the project, helping make Arduino accessible to everyone.
+
+The translations for the text found in the Arduino IDE come from several sources:
+
+## Arduino IDE Text
+
+Translations of Arduino IDE's text is done in the "**Arduino IDE 2.0**" project on the **Transifex** localization platform:
+
+https://explore.transifex.com/arduino-1/ide2/
+
+## Base Application Text
+
+Arduino IDE leverages the localization data available for the [**VS Code**](https://code.visualstudio.com/) editor to localize shared UI text. This reduces the translation work required to add a new language to the text specific to the Arduino IDE project.
+
+For this reason, some of Arduino IDE's text is not found in the **Transifex** project. Suggestions for corrections or improvement to this text are made by submitting an issue to the `microsoft/vscode-loc` GitHub repository.
+
+Before submitting an issue, please check the existing issues to make sure it wasn't already reported:<br />
+https://github.com/microsoft/vscode-loc/issues
+
+After that, submit an issue here:<br />
+https://github.com/microsoft/vscode-loc/issues/new
+
+## Arduino CLI Text
+
+The [**Arduino CLI**](https://arduino.github.io/arduino-cli/latest/) tool handles non-GUI operations for the Arduino IDE. Some of the text printed in the "**Output**" panel and in notifications originates from **Arduino CLI**.
+
+Translations of Arduino CLI's text is done in the "**Arduino CLI**" Transifex project:
+
+https://explore.transifex.com/arduino-1/arduino-cli/

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -1,0 +1,11 @@
+# Localization Data
+
+This folder contains the [localization](https://en.wikipedia.org/wiki/Internationalization_and_localization) data for Arduino IDE.
+
+❗ These files are automatically generated and so can not be edited directly. If you wish to modify the contents, do it at the source:
+
+- **en.json** - edit the string in [the source code](../arduino-ide-extension/src)
+- **All other files** - the localization is done on **Transifex**:<br />
+  https://explore.transifex.com/arduino-1/ide2/
+
+For more information on translating Arduino IDE, see [the **Translator Guide**](../docs/contributor-guide/translation.md).


### PR DESCRIPTION
### Motivation

Translation of the strings of the Arduino IDE UI is a valuable contribution which helps to make Arduino accessible to everyone around the world.

Localization of the Arduino-specific strings of the IDE is done in [the "**Arduino IDE 2.0**" project on **Transifex**](https://explore.transifex.com/arduino-1/ide2/). Previously, the "Translation" row in the contribution methods summary table in [the contributor guide entry page](https://github.com/arduino/arduino-ide/blob/main/docs/CONTRIBUTING.md#contributor-guide) simply linked to that project.

Arduino IDE also uses localized strings from several other sources:

- [**VS Code** language packs](https://open-vsx.org/?search=&category=Language%20Packs&sortBy=relevance&sortOrder=asc)
- [**Arduino CLI**](https://arduino.github.io/arduino-cli/latest/)

Users may notice unlocalized strings or errors or areas for improvement in the existing translations and wish to contribute translations. For this reason, it is important to also provide instructions for contributing to those other localization data sources.

### Change description

#### Creation of translator guide document

The contribution methods summary table can not effectively accommodate the additional content required to document all localization data sources so addition of a dedicated document is proposed for the purpose.

The use of a dedicated document for this information will also allow linking directly to that information from related documentation or conversations.

#### Add readme for localization data

Experience with maintenance of Arduino's localized projects indicates that the localization data files can appear to be the appropriate place to make edits for casual contributors not familiar with the project's sophisticated internationalization infrastructure.

Examples:

- https://github.com/arduino/arduino-ide/pull/1468
- https://github.com/arduino/arduino-ide/pull/1374
- https://github.com/arduino/arduino-cli/pull/1753
- https://github.com/arduino/Arduino/pull/11817
- https://github.com/arduino/Arduino/pull/10026
- https://github.com/arduino/Arduino/pull/8691
- https://github.com/arduino/Arduino/pull/5862
- https://github.com/arduino/Arduino/pull/5635
- https://github.com/arduino/Arduino/pull/5357
- https://github.com/arduino/Arduino/pull/4186
- https://github.com/arduino/Arduino/pull/3962
- https://github.com/arduino/Arduino/pull/2734
- https://github.com/arduino/Arduino/pull/2623
- https://github.com/arduino/Arduino/pull/1718

Since those files are generated by automated systems, any edits made there would only be overwritten, so it is important to clearly communicate the correct way to make enhancements or corrections to these strings. This is accomplished by a local readme file most likely to be seen by those working in the folder containing these files. This file supplements the existing information about translation in the project's translation guide.

### Other information

The rendered documents can be previewed here:

https://github.com/per1234/arduino-ide/blob/translation-guide/docs/contributor-guide/translation.md

https://github.com/per1234/arduino-ide/tree/translation-guide/i18n#readme

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)