### PR TITLE
Limit interface scale

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -333,6 +333,7 @@ import { StartupTaskProvider } from '../electron-common/startup-task';
 import { DeleteSketch } from './contributions/delete-sketch';
 import { UserFields } from './contributions/user-fields';
 import { UpdateIndexes } from './contributions/update-indexes';
+import { InterfaceScale } from './contributions/interface-scale';
 
 const registerArduinoThemes = () => {
   const themes: MonacoThemeJson[] = [
@@ -746,6 +747,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   Contribution.configure(bind, UserFields);
   Contribution.configure(bind, DeleteSketch);
   Contribution.configure(bind, UpdateIndexes);
+  Contribution.configure(bind, InterfaceScale);
 
   bindContributionProvider(bind, StartupTaskProvider);
   bind(StartupTaskProvider).toService(BoardsServiceProvider); // to reuse the boards config in another window

--- a/arduino-ide-extension/src/browser/contributions/interface-scale.ts
+++ b/arduino-ide-extension/src/browser/contributions/interface-scale.ts
@@ -23,7 +23,7 @@ export class InterfaceScale extends Contribution {
   private readonly menuRegistry: MenuModelRegistry;
 
   @inject(MainMenuManager)
-  protected readonly mainMenuManager: MainMenuManager;
+  private readonly mainMenuManager: MainMenuManager;
 
   private readonly menuActionsDisposables = new DisposableCollection();
   private fontScalingEnabled: InterfaceScale.FontScalingEnabled = {

--- a/arduino-ide-extension/src/browser/contributions/interface-scale.ts
+++ b/arduino-ide-extension/src/browser/contributions/interface-scale.ts
@@ -31,7 +31,6 @@ export class InterfaceScale extends Contribution {
     decrease: true,
   };
 
-  private currentScale: InterfaceScale.ScaleSettings;
   private currentSettings: Settings;
   private updateSettingsDebounced = debounce(
     async () => {
@@ -45,7 +44,6 @@ export class InterfaceScale extends Contribution {
   override onStart(): MaybePromise<void> {
     const updateCurrent = (settings: Settings) => {
       this.currentSettings = settings;
-      this.currentScale = { ...settings };
     };
     this.settingsService.onDidChange((settings) => updateCurrent(settings));
     this.settingsService.settings().then((settings) => updateCurrent(settings));
@@ -125,18 +123,13 @@ export class InterfaceScale extends Contribution {
   private async updateFontSize(mode: 'increase' | 'decrease'): Promise<void> {
     if (this.currentSettings.autoScaleInterface) {
       mode === 'increase'
-        ? (this.currentScale.interfaceScale += InterfaceScale.ZoomLevel.STEP)
-        : (this.currentScale.interfaceScale -= InterfaceScale.ZoomLevel.STEP);
+        ? (this.currentSettings.interfaceScale += InterfaceScale.ZoomLevel.STEP)
+        : (this.currentSettings.interfaceScale -= InterfaceScale.ZoomLevel.STEP);
     } else {
       mode === 'increase'
-        ? (this.currentScale.editorFontSize += InterfaceScale.FontSize.STEP)
-        : (this.currentScale.editorFontSize -= InterfaceScale.FontSize.STEP);
+        ? (this.currentSettings.editorFontSize += InterfaceScale.FontSize.STEP)
+        : (this.currentSettings.editorFontSize -= InterfaceScale.FontSize.STEP);
     }
-    this.currentSettings = {
-      ...this.currentSettings,
-      editorFontSize: this.currentScale.editorFontSize,
-      interfaceScale: this.currentScale.interfaceScale,
-    };
     let newFontScalingEnabled: InterfaceScale.FontScalingEnabled = {
       increase: true,
       decrease: true,
@@ -225,9 +218,4 @@ export namespace InterfaceScale {
     increase: boolean;
     decrease: boolean;
   }
-
-  export type ScaleSettings = Pick<
-    Settings,
-    'interfaceScale' | 'editorFontSize'
-  >;
 }

--- a/arduino-ide-extension/src/browser/contributions/interface-scale.ts
+++ b/arduino-ide-extension/src/browser/contributions/interface-scale.ts
@@ -1,0 +1,233 @@
+import { inject, injectable } from '@theia/core/shared/inversify';
+import {
+  Contribution,
+  Command,
+  MenuModelRegistry,
+  KeybindingRegistry,
+} from './contribution';
+import { ArduinoMenus, PlaceholderMenuNode } from '../menu/arduino-menus';
+import {
+  CommandRegistry,
+  DisposableCollection,
+  MaybePromise,
+  nls,
+} from '@theia/core/lib/common';
+
+import { Settings } from '../dialogs/settings/settings';
+import { MainMenuManager } from '../../common/main-menu-manager';
+import debounce = require('lodash.debounce');
+
+@injectable()
+export class InterfaceScale extends Contribution {
+  @inject(MenuModelRegistry)
+  private readonly menuRegistry: MenuModelRegistry;
+
+  @inject(MainMenuManager)
+  protected readonly mainMenuManager: MainMenuManager;
+
+  private readonly menuActionsDisposables = new DisposableCollection();
+  private fontScalingEnabled: InterfaceScale.FontScalingEnabled = {
+    increase: true,
+    decrease: true,
+  };
+
+  private currentScale: InterfaceScale.ScaleSettings;
+  private currentSettings: Settings;
+  private updateSettingsDebounced = debounce(
+    async () => {
+      await this.settingsService.update(this.currentSettings);
+      await this.settingsService.save();
+    },
+    100,
+    { maxWait: 200 }
+  );
+
+  override onStart(): MaybePromise<void> {
+    const updateCurrent = (settings: Settings) => {
+      this.currentSettings = settings;
+      this.currentScale = { ...settings };
+    };
+    this.settingsService.onDidChange((settings) => updateCurrent(settings));
+    this.settingsService.settings().then((settings) => updateCurrent(settings));
+  }
+
+  override registerCommands(registry: CommandRegistry): void {
+    registry.registerCommand(InterfaceScale.Commands.INCREASE_FONT_SIZE, {
+      execute: () => this.updateFontSize('increase'),
+      isEnabled: () => this.fontScalingEnabled.increase,
+    });
+    registry.registerCommand(InterfaceScale.Commands.DECREASE_FONT_SIZE, {
+      execute: () => this.updateFontSize('decrease'),
+      isEnabled: () => this.fontScalingEnabled.decrease,
+    });
+  }
+
+  override registerMenus(registry: MenuModelRegistry): void {
+    this.menuActionsDisposables.dispose();
+    const increaseFontSizeMenuAction = {
+      commandId: InterfaceScale.Commands.INCREASE_FONT_SIZE.id,
+      label: nls.localize(
+        'arduino/editor/increaseFontSize',
+        'Increase Font Size'
+      ),
+      order: '0',
+    };
+    const decreaseFontSizeMenuAction = {
+      commandId: InterfaceScale.Commands.DECREASE_FONT_SIZE.id,
+      label: nls.localize(
+        'arduino/editor/decreaseFontSize',
+        'Decrease Font Size'
+      ),
+      order: '1',
+    };
+
+    if (this.fontScalingEnabled.increase) {
+      this.menuActionsDisposables.push(
+        registry.registerMenuAction(
+          ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
+          increaseFontSizeMenuAction
+        )
+      );
+    } else {
+      this.menuActionsDisposables.push(
+        registry.registerMenuNode(
+          ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
+          new PlaceholderMenuNode(
+            ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
+            increaseFontSizeMenuAction.label,
+            { order: increaseFontSizeMenuAction.order }
+          )
+        )
+      );
+    }
+    if (this.fontScalingEnabled.decrease) {
+      this.menuActionsDisposables.push(
+        this.menuRegistry.registerMenuAction(
+          ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
+          decreaseFontSizeMenuAction
+        )
+      );
+    } else {
+      this.menuActionsDisposables.push(
+        this.menuRegistry.registerMenuNode(
+          ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
+          new PlaceholderMenuNode(
+            ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
+            decreaseFontSizeMenuAction.label,
+            { order: decreaseFontSizeMenuAction.order }
+          )
+        )
+      );
+    }
+    this.mainMenuManager.update();
+  }
+
+  private async updateFontSize(mode: 'increase' | 'decrease'): Promise<void> {
+    if (this.currentSettings.autoScaleInterface) {
+      mode === 'increase'
+        ? (this.currentScale.interfaceScale += InterfaceScale.ZoomLevel.STEP)
+        : (this.currentScale.interfaceScale -= InterfaceScale.ZoomLevel.STEP);
+    } else {
+      mode === 'increase'
+        ? (this.currentScale.editorFontSize += InterfaceScale.FontSize.STEP)
+        : (this.currentScale.editorFontSize -= InterfaceScale.FontSize.STEP);
+    }
+    this.currentSettings = {
+      ...this.currentSettings,
+      editorFontSize: this.currentScale.editorFontSize,
+      interfaceScale: this.currentScale.interfaceScale,
+    };
+    let newFontScalingEnabled: InterfaceScale.FontScalingEnabled = {
+      increase: true,
+      decrease: true,
+    };
+    if (this.currentSettings.autoScaleInterface) {
+      newFontScalingEnabled = {
+        increase:
+          this.currentSettings.interfaceScale + InterfaceScale.ZoomLevel.STEP <=
+          InterfaceScale.ZoomLevel.MAX,
+        decrease:
+          this.currentSettings.interfaceScale - InterfaceScale.ZoomLevel.STEP >=
+          InterfaceScale.ZoomLevel.MIN,
+      };
+    } else {
+      newFontScalingEnabled = {
+        increase:
+          this.currentSettings.editorFontSize + InterfaceScale.FontSize.STEP <=
+          InterfaceScale.FontSize.MAX,
+        decrease:
+          this.currentSettings.editorFontSize - InterfaceScale.FontSize.STEP >=
+          InterfaceScale.FontSize.MIN,
+      };
+    }
+    const isChanged = Object.keys(newFontScalingEnabled).some(
+      (key: keyof InterfaceScale.FontScalingEnabled) =>
+        newFontScalingEnabled[key] !== this.fontScalingEnabled[key]
+    );
+    if (isChanged) {
+      this.registerMenus(this.menuRegistry);
+      this.fontScalingEnabled = newFontScalingEnabled;
+    }
+    this.fontScalingEnabled = newFontScalingEnabled;
+    this.updateSettingsDebounced();
+  }
+
+  override registerKeybindings(registry: KeybindingRegistry): void {
+    registry.registerKeybinding({
+      command: InterfaceScale.Commands.INCREASE_FONT_SIZE.id,
+      keybinding: 'CtrlCmd+=',
+    });
+    registry.registerKeybinding({
+      command: InterfaceScale.Commands.DECREASE_FONT_SIZE.id,
+      keybinding: 'CtrlCmd+-',
+    });
+  }
+}
+
+export namespace InterfaceScale {
+  export namespace Commands {
+    export const INCREASE_FONT_SIZE: Command = {
+      id: 'arduino-increase-font-size',
+    };
+    export const DECREASE_FONT_SIZE: Command = {
+      id: 'arduino-decrease-font-size',
+    };
+  }
+
+  export namespace ZoomLevel {
+    export const MIN = -8;
+    export const MAX = 9;
+    export const STEP = 1;
+
+    export function toPercentage(scale: number): number {
+      return scale * 20 + 100;
+    }
+    export function fromPercentage(percentage: number): number {
+      return (percentage - 100) / 20;
+    }
+    export namespace Step {
+      export function toPercentage(step: number): number {
+        return step * 20;
+      }
+      export function fromPercentage(percentage: number): number {
+        return percentage / 20;
+      }
+    }
+  }
+
+  export namespace FontSize {
+    export const MIN = 8;
+    export const MAX = 72;
+    export const STEP = 2;
+  }
+
+  export interface FontScalingEnabled {
+    increase: boolean;
+    decrease: boolean;
+  }
+
+  export type ScaleSettings = Pick<
+    Settings,
+    'interfaceScale' | 'editorFontSize'
+  >;
+}

--- a/arduino-ide-extension/src/browser/contributions/interface-scale.ts
+++ b/arduino-ide-extension/src/browser/contributions/interface-scale.ts
@@ -120,11 +120,12 @@ export class InterfaceScale extends Contribution {
     this.mainMenuManager.update();
   }
 
-  private async updateFontSize(mode: 'increase' | 'decrease'): Promise<void> {
+  private updateFontSize(mode: 'increase' | 'decrease'): void {
     if (this.currentSettings.autoScaleInterface) {
       mode === 'increase'
         ? (this.currentSettings.interfaceScale += InterfaceScale.ZoomLevel.STEP)
-        : (this.currentSettings.interfaceScale -= InterfaceScale.ZoomLevel.STEP);
+        : (this.currentSettings.interfaceScale -=
+            InterfaceScale.ZoomLevel.STEP);
     } else {
       mode === 'increase'
         ? (this.currentSettings.editorFontSize += InterfaceScale.FontSize.STEP)

--- a/arduino-ide-extension/src/browser/contributions/interface-scale.ts
+++ b/arduino-ide-extension/src/browser/contributions/interface-scale.ts
@@ -159,10 +159,9 @@ export class InterfaceScale extends Contribution {
         newFontScalingEnabled[key] !== this.fontScalingEnabled[key]
     );
     if (isChanged) {
-      this.registerMenus(this.menuRegistry);
       this.fontScalingEnabled = newFontScalingEnabled;
+      this.registerMenus(this.menuRegistry);
     }
-    this.fontScalingEnabled = newFontScalingEnabled;
     this.updateSettingsDebounced();
   }
 

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
@@ -23,14 +23,22 @@ import {
   LanguageInfo,
 } from '@theia/core/lib/common/i18n/localization';
 import SettingsStepInput from './settings-step-input';
+import { InterfaceScale } from '../../contributions/interface-scale';
 
-const maxScale = 280;
-const minScale = -60;
-const scaleStep = 20;
+const maxScale = InterfaceScale.ZoomLevel.toPercentage(
+  InterfaceScale.ZoomLevel.MAX
+);
+const minScale = InterfaceScale.ZoomLevel.toPercentage(
+  InterfaceScale.ZoomLevel.MIN
+);
+const scaleStep = InterfaceScale.ZoomLevel.Step.fromPercentage(
+  InterfaceScale.ZoomLevel.STEP
+);
 
-const maxFontSize = 72;
-const minFontSize = 0;
-const fontSizeStep = 2;
+const maxFontSize = InterfaceScale.FontSize.MAX;
+const minFontSize = InterfaceScale.FontSize.MIN;
+const fontSizeStep = InterfaceScale.FontSize.STEP;
+
 export class SettingsComponent extends React.Component<
   SettingsComponent.Props,
   SettingsComponent.State
@@ -554,8 +562,7 @@ export class SettingsComponent extends React.Component<
   };
 
   private setInterfaceScale = (percentage: number) => {
-    const interfaceScale = (percentage - 100) / 20;
-
+    const interfaceScale = InterfaceScale.ZoomLevel.fromPercentage(percentage);
     this.setState({ interfaceScale });
   };
 

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
@@ -31,7 +31,7 @@ const maxScale = InterfaceScale.ZoomLevel.toPercentage(
 const minScale = InterfaceScale.ZoomLevel.toPercentage(
   InterfaceScale.ZoomLevel.MIN
 );
-const scaleStep = InterfaceScale.ZoomLevel.Step.fromPercentage(
+const scaleStep = InterfaceScale.ZoomLevel.Step.toPercentage(
   InterfaceScale.ZoomLevel.STEP
 );
 


### PR DESCRIPTION
### Motivation
The interface scaling of the IDE doesn't handle scaling properly:
- as stated in #1384, it's possible to find yourself in unpredictable situations we're only limiting the scaling when using the stepper input
- same thing happen with the editor font size
- when changing the scaling really fast (e.g.: holding down `CTRL/CMD + =` for a while), the interface seems to 'bounce' from bigger to smaller and viceversa until it's stable

### Change description
- move the interface scaling logic to a separate contribution
- the stepper in the settings dialog and the related commands now uses common values for min/max scale and font size
- when the `Automatic` flag in the settings dialog is **checked**, enable/disable the **'Increase/Decrease Font Size'** menu item and shortcuts when reaching `-60%` (min) and `280%` (max) 
- when the `Automatic` flag in the settings dialog is **unchecked**, enable/disable the **'Increase/Decrease Font Size'** menu item and shortcuts when reaching `8` (min) and `72` (max)

### Other information
Since [Theia doesn't support dynamic menu items](https://github.com/eclipse-theia/theia/issues/446), to achieve this I needed to dispose the menu items and re-register them, and then [update the `mainMenuManager`](https://github.com/arduino/arduino-ide/compare/limit-interface-scale?expand=1#diff-e85455776c63a56847b610b7e290b72e1ffb4bcfb0188d3351d9fe17866c33a2R122) manually, otherwise they wouldn't get updated as expected.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)