### PR TITLE
Correct text of "INSTALLED" label in Library/Boards Manager

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/component-list/list-item-renderer.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/list-item-renderer.tsx
@@ -59,7 +59,7 @@ export class ListItemRenderer<T extends ArduinoComponent> {
           className="installed"
           onClick={onClickUninstall}
           {...{
-            install: nls.localize('arduino/component/install', 'INSTALL'),
+            install: nls.localize('arduino/component/installed', 'INSTALLED'),
             uninstall: nls.localize('arduino/component/uninstall', 'Uninstall'),
           }}
         />

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -145,6 +145,7 @@
       "by": "by",
       "filterSearch": "Filter your search...",
       "install": "INSTALL",
+      "installed": "INSTALLED",
       "moreInfo": "More info",
       "uninstall": "Uninstall",
       "uninstallMsg": "Do you want to uninstall {0}?",


### PR DESCRIPTION
### Motivation

An "**INSTALLED**" label is shown on the items in the **Library Manager** and **Boards Manager** views that are currently installed on the user's system:

![image](https://user-images.githubusercontent.com/8572152/193248674-9755a2c6-962d-4cb0-a33d-21ae9cd25f9b.png)

During some work to add missing internationalization to the UI strings (https://github.com/arduino/arduino-ide/pull/1449), this text was changed to "**INSTALL**".

![image](https://user-images.githubusercontent.com/8572152/193248886-e85dd94a-7247-4441-a505-c02fffac9047.png)

"**INSTALL**" is not appropriate for what this label is intended to communicate.

### Change description

Correct the regression, while retaining the internationalization of the string.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)