### PR TITLE
Update library dependency installation dialog response indexes

### DIFF
--- a/arduino-ide-extension/src/browser/library/library-list-widget.ts
+++ b/arduino-ide-extension/src/browser/library/library-list-widget.ts
@@ -139,12 +139,12 @@ export class LibraryListWidget extends ListWidget<
 
       if (result) {
         const { response } = result;
-        if (response === 0) {
-          // All
-          installDependencies = true;
-        } else if (response === 1) {
+        if (response === 1) {
           // Current only
           installDependencies = false;
+        } else if (response === 2) {
+          // All
+          installDependencies = true;
         }
       }
     } else {


### PR DESCRIPTION
### Motivation

Arduino libraries may specify dependencies on other libraries in their [metadata](https://arduino.github.io/arduino-cli/dev/library-specification/#library-metadata). The installation of these dependencies is offered by Arduino IDE when the user installs the dependent library using the "**Library Manager**" widget.

![image](https://user-images.githubusercontent.com/8572152/193454016-e12a953d-995e-4c45-9610-b3a4a8680223.png)

The order of the buttons in the dialog that offers the dependencies installation was recently rearranged (https://github.com/arduino/arduino-ide/pull/1382). The dialog response interpretation code was not updated to reflect the changes to the button indexes at that time. This caused the "**CANCEL**" button to trigger the behavior expected from the "**INSTALL ALL**" button, and vice versa.

#### To reproduce

1. Open the "**Library Manager**" view.
1. Install any version of the "ArduinoIoTCloud" library.
   **ⓘ** This library was picked arbitrarily. Any library that specifies dependencies can be used.
1. Click the "**INSTALL ALL**" button on the "**Dependencies for library ArduinoIoTCloud:\_\_\_**" dialog.
   🐛 The dialog closes and no libraries are installed.
1. Install any version of the "ArduinoIoTCloud" library.
1. Click the "**CANCEL**" button on the "**Dependencies for library ArduinoIoTCloud:\_\_\_**" dialog.
   🐛 The notification and **Output** view show the "**ArduinoIoTCloud**" library and all dependencies being installed.

### Change description

Update library dependency installation dialog response interpretation code to use the new button indexes.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)