### PR TITLE
Bump arduino-serial-plotter-webapp dependency to 0.2.0

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -56,7 +56,7 @@
     "@types/temp": "^0.8.34",
     "@types/which": "^1.3.1",
     "ajv": "^6.5.3",
-    "arduino-serial-plotter-webapp": "0.1.0",
+    "arduino-serial-plotter-webapp": "0.2.0",
     "async-mutex": "^0.3.0",
     "atob": "^2.1.2",
     "auth0-js": "^9.14.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4267,10 +4267,10 @@ archive-type@^4.0.0:
   dependencies:
     file-type "^4.2.0"
 
-arduino-serial-plotter-webapp@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/arduino-serial-plotter-webapp/-/arduino-serial-plotter-webapp-0.1.0.tgz#fa631483a93a12acd89d7bbe0487a3c0e57fac9f"
-  integrity sha512-0gHDGDz6guIC7Y8JXHaUad0RoueG2A+ykKNY1yo59+hWGbkM37hdRy4GKLsOkn0NMqU1TjnWmQHaSmYJjD1cAQ==
+arduino-serial-plotter-webapp@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/arduino-serial-plotter-webapp/-/arduino-serial-plotter-webapp-0.2.0.tgz#90d61ad7ed1452f70fd226ff25eccb36c1ab1a4f"
+  integrity sha512-AxQIsKr6Mf8K1c3kj+ojjFvE9Vz8cUqJqRink6/myp/ranEGwsQQ83hziktkPKZvBQshqrMH8nzoGIY2Z3A2OA==
 
 are-we-there-yet@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Motivation

A new version of the arduino-serial-plotter-webapp dependency is available.

### Change description

Bump arduino-serial-plotter-webapp dependency to 0.2.0

### Other information

Fixes https://github.com/arduino/arduino-ide/issues/1360

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)