### PR TITLE
Fix status bar clipped in minimal state

### DIFF
--- a/arduino-ide-extension/src/browser/style/index.css
+++ b/arduino-ide-extension/src/browser/style/index.css
@@ -55,7 +55,8 @@
 /* Makes the sidepanel a bit wider when opening the widget */
 .p-DockPanel-widget {
   min-width: 200px;
-  min-height: 200px;
+  min-height: 20px;
+  height: 200px;
 }
 
 /* Overrule the default Theia CSS button styles. */


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
Fix bottom status bar(or top tool bar when click the `output` title) is clipped by allowing the `DockPanel` has a wider height range.

### Change description
<!-- What does your code do? -->
Make the total height of the split children less than the preset [minHeight](https://github.com/arduino/arduino-ide/commit/99664ee544d146c43a047547ea37e035eb90ff95) as much as possible.

### Other information
<!-- Any additional information that could help the review process -->
Related to #1515 #1151 #779 #662
### Reviewer checklist

* [x] PR addresses a single concern.
* [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [x] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)