### PR TITLE
Fix boards listing

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-data-menu-updater.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-data-menu-updater.ts
@@ -111,7 +111,7 @@ export class BoardsDataMenuUpdater implements FrontendApplicationContribution {
                   const { label } = commands.get(commandId)!;
                   this.menuRegistry.registerMenuAction(menuPath, {
                     commandId,
-                    order: `${i}`,
+                    order: String(i).padStart(4),
                     label,
                   });
                   return Disposable.create(() =>

--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -243,7 +243,7 @@ PID: ${PID}`;
       const menuAction = {
         commandId: id,
         label: name,
-        order: `${index}`,
+        order: String(index).padStart(4), // pads with leading zeros for alphanumeric sort where order is 1, 2, 11, and NOT 1, 11, 2
       };
       this.commandRegistry.registerCommand(command, handler);
       this.toDisposeBeforeMenuRebuild.push(
@@ -329,7 +329,7 @@ PID: ${PID}`;
         const menuAction = {
           commandId: id,
           label,
-          order: `${protocolOrder + i + 1}`,
+          order: String(protocolOrder + i + 1).padStart(4),
         };
         this.commandRegistry.registerCommand(command, handler);
         this.toDisposeBeforeMenuRebuild.push(

--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -361,7 +361,7 @@ PID: ${PID}`;
   }
 
   protected async installedBoards(): Promise<InstalledBoardWithPackage[]> {
-    const allBoards = await this.boardsService.searchBoards({});
+    const allBoards = await this.boardsService.getInstalledBoards();
     return allBoards.filter(InstalledBoardWithPackage.is);
   }
 }

--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -199,14 +199,15 @@ PID: ${PID}`;
     });
 
     // Installed boards
-    for (const board of installedBoards) {
+    installedBoards.forEach((board, index) => {
       const { packageId, packageName, fqbn, name, manuallyInstalled } = board;
 
       const packageLabel =
         packageName +
-        `${manuallyInstalled
-          ? nls.localize('arduino/board/inSketchbook', ' (in Sketchbook)')
-          : ''
+        `${
+          manuallyInstalled
+            ? nls.localize('arduino/board/inSketchbook', ' (in Sketchbook)')
+            : ''
         }`;
       // Platform submenu
       const platformMenuPath = [...boardsPackagesGroup, packageId];
@@ -239,14 +240,18 @@ PID: ${PID}`;
       };
 
       // Board menu
-      const menuAction = { commandId: id, label: name };
+      const menuAction = {
+        commandId: id,
+        label: name,
+        order: `${index}`,
+      };
       this.commandRegistry.registerCommand(command, handler);
       this.toDisposeBeforeMenuRebuild.push(
         Disposable.create(() => this.commandRegistry.unregisterCommand(command))
       );
       this.menuModelRegistry.registerMenuAction(platformMenuPath, menuAction);
       // Note: we do not dispose the menu actions individually. Calling `unregisterSubmenu` on the parent will wipe the children menu nodes recursively.
-    }
+    });
 
     // Installed ports
     const registerPorts = (
@@ -282,11 +287,13 @@ PID: ${PID}`;
 
       // First we show addresses with recognized boards connected,
       // then all the rest.
-      const sortedIDs = Object.keys(ports).sort((left: string, right: string): number => {
-        const [, leftBoards] = ports[left];
-        const [, rightBoards] = ports[right];
-        return rightBoards.length - leftBoards.length;
-      });
+      const sortedIDs = Object.keys(ports).sort(
+        (left: string, right: string): number => {
+          const [, leftBoards] = ports[left];
+          const [, rightBoards] = ports[right];
+          return rightBoards.length - leftBoards.length;
+        }
+      );
 
       for (let i = 0; i < sortedIDs.length; i++) {
         const portID = sortedIDs[i];

--- a/arduino-ide-extension/src/browser/contributions/sketch-control.ts
+++ b/arduino-ide-extension/src/browser/contributions/sketch-control.ts
@@ -176,7 +176,7 @@ export class SketchControl extends SketchContribution {
               {
                 commandId: command.id,
                 label: this.labelProvider.getName(uri),
-                order: `${i}`,
+                order: String(i).padStart(4),
               }
             );
             this.toDisposeBeforeCreateNewContextMenu.push(

--- a/arduino-ide-extension/src/common/protocol/boards-service.ts
+++ b/arduino-ide-extension/src/common/protocol/boards-service.ts
@@ -141,6 +141,7 @@ export interface BoardsService
     fqbn: string;
   }): Promise<BoardsPackage | undefined>;
   searchBoards({ query }: { query?: string }): Promise<BoardWithPackage[]>;
+  getInstalledBoards(): Promise<BoardWithPackage[]>;
   getBoardUserFields(options: {
     fqbn: string;
     protocol: string;

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -211,7 +211,7 @@ export class BoardsServiceImpl
     return this.handleListBoards(client.boardListAll.bind(client), req);
   }
 
-  async handleListBoards(
+  private async handleListBoards(
     getBoards: (
       request: BoardListAllRequest | BoardSearchRequest,
       callback: (

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -32,7 +32,7 @@ import { CoreClientAware } from './core-client-provider';
 import {
   BoardDetailsRequest,
   BoardDetailsResponse,
-  BoardSearchRequest,
+  BoardListAllRequest,
 } from './cli-protocol/cc/arduino/cli/commands/v1/board_pb';
 import {
   ListProgrammersAvailableForUploadRequest,
@@ -196,11 +196,11 @@ export class BoardsServiceImpl
     query?: string;
   }): Promise<BoardWithPackage[]> {
     const { instance, client } = await this.coreClient;
-    const req = new BoardSearchRequest();
-    req.setSearchArgs(query || '');
+    const req = new BoardListAllRequest();
+    req.addSearchArgs(query || '');
     req.setInstance(instance);
     const boards = await new Promise<BoardWithPackage[]>((resolve, reject) => {
-      client.boardSearch(req, (error, resp) => {
+      client.boardListAll(req, (error, resp) => {
         if (error) {
           reject(error);
           return;


### PR DESCRIPTION
### Motivation
The IDE needs to sort the menu for each platform in **Tools > Board** (e.g., **Tools > Board > Arduino AVR Boards**) according to the order of occurrence of the `name` property for each board definitions in the platform's [`boards.txt` configuration file](https://arduino.github.io/arduino-cli/dev/platform-specification/#boardstxt).

### Change description
- use `listall` instead of `search` command in the arduino-cli
- add a proper order to the menu item when registering a board
- update the arduino-cli to use the sorting fix

### Other information
Fixes #802.

This needed a fix in the CLI to get the correct order: https://github.com/arduino/arduino-cli/pull/1903

This PR is in **draft** because there isn't a release for the arduino-cli yet, but it can already be tested.

**Arduino IDE 2.x** _before_ this change:
![image](https://user-images.githubusercontent.com/6939054/193781849-e69fa288-6028-43d0-9923-f3a88e699949.png)

**Arduino IDE 2.x** _after_ this change:
![Screenshot 2022-10-04 at 10 51 36](https://user-images.githubusercontent.com/6939054/193781964-9c3e2ff8-e032-4a6f-a2da-da1c926cc3a8.png)

**Arduino IDE 1.x**:
![Screenshot 2022-10-04 at 10 51 46](https://user-images.githubusercontent.com/6939054/193781959-963daab8-0afd-4ee2-9ca4-f3a8e2d0ddb9.png)



### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)