### PR TITLE
Let CSS do the uppercase transformation.

### DIFF
--- a/arduino-ide-extension/src/browser/style/index.css
+++ b/arduino-ide-extension/src/browser/style/index.css
@@ -136,6 +136,9 @@ button.secondary[disabled], .theia-button.secondary[disabled] {
   font-size: 14px;
 }
 
+.uppercase {
+  text-transform: uppercase;
+}
 
 /* High Contrast Theme rules */
 /* TODO: Remove it when the Theia version is upgraded to 1.27.0 and use Theia APIs to implement it*/

--- a/arduino-ide-extension/src/browser/style/list-widget.css
+++ b/arduino-ide-extension/src/browser/style/list-widget.css
@@ -112,14 +112,12 @@
     max-height: calc(1em + 4px);
     color: var(--theia-button-foreground);
     content: attr(install);
-    text-transform: uppercase;
 }
 
 .component-list-item .header .installed:hover:before {
     background-color: var(--theia-button-foreground);
     color: var(--theia-button-background);
     content: attr(uninstall);
-    text-transform: uppercase;
 }
 
 .component-list-item[min-width~="170px"] .footer {

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-widget.tsx
@@ -61,10 +61,10 @@ export class CloudSketchbookTreeWidget extends SketchbookTreeWidget {
           </div>
         </div>
         <button
-          className="theia-button"
+          className="theia-button uppercase"
           onClick={() => shell.openExternal('https://create.arduino.cc/editor')}
         >
-          {nls.localize('cloud/GoToCloud', 'GO TO CLOUD')}
+          {nls.localize('arduino/cloud/goToCloud', 'Go to Cloud')}
         </button>
         <div className="center item"></div>
       </div>

--- a/arduino-ide-extension/src/browser/widgets/component-list/list-item-renderer.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/list-item-renderer.tsx
@@ -56,10 +56,10 @@ export class ListItemRenderer<T extends ArduinoComponent> {
           )}
         </span>
         <span
-          className="installed"
+          className="installed uppercase"
           onClick={onClickUninstall}
           {...{
-            install: nls.localize('arduino/component/installed', 'INSTALLED'),
+            install: nls.localize('arduino/component/installed', 'Installed'),
             uninstall: nls.localize('arduino/component/uninstall', 'Uninstall'),
           }}
         />
@@ -77,10 +77,10 @@ export class ListItemRenderer<T extends ArduinoComponent> {
     const onClickInstall = () => install(item);
     const installButton = item.installable && (
       <button
-        className="theia-button secondary install"
+        className="theia-button secondary install uppercase"
         onClick={onClickInstall}
       >
-        {nls.localize('arduino/component/install', 'INSTALL')}
+        {nls.localize('arduino/component/install', 'Install')}
       </button>
     );
 

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -90,6 +90,7 @@
       "donePushing": "Done pushing ‘{0}’.",
       "embed": "Embed:",
       "emptySketchbook": "Your Sketchbook is empty",
+      "goToCloud": "Go to Cloud",
       "learnMore": "Learn more",
       "link": "Link:",
       "notYetPulled": "Cannot push to Cloud. It is not yet pulled.",
@@ -144,8 +145,8 @@
       "boardsIncluded": "Boards included in this package:",
       "by": "by",
       "filterSearch": "Filter your search...",
-      "install": "INSTALL",
-      "installed": "INSTALLED",
+      "install": "Install",
+      "installed": "Installed",
       "moreInfo": "More info",
       "uninstall": "Uninstall",
       "uninstallMsg": "Do you want to uninstall {0}?",
@@ -421,9 +422,6 @@
       "enterField": "Enter {0}",
       "upload": "Upload"
     }
-  },
-  "cloud": {
-    "GoToCloud": "GO TO CLOUD"
   },
   "theia": {
     "core": {


### PR DESCRIPTION
### Motivation
Do not expose implementation details in the translation files. Related comment: https://github.com/arduino/arduino-ide/pull/1341#discussion_r950823868

This PR is a follow-up of #1507. Use no `uppercase` letters. CSS will do the trick [here](https://github.com/arduino/arduino-ide/blob/945a8f48412ddfd398192e5997b14f71534b09d6/arduino-ide-extension/src/browser/style/list-widget.css#L115) and [here](https://github.com/arduino/arduino-ide/blob/945a8f48412ddfd398192e5997b14f71534b09d6/arduino-ide-extension/src/browser/style/list-widget.css#L122).

This PR also changes the default translations of the following UI labels as requested in https://github.com/arduino/arduino-ide/pull/1521#pullrequestreview-1130249047:
 - `GO TO CLOUD` ->. `Go to Cloud`, and
 - `INSTALL` -> `Install`,

### Change description
<!-- What does your code do? -->

To verify:
 - Open the library/boards manager widget, and if you do not have any libs/cores installed install one or two.
   - During the installation, make sure the _Install_ button shows `INSTALL` although the translation file contains `Install`,
   - After installing a few libs/cores, you should see `INSTALLED` and **not** `Installed` for the items,
   - When you hover over `INSTALLED`, you should see `UNINSTALL` (assuming your IDE2 language is English)
 - The cloud verification is a bit trickier as the `GO TO CLOUD` is only visible if you are logged in to Arduino Create but do not have any cloud sketches. Ensuring zero remote sketches was difficult as the Create editor forced me to have at least one sketch, but I found a glitch and could workaround this behavior. When there is a single sketch, delete it, reload the page, and delete it again, then Create Editor fails to create a new resource. Here is a screencast with the steps:

https://user-images.githubusercontent.com/1405703/194056261-4e740dd2-64bb-462f-85da-6077a24abc8a.mp4


Here are the changes in action in IDE2:

`INSTALL`/`INSTALLED`/`UNINSTALL`:

https://user-images.githubusercontent.com/1405703/194056656-1c36b609-e314-4410-ba23-500804ef1662.mp4

`GO TO CLOUD`:

https://user-images.githubusercontent.com/1405703/194056971-90e2ae0c-1c78-4fe2-bdf1-2556d9904811.mp4


### Other information
 
No behavioral changes are expected.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)