### PR TITLE
#1525 Removed the `real_name` of the libraries

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -159,9 +159,9 @@
   "arduino": {
     "cli": {
       "version": {
-        "owner": "cmaglie",
+        "owner": "arduino",
         "repo": "arduino-cli",
-        "commitish": "download_progress_refactor"
+        "commitish": "c8ff042"
       }
     },
     "fwuploader": {

--- a/arduino-ide-extension/src/common/protocol/library-service.ts
+++ b/arduino-ide-extension/src/common/protocol/library-service.ts
@@ -163,12 +163,6 @@ export enum LibraryLocation {
 
 export interface LibraryPackage extends ArduinoComponent {
   /**
-   * Same as [`Library#real_name`](https://arduino.github.io/arduino-cli/latest/rpc/commands/#library).
-   * Should be used for the UI, and `name` is used to uniquely identify a library. It does not have an ID.
-   */
-  readonly label: string;
-
-  /**
    * An array of string that should be included into the `ino` file if this library is used.
    * For example, including `SD` will prepend `#include <SD.h>` to the `ino` file. While including `Bridge`
    * requires multiple `#include` declarations: `YunClient`, `YunServer`, `Bridge`, etc.

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.d.ts
@@ -765,9 +765,6 @@ export class Library extends jspb.Message {
     getContainerPlatform(): string;
     setContainerPlatform(value: string): Library;
 
-    getRealName(): string;
-    setRealName(value: string): Library;
-
     getDotALinkage(): boolean;
     setDotALinkage(value: boolean): Library;
 
@@ -836,7 +833,6 @@ export namespace Library {
         sourceDir: string,
         utilityDir: string,
         containerPlatform: string,
-        realName: string,
         dotALinkage: boolean,
         precompiled: boolean,
         ldFlags: string,

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.js
@@ -5447,7 +5447,6 @@ proto.cc.arduino.cli.commands.v1.Library.toObject = function(includeInstance, ms
     sourceDir: jspb.Message.getFieldWithDefault(msg, 11, ""),
     utilityDir: jspb.Message.getFieldWithDefault(msg, 12, ""),
     containerPlatform: jspb.Message.getFieldWithDefault(msg, 14, ""),
-    realName: jspb.Message.getFieldWithDefault(msg, 16, ""),
     dotALinkage: jspb.Message.getBooleanFieldWithDefault(msg, 17, false),
     precompiled: jspb.Message.getBooleanFieldWithDefault(msg, 18, false),
     ldFlags: jspb.Message.getFieldWithDefault(msg, 19, ""),
@@ -5547,10 +5546,6 @@ proto.cc.arduino.cli.commands.v1.Library.deserializeBinaryFromReader = function(
     case 14:
       var value = /** @type {string} */ (reader.readString());
       msg.setContainerPlatform(value);
-      break;
-    case 16:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setRealName(value);
       break;
     case 17:
       var value = /** @type {boolean} */ (reader.readBool());
@@ -5721,13 +5716,6 @@ proto.cc.arduino.cli.commands.v1.Library.serializeBinaryToWriter = function(mess
   if (f.length > 0) {
     writer.writeString(
       14,
-      f
-    );
-  }
-  f = message.getRealName();
-  if (f.length > 0) {
-    writer.writeString(
-      16,
       f
     );
   }
@@ -6081,24 +6069,6 @@ proto.cc.arduino.cli.commands.v1.Library.prototype.getContainerPlatform = functi
  */
 proto.cc.arduino.cli.commands.v1.Library.prototype.setContainerPlatform = function(value) {
   return jspb.Message.setProto3StringField(this, 14, value);
-};
-
-
-/**
- * optional string real_name = 16;
- * @return {string}
- */
-proto.cc.arduino.cli.commands.v1.Library.prototype.getRealName = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 16, ""));
-};
-
-
-/**
- * @param {string} value
- * @return {!proto.cc.arduino.cli.commands.v1.Library} returns this
- */
-proto.cc.arduino.cli.commands.v1.Library.prototype.setRealName = function(value) {
-  return jspb.Message.setProto3StringField(this, 16, value);
 };
 
 

--- a/arduino-ide-extension/src/node/examples-service-impl.ts
+++ b/arduino-ide-extension/src/node/examples-service-impl.ts
@@ -124,11 +124,11 @@ export class ExamplesServiceImpl implements ExamplesService {
    * location of the examples. Otherwise it creates the example container from the direct examples FS paths.
    */
   private async tryGroupExamples({
-    label,
+    name,
     exampleUris,
     installDirUri,
   }: LibraryPackage): Promise<SketchContainer> {
-    const container = SketchContainer.create(label);
+    const container = SketchContainer.create(name);
     if (!installDirUri || !exampleUris.length) {
       return container;
     }

--- a/arduino-ide-extension/src/node/library-service-impl.ts
+++ b/arduino-ide-extension/src/node/library-service-impl.ts
@@ -66,7 +66,7 @@ export class LibraryServiceImpl
       if (installedLib.hasLibrary()) {
         const lib = installedLib.getLibrary();
         if (lib) {
-          installedLibsIdx.set(lib.getRealName(), installedLib);
+          installedLibsIdx.set(lib.getName(), installedLib);
         }
       }
     }
@@ -210,7 +210,6 @@ export class LibraryServiceImpl
         return toLibrary(
           {
             name: library.getName(),
-            label: library.getRealName(),
             installedVersion,
             installable: true,
             description: library.getSentence(),
@@ -443,7 +442,6 @@ function toLibrary(
 ): LibraryPackage {
   return {
     name: '',
-    label: '',
     exampleUris: [],
     installable: false,
     deprecated: false,


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
Align gRPC APIs with the most recent Arduino CLI. The `Library#real_name` has been removed from the gRPC API: arduino/arduino-cli#1890

This PR switches from `real_name` to `name` in the UI, as the `name` is the canonical form provided by the CLI.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

How to verify:
 - start the IDE2,
 - open the library manager widget and type `SparkFun color lcd` in the search `<input>`, (expected a single result: `SparkFun Color LCD Shield`)
 - if the library is installed, uninstall it by clicking on `UNINSTALL`,
 - this should wipe the library without any errors,
 - install the `SparkFun Color LCD Shield@1.0.1`,
 - open `File` > `Examples`> verify that you see `SparkFun Color LCD Shield` as the grouping menu item. Like this:

<img width="455" alt="Screen Shot 2022-10-05 at 11 50 02" src="https://user-images.githubusercontent.com/1405703/194032769-03b32992-f227-4784-96cb-b16bd1087b3b.png">



Closes #1525

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)