### PR TITLE
#1529 Avoid using `reportResult` if installing lib/core

### DIFF
--- a/arduino-ide-extension/src/node/core-client-provider.ts
+++ b/arduino-ide-extension/src/node/core-client-provider.ts
@@ -370,8 +370,8 @@ export class CoreClientProvider {
                 );
                 progressHandler?.reportProgress(message);
               },
-              reportResult: (result) => progressHandler?.reportResult(result),
             },
+            reportResult: (result) => progressHandler?.reportResult(result),
             progressId,
           })
         )

--- a/arduino-ide-extension/src/node/grpc-progressible.ts
+++ b/arduino-ide-extension/src/node/grpc-progressible.ts
@@ -163,14 +163,17 @@ export namespace ExecuteWithProgress {
      * _unknown_ progress if falsy.
      */
     readonly progressId?: string;
-    readonly responseService: Partial<
-      ResponseService & { reportResult: (result: DownloadResult) => void }
-    >;
+    readonly responseService: Partial<ResponseService>;
+    /**
+     * It's only relevant for index updates to build a summary of possible client (4xx) and server (5xx) errors when downloading the files during the index update. It's missing for lib/platform installations.
+     */
+    readonly reportResult?: (result: DownloadResult) => void;
   }
 
   export function createDataCallback<R extends ProgressResponse>({
     responseService,
     progressId,
+    reportResult,
   }: ExecuteWithProgress.Options): (response: R) => void {
     const uuid = v4();
     let message = '';
@@ -252,8 +255,8 @@ export namespace ExecuteWithProgress {
             });
           }
         } else if (phase instanceof DownloadProgressEnd) {
-          if (url) {
-            responseService.reportResult?.({
+          if (url && reportResult) {
+            reportResult({
               url,
               message: phase.getMessage(),
               success: phase.getSuccess(),


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To fix the persistent error (see #1529) when installing a library or platform. As part of the arduino/arduino-cli#1875 the `DownloadProgress(Start|Update|End)` APIs have been unified. Besides the index updates, the lib/platform install started to use the same API as the index update, but IDE2 was not prepared for this. The PR should fix the bug by avoiding calling non-existing IDE2 code when installing a lib/platform. For the index updates, everything remains the same in IDE2.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

To verify:
 - Start IDE2 from a terminal or open DevTools in the browser window,
 - Install a couple of libraries and platforms. It should work. It fails from the `main` (61a11a0)

Closes #1529

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)