### PR TITLE
#1526 Ensure exact match when installing `Arduino_BuiltIn` on the first IDE2 startup

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/first-startup-installer.ts
+++ b/arduino-ide-extension/src/browser/contributions/first-startup-installer.ts
@@ -7,6 +7,8 @@ import {
 } from '../../common/protocol';
 import { Contribution } from './contribution';
 
+const Arduino_BuiltIn = 'Arduino_BuiltIn';
+
 @injectable()
 export class FirstStartupInstaller extends Contribution {
   @inject(LocalStorageService)
@@ -25,8 +27,8 @@ export class FirstStartupInstaller extends Contribution {
         id: 'arduino:avr',
       });
       const builtInLibrary = (
-        await this.libraryService.search({ query: 'Arduino_BuiltIn' })
-      )[0];
+        await this.libraryService.search({ query: Arduino_BuiltIn })
+      ).find(({ name }) => name === Arduino_BuiltIn); // Filter by `name` to ensure "exact match". See: https://github.com/arduino/arduino-ide/issues/1526.
 
       let avrPackageError: Error | undefined;
       let builtInLibraryError: Error | undefined;
@@ -84,7 +86,7 @@ export class FirstStartupInstaller extends Contribution {
       }
       if (builtInLibraryError) {
         this.messageService.error(
-          `Could not install ${builtInLibrary.name} library: ${builtInLibraryError}`
+          `Could not install ${Arduino_BuiltIn} library: ${builtInLibraryError}`
         );
       }
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

~**This PR depends on #1530.**~ ✅ 

-----

This PR ensures that the `Arduino_BuiltIn` will be installed on the first start in case of absence.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

To verify:
 - Follow the steps described in #1526.
 - After the first installation, the `Arduino_BuiltIn` library must be installed instead of any pseudo-random library containing either `Arduino` or `BuiltIn` as metadata.

Closes #1526

----

Local verification after wiping the `localStorage` content and starting IDE2.

```
Platform arduino:avr@1.8.5 already installed
Already installed Servo@1.1.8
Already installed Stepper@1.1.3
Already installed Ethernet@2.0.1
Already installed Firmata@2.5.8
Already installed Keyboard@1.0.4
Already installed LiquidCrystal@1.0.7
Already installed Mouse@1.0.1
Already installed SD@1.2.4
Already installed TFT@1.0.6
Already installed Arduino_BuiltIn@1.0.0
```

```
Platform arduino:avr@1.8.5 already installed
Already installed Keyboard@1.0.4
Already installed Stepper@1.1.3
Already installed Firmata@2.5.8
Already installed SD@1.2.4
Already installed Ethernet@2.0.1
Already installed Mouse@1.0.1
Already installed Arduino_BuiltIn@1.0.0
Already installed Servo@1.1.8
Already installed TFT@1.0.6
Already installed LiquidCrystal@1.0.7
```

```
Platform arduino:avr@1.8.5 already installed
Already installed Stepper@1.1.3
Already installed TFT@1.0.6
Already installed Servo@1.1.8
Already installed SD@1.2.4
Already installed LiquidCrystal@1.0.7
Already installed Mouse@1.0.1
Already installed Arduino_BuiltIn@1.0.0
Already installed Firmata@2.5.8
Already installed Keyboard@1.0.4
Already installed Ethernet@2.0.1
```

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)