### PR TITLE
#573 Listen on the client's port change event

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-config.tsx
+++ b/arduino-ide-extension/src/browser/boards/boards-config.tsx
@@ -6,7 +6,6 @@ import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import {
   Board,
   Port,
-  AttachedBoardsChangeEvent,
   BoardWithPackage,
 } from '../../common/protocol/boards-service';
 import { NotificationCenter } from '../notification-center';
@@ -113,11 +112,14 @@ export class BoardsConfig extends React.Component<
           );
         }
       }),
-      this.props.notificationCenter.onAttachedBoardsDidChange((event) =>
-        this.updatePorts(
-          event.newState.ports,
-          AttachedBoardsChangeEvent.diff(event).detached.ports
-        )
+      this.props.boardsServiceProvider.onAvailablePortsChanged(
+        ({ newState, oldState }) => {
+          const removedPorts = oldState.filter(
+            (oldPort) =>
+              !newState.find((newPort) => Port.sameAs(newPort, oldPort))
+          );
+          this.updatePorts(newState, removedPorts);
+        }
       ),
       this.props.boardsServiceProvider.onBoardsConfigChanged(
         ({ selectedBoard, selectedPort }) => {

--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -63,7 +63,10 @@ export class BoardsServiceProvider
   protected readonly onAvailableBoardsChangedEmitter = new Emitter<
     AvailableBoard[]
   >();
-  protected readonly onAvailablePortsChangedEmitter = new Emitter<Port[]>();
+  protected readonly onAvailablePortsChangedEmitter = new Emitter<{
+    newState: Port[];
+    oldState: Port[];
+  }>();
   private readonly inheritedConfig = new Deferred<BoardsConfig.Config>();
 
   /**
@@ -120,8 +123,12 @@ export class BoardsServiceProvider
       const { boards: attachedBoards, ports: availablePorts } =
         AvailablePorts.split(state);
       this._attachedBoards = attachedBoards;
+      const oldState = this._availablePorts.slice();
       this._availablePorts = availablePorts;
-      this.onAvailablePortsChangedEmitter.fire(this._availablePorts);
+      this.onAvailablePortsChangedEmitter.fire({
+        newState: this._availablePorts.slice(),
+        oldState,
+      });
 
       await this.reconcileAvailableBoards();
 
@@ -229,8 +236,12 @@ export class BoardsServiceProvider
     }
 
     this._attachedBoards = event.newState.boards;
+    const oldState = this._availablePorts.slice();
     this._availablePorts = event.newState.ports;
-    this.onAvailablePortsChangedEmitter.fire(this._availablePorts);
+    this.onAvailablePortsChangedEmitter.fire({
+      newState: this._availablePorts.slice(),
+      oldState,
+    });
     this.reconcileAvailableBoards().then(() => {
       const { uploadInProgress } = event;
       // avoid attempting "auto-selection" while an


### PR DESCRIPTION
### Motivation

Listen on the client's port changes to fix intermittent failure to recognize ports.

The problem was that the _board select_ dialog was listening on the backend's board/port changes to show the available ports in the dialog. This was fundamentally incorrect as the following use case could happen.
 - Attach boards,
 - Start IDE2,
 - Backend starts and detects the boards and ports via the `board list -w` gRPC equivalent, dispatches board/port change event **but** client is not started yet,
 - Client starts,
 - Initialize the dialog with zero ports (this is common practice to init with empty),
 - Listen on the backend board/port changes (event never arrives),
 - Attach/detach a board, and the ports section in the dialog starts working.

It was never an issue with the `Tool` > `Port` menu, as it was correctly listening on the client's events:

https://github.com/arduino/arduino-ide/blob/bc264d1adfd525778c45a0fc1414efc51d8eccff/arduino-ide-extension/src/browser/contributions/board-selection.ts#L109-L111

With the proposed changes, the dialog is correctly listening on the client's board/port changes, so it cannot miss the event.

<!-- Why this pull request? -->

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Closes #573

Locally, it was easy to reproduce the defect. Attach boards before starting IDE2. When IDE2 is up, open the _board select_ dialog. Ports were empty. Now, it should work with the build from this PR.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)