### PR TITLE
Let the user edit the font size settings with the keyboard

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
@@ -180,7 +180,8 @@ export class SettingsComponent extends React.Component<
           <div className="column">
             <div className="flex-line">
               <SettingsStepInput
-                value={this.state.editorFontSize}
+                key={`font-size-stepper-${String(this.state.editorFontSize)}`}
+                initialValue={this.state.editorFontSize}
                 setSettingsStateValue={this.setFontSize}
                 step={fontSizeStep}
                 maxValue={maxFontSize}
@@ -199,13 +200,18 @@ export class SettingsComponent extends React.Component<
               </label>
               <div>
                 <SettingsStepInput
-                  value={scalePercentage}
+                  key={`scale-stepper-${String(scalePercentage)}`}
+                  initialValue={scalePercentage}
                   setSettingsStateValue={this.setInterfaceScale}
                   step={scaleStep}
                   maxValue={maxScale}
                   minValue={minScale}
                   unitOfMeasure="%"
-                  classNames={{ input: 'theia-input small with-margin' }}
+                  classNames={{
+                    input: 'theia-input small with-margin',
+                    buttonsContainer:
+                      'settings-step-input-buttons-container-perc',
+                  }}
                 />
               </div>
             </div>

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-step-input.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-step-input.tsx
@@ -37,10 +37,11 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
     return Math.min(Math.max(value, min), max);
   };
 
-  const setValidValue = (value: number): void => {
-    const clampedValue = clamp(value, minValue, maxValue);
-    setValueState({ currentValue: clampedValue, isEmptyString: false });
-    setSettingsStateValue(clampedValue);
+  const resetToInitialState = (): void => {
+    setValueState({
+      currentValue: initialValue,
+      isEmptyString: false,
+    });
   };
 
   const onStep = (
@@ -53,7 +54,9 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
       valueRoundedToScale === currentValue
         ? stepOperation(currentValue, step)
         : valueRoundedToScale;
-    setValidValue(calculatedValue);
+    const newValue = clamp(calculatedValue, minValue, maxValue);
+
+    setSettingsStateValue(newValue);
   };
 
   const onStepUp = (): void => {
@@ -74,25 +77,20 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
 
   /* Prevent the user from entering invalid values */
   const onBlur = (event: React.FocusEvent): void => {
-    if (event.currentTarget.contains(event.relatedTarget as Node)) {
-      return;
-    }
-
     if (
-      (currentValue === 0 && minValue > 0) ||
-      isNaN(currentValue) ||
-      isEmptyString
+      (currentValue === initialValue && !isEmptyString) ||
+      event.currentTarget.contains(event.relatedTarget as Node)
     ) {
-      setValueState({
-        currentValue: initialValue,
-        isEmptyString: false,
-      });
       return;
     }
 
-    if (currentValue !== initialValue) {
-      setValidValue(currentValue);
+    const clampedValue = clamp(currentValue, minValue, maxValue);
+    if (clampedValue === initialValue || isNaN(currentValue) || isEmptyString) {
+      resetToInitialState();
+      return;
     }
+
+    setSettingsStateValue(clampedValue);
   };
 
   const valueIsNotWithinRange =

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-step-input.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-step-input.tsx
@@ -69,8 +69,16 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
   };
 
   /* Prevent the user from entering invalid values */
-  const onBlur = (): void => {
-    if ((currentValue === 0 && minValue > 0) || isNaN(currentValue)) {
+  const onBlur = (event: React.FocusEvent): void => {
+    if (event.currentTarget.contains(event.relatedTarget as Node)) {
+      return;
+    }
+
+    if (
+      (currentValue === 0 && minValue > 0) ||
+      isNaN(currentValue) ||
+      isEmptyString
+    ) {
       setValueState({
         currentValue: initialValue,
         isEmptyString: false,
@@ -95,12 +103,11 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
   const downDisabled = isDisabledException || currentValue <= minValue;
 
   return (
-    <div className="settings-step-input-container">
+    <div className="settings-step-input-container" onBlur={onBlur}>
       <input
         className={classnames('settings-step-input-element', classNames?.input)}
         value={isEmptyString ? '' : String(currentValue)}
         onChange={onUserInput}
-        onBlur={onBlur}
         type="number"
         pattern="[0-9]+"
       />

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-step-input.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-step-input.tsx
@@ -24,6 +24,8 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
     classNames,
   } = props;
 
+  const [tempValue, setTempValue] = React.useState<string>(String(value));
+
   const clamp = (value: number, min: number, max: number): number => {
     return Math.min(Math.max(value, min), max);
   };
@@ -52,17 +54,24 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
 
   const onUserInput = (event: React.ChangeEvent<HTMLInputElement>): void => {
     const { value: eventValue } = event.target;
+    setTempValue(eventValue);
+  };
 
-    if (eventValue === '') {
-      setSettingsStateValue(0);
+  /* Prevent the user from entering invalid values */
+  const onBlur = (): void => {
+    const tempValueAsNumber = Number(tempValue);
+
+    /* If the user input is not a number, reset the input to the previous value */
+    if (isNaN(tempValueAsNumber) || tempValue === '') {
+      setTempValue(String(value));
+      return;
     }
-
-    const number = Number(eventValue);
-
-    if (!isNaN(number) && number !== value) {
-      const newValue = clamp(number, minValue, maxValue);
+    if (tempValueAsNumber !== value) {
+      /* If the user input is a number, clamp it to the min and max values */
+      const newValue = clamp(tempValueAsNumber, minValue, maxValue);
 
       setSettingsStateValue(newValue);
+      setTempValue(String(newValue));
     }
   };
 
@@ -73,8 +82,9 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
     <div className="settings-step-input-container">
       <input
         className={classnames('settings-step-input-element', classNames?.input)}
-        value={value.toString()}
+        value={tempValue.toString()}
         onChange={onUserInput}
+        onBlur={onBlur}
         type="number"
         pattern="[0-9]+"
       />

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-step-input.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-step-input.tsx
@@ -37,6 +37,12 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
     return Math.min(Math.max(value, min), max);
   };
 
+  const setValidValue = (value: number): void => {
+    const clampedValue = clamp(value, minValue, maxValue);
+    setValueState({ currentValue: clampedValue, isEmptyString: false });
+    setSettingsStateValue(clampedValue);
+  };
+
   const onStep = (
     roundingOperation: 'ceil' | 'floor',
     stepOperation: (a: number, b: number) => number
@@ -47,9 +53,7 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
       valueRoundedToScale === currentValue
         ? stepOperation(currentValue, step)
         : valueRoundedToScale;
-    const newValue = clamp(calculatedValue, minValue, maxValue);
-
-    setSettingsStateValue(newValue);
+    setValidValue(calculatedValue);
   };
 
   const onStepUp = (): void => {
@@ -87,10 +91,7 @@ const SettingsStepInput: React.FC<SettingsStepInputProps> = (
     }
 
     if (currentValue !== initialValue) {
-      /* If the user input is a number, clamp it to the min and max values */
-      const newValue = clamp(currentValue, minValue, maxValue);
-
-      setSettingsStateValue(newValue);
+      setValidValue(currentValue);
     }
   };
 

--- a/arduino-ide-extension/src/browser/style/settings-step-input.css
+++ b/arduino-ide-extension/src/browser/style/settings-step-input.css
@@ -2,10 +2,10 @@
     position: relative
 }
 
-.settings-step-input-element::-webkit-inner-spin-button, 
+.settings-step-input-element::-webkit-inner-spin-button,
 .settings-step-input-element::-webkit-outer-spin-button {
-  -webkit-appearance: none;
-  margin: 0;
+    -webkit-appearance: none;
+    margin: 0;
 }
 
 .settings-step-input-buttons-container {
@@ -25,7 +25,7 @@
     right: 14px;
 }
 
-.settings-step-input-container:hover > .settings-step-input-buttons-container {
+.settings-step-input-container:hover>.settings-step-input-buttons-container {
     display: flex;
 }
 

--- a/arduino-ide-extension/src/browser/style/settings-step-input.css
+++ b/arduino-ide-extension/src/browser/style/settings-step-input.css
@@ -12,13 +12,17 @@
     display: none;
     flex-direction: column;
     position: absolute;
-    right: 14px;
+    right: 0px;
     top: 50%;
     transform: translate(0px, -50%);
     height: calc(100% - 4px);
     width: 14px;
     padding: 2px;
     background: var(--theia-input-background);
+}
+
+.settings-step-input-buttons-container-perc {
+    right: 14px;
 }
 
 .settings-step-input-container:hover > .settings-step-input-buttons-container {


### PR DESCRIPTION
### Motivation
It's difficult for the user to edit the font size in the preferences using the keyboard.

On the current state, when a user tries to edit the value of the font size with the keyboard, the value would update unexpectedly.

For example:
- the font size is 72
- focus the input field
- press BACKSPACE
- expected: the font size is 7; result: the font size is 8 😢 
- now press 1
- expected: the font size is 81; result: the font size is 72 😢 

The reason is we validate the user input _as they type_, and if the input is invalid, we change the value to a valid one.

### Change description
With this change, I want to validate the user input _as they finished typing_ instead of _as they type_. In order to achieve that, I used the `onBlur` callback of the input field, so that the user can type whatever they want in the input field (only numbers, to be precise), and as soon as their focus change from the input field to another element (e.g.: they click on any other piece of UI or press ESCAPE) we validate the input they just typed in and, if necessary, change it to a valid value.

<details>
  <summary>Before the change (video):</summary>

https://user-images.githubusercontent.com/6939054/194602614-cc7f3ce5-b45e-49c5-83d5-ac0c553d7b9a.mov

</details>

<details>
  <summary>After the change (video):</summary>

https://user-images.githubusercontent.com/6939054/194602625-cf8fe2f3-ede7-4b6d-b791-9f5296f1c442.mov

</details>


### Other information
Fixes #1542 

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)