### PR TITLE
Allow uploads without port selection

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-service-provider.ts
@@ -409,14 +409,16 @@ export class BoardsServiceProvider
   }
 
   async selectedBoardUserFields(): Promise<BoardUserField[]> {
-    if (!this._boardsConfig.selectedBoard || !this._boardsConfig.selectedPort) {
+    if (!this._boardsConfig.selectedBoard) {
       return [];
     }
     const fqbn = this._boardsConfig.selectedBoard.fqbn;
     if (!fqbn) {
       return [];
     }
-    const protocol = this._boardsConfig.selectedPort.protocol;
+    // Protocol must be set to `default` when uploading without a port selected:
+    // https://arduino.github.io/arduino-cli/dev/platform-specification/#sketch-upload-configuration
+    const protocol = this._boardsConfig.selectedPort?.protocol || 'default';
     return await this.boardsService.getBoardUserFields({ fqbn, protocol });
   }
 

--- a/arduino-ide-extension/src/browser/contributions/user-fields.ts
+++ b/arduino-ide-extension/src/browser/contributions/user-fields.ts
@@ -66,10 +66,8 @@ export class UserFields extends Contribution {
     }
     const address =
       boardsConfig.selectedBoard?.port?.address ||
-      boardsConfig.selectedPort?.address;
-    if (!address) {
-      return undefined;
-    }
+      boardsConfig.selectedPort?.address ||
+      '';
     return fqbn + '|' + address;
   }
 


### PR DESCRIPTION

### Motivation
It is common for a "port" to be used in some way during the process of uploading to a board. However, the array of Arduino boards is very diverse. Some of these do not produce a port and their upload method has no need for one.

For this reason, the IDE must allow the upload process to be initiated regardless of whether a port happens to be selected. During the addition of support for [user provided fields](https://arduino.github.io/arduino-cli/dev/platform-specification/#user-provided-fields) (https://github.com/arduino/arduino-ide/pull/550), an unwarranted assumption was made that all boards require a port selection for upload and this resulted in a regression that broke uploading for these boards. This regression was especially user unfriendly in that there was no response whatsoever from the IDE when the user attempted to initiate an upload under these conditions.


### Change description
Always initiate the upload process regardless of whether a port is selected. In cases where a port is required, the resulting error message returned by Arduino CLI or the upload tool will communicate the problem to the user.

### Other information

Fixes https://github.com/arduino/arduino-ide/issues/702

Fixes https://github.com/arduino/arduino-ide/issues/770

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)