### PR TITLE
Fix #1566 : Port submenu section heading show at top

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -276,7 +276,7 @@ PID: ${PID}`;
           '{0} ports',
           Port.Protocols.protocolLabel(protocol)
         ),
-        { order: protocolOrder.toString() }
+        { order: protocolOrder.toString().padStart(4) }
       );
       this.menuModelRegistry.registerMenuNode(menuPath, placeholder);
       this.toDisposeBeforeMenuRebuild.push(


### PR DESCRIPTION
### Motivation
The Port submenu Section Heading for different protocols was being displayed at the bottom which is now corrected to show at top.

### Change description
PR #1520 introduced this regression wherein the padStart method was used to fix sorting of entries in Boards and Port menu. However, this was missed for the Port Submenu Section headings.

### Other information
Fixes #1566 

### Reviewer checklist

* [x] PR addresses a single concern.
* [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [x] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)