### PR TITLE
#1580 Create remote sketch

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -335,6 +335,8 @@ import { UserFields } from './contributions/user-fields';
 import { UpdateIndexes } from './contributions/update-indexes';
 import { InterfaceScale } from './contributions/interface-scale';
 import { OpenHandler } from '@theia/core/lib/browser/opener-service';
+import { NewCloudSketch } from './contributions/new-cloud-sketch';
+import { SketchbookCompositeWidget } from './widgets/sketchbook/sketchbook-composite-widget';
 
 const registerArduinoThemes = () => {
   const themes: MonacoThemeJson[] = [
@@ -751,6 +753,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   Contribution.configure(bind, DeleteSketch);
   Contribution.configure(bind, UpdateIndexes);
   Contribution.configure(bind, InterfaceScale);
+  Contribution.configure(bind, NewCloudSketch);
 
   bindContributionProvider(bind, StartupTaskProvider);
   bind(StartupTaskProvider).toService(BoardsServiceProvider); // to reuse the boards config in another window
@@ -904,6 +907,11 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(WidgetFactory).toDynamicValue(({ container }) => ({
     id: 'arduino-sketchbook-widget',
     createWidget: () => container.get(SketchbookWidget),
+  }));
+  bind(SketchbookCompositeWidget).toSelf();
+  bind<WidgetFactory>(WidgetFactory).toDynamicValue((ctx) => ({
+    id: 'sketchbook-composite-widget',
+    createWidget: () => ctx.container.get(SketchbookCompositeWidget),
   }));
 
   bind(CloudSketchbookWidget).toSelf();

--- a/arduino-ide-extension/src/browser/contributions/close.ts
+++ b/arduino-ide-extension/src/browser/contributions/close.ts
@@ -65,7 +65,7 @@ export class Close extends SketchContribution {
     registry.registerMenuAction(ArduinoMenus.FILE__SKETCH_GROUP, {
       commandId: Close.Commands.CLOSE.id,
       label: nls.localize('vscode/editor.contribution/close', 'Close'),
-      order: '5',
+      order: '6',
     });
   }
 

--- a/arduino-ide-extension/src/browser/contributions/new-cloud-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/new-cloud-sketch.ts
@@ -1,0 +1,247 @@
+import { MenuModelRegistry } from '@theia/core/lib/common/menu';
+import { KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
+import { CompositeTreeNode } from '@theia/core/lib/browser/tree';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { nls } from '@theia/core/lib/common/nls';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { MainMenuManager } from '../../common/main-menu-manager';
+import type { AuthenticationSession } from '../../node/auth/types';
+import { AuthenticationClientService } from '../auth/authentication-client-service';
+import { CreateApi } from '../create/create-api';
+import { CreateUri } from '../create/create-uri';
+import { Create } from '../create/typings';
+import { ArduinoMenus } from '../menu/arduino-menus';
+import { WorkspaceInputDialog } from '../theia/workspace/workspace-input-dialog';
+import { CloudSketchbookTree } from '../widgets/cloud-sketchbook/cloud-sketchbook-tree';
+import { CloudSketchbookTreeModel } from '../widgets/cloud-sketchbook/cloud-sketchbook-tree-model';
+import { CloudSketchbookTreeWidget } from '../widgets/cloud-sketchbook/cloud-sketchbook-tree-widget';
+import { SketchbookCommands } from '../widgets/sketchbook/sketchbook-commands';
+import { SketchbookWidget } from '../widgets/sketchbook/sketchbook-widget';
+import { SketchbookWidgetContribution } from '../widgets/sketchbook/sketchbook-widget-contribution';
+import { Command, CommandRegistry, Contribution, URI } from './contribution';
+
+@injectable()
+export class NewCloudSketch extends Contribution {
+  @inject(CreateApi)
+  private readonly createApi: CreateApi;
+  @inject(SketchbookWidgetContribution)
+  private readonly widgetContribution: SketchbookWidgetContribution;
+  @inject(AuthenticationClientService)
+  private readonly authenticationService: AuthenticationClientService;
+  @inject(MainMenuManager)
+  private readonly mainMenuManager: MainMenuManager;
+
+  private readonly toDispose = new DisposableCollection();
+  private _session: AuthenticationSession | undefined;
+  private _enabled: boolean;
+
+  override onReady(): void {
+    this.toDispose.pushAll([
+      this.authenticationService.onSessionDidChange((session) => {
+        const oldSession = this._session;
+        this._session = session;
+        if (!!oldSession !== !!this._session) {
+          this.mainMenuManager.update();
+        }
+      }),
+      this.preferences.onPreferenceChanged(({ preferenceName, newValue }) => {
+        if (preferenceName === 'arduino.cloud.enabled') {
+          const oldEnabled = this._enabled;
+          this._enabled = Boolean(newValue);
+          if (this._enabled !== oldEnabled) {
+            this.mainMenuManager.update();
+          }
+        }
+      }),
+    ]);
+    this._enabled = this.preferences['arduino.cloud.enabled'];
+    this._session = this.authenticationService.session;
+    if (this._session) {
+      this.mainMenuManager.update();
+    }
+  }
+
+  onStop(): void {
+    this.toDispose.dispose();
+  }
+
+  override registerCommands(registry: CommandRegistry): void {
+    registry.registerCommand(NewCloudSketch.Commands.NEW_CLOUD_SKETCH, {
+      execute: () => this.createNewSketch(),
+      isEnabled: () => !!this._session,
+      isVisible: () => this._enabled,
+    });
+  }
+
+  override registerMenus(registry: MenuModelRegistry): void {
+    registry.registerMenuAction(ArduinoMenus.FILE__SKETCH_GROUP, {
+      commandId: NewCloudSketch.Commands.NEW_CLOUD_SKETCH.id,
+      label: nls.localize('arduino/cloudSketch/new', 'New Remote Sketch'),
+      order: '1',
+    });
+  }
+
+  override registerKeybindings(registry: KeybindingRegistry): void {
+    registry.registerKeybinding({
+      command: NewCloudSketch.Commands.NEW_CLOUD_SKETCH.id,
+      keybinding: 'CtrlCmd+Alt+N',
+    });
+  }
+
+  private async createNewSketch(
+    initialValue?: string | undefined
+  ): Promise<URI | undefined> {
+    const widget = await this.widgetContribution.widget;
+    const treeModel = this.treeModelFrom(widget);
+    if (!treeModel) {
+      return undefined;
+    }
+    const rootNode = CompositeTreeNode.is(treeModel.root)
+      ? treeModel.root
+      : undefined;
+    if (!rootNode) {
+      return undefined;
+    }
+
+    const newSketchName = await this.newSketchName(rootNode, initialValue);
+    if (!newSketchName) {
+      return undefined;
+    }
+    let result: Create.Sketch | undefined | 'conflict';
+    try {
+      result = await this.createApi.createSketch(newSketchName);
+    } catch (err) {
+      if (isConflict(err)) {
+        result = 'conflict';
+      } else {
+        throw err;
+      }
+    } finally {
+      if (result) {
+        await treeModel.refresh();
+      }
+    }
+
+    if (result === 'conflict') {
+      return this.createNewSketch(newSketchName);
+    }
+
+    if (result) {
+      return this.open(treeModel, result);
+    }
+    return undefined;
+  }
+
+  private async open(
+    treeModel: CloudSketchbookTreeModel,
+    newSketch: Create.Sketch
+  ): Promise<URI | undefined> {
+    const id = CreateUri.toUri(newSketch).path.toString();
+    const node = treeModel.getNode(id);
+    if (!node) {
+      throw new Error(
+        `Could not find remote sketchbook tree node with Tree node ID: ${id}.`
+      );
+    }
+    if (!CloudSketchbookTree.CloudSketchDirNode.is(node)) {
+      throw new Error(
+        `Remote sketchbook tree node expected to represent a directory but it did not. Tree node ID: ${id}.`
+      );
+    }
+    try {
+      await treeModel.sketchbookTree().pull({ node });
+    } catch (err) {
+      if (isNotFound(err)) {
+        await treeModel.refresh();
+        this.messageService.error(
+          nls.localize(
+            'arduino/newCloudSketch/notFound',
+            "Could not pull the remote sketch '{0}'. It does not exist.",
+            newSketch.name
+          )
+        );
+        return undefined;
+      }
+      throw err;
+    }
+    return this.commandService.executeCommand(
+      SketchbookCommands.OPEN_NEW_WINDOW.id,
+      { node }
+    );
+  }
+
+  private treeModelFrom(
+    widget: SketchbookWidget
+  ): CloudSketchbookTreeModel | undefined {
+    const treeWidget = widget.getTreeWidget();
+    if (treeWidget instanceof CloudSketchbookTreeWidget) {
+      const model = treeWidget.model;
+      if (model instanceof CloudSketchbookTreeModel) {
+        return model;
+      }
+    }
+    return undefined;
+  }
+
+  private async newSketchName(
+    rootNode: CompositeTreeNode,
+    initialValue?: string | undefined
+  ): Promise<string | undefined> {
+    const existingNames = rootNode.children
+      .filter(CloudSketchbookTree.CloudSketchDirNode.is)
+      .map(({ fileStat }) => fileStat.name);
+    return new WorkspaceInputDialog(
+      {
+        title: nls.localize(
+          'arduino/newCloudSketch/newSketchTitle',
+          'Name of a new Remote Sketch'
+        ),
+        parentUri: CreateUri.root,
+        initialValue,
+        validate: (input) => {
+          if (existingNames.includes(input)) {
+            return nls.localize(
+              'arduino/newCloudSketch/sketchAlreadyExists',
+              "Remote sketch '{0}' already exists.",
+              input
+            );
+          }
+          // This is how https://create.arduino.cc/editor/ works when renaming a sketch.
+          if (/^[0-9a-zA-Z_]{1,36}$/.test(input)) {
+            return '';
+          }
+          return nls.localize(
+            'arduino/newCloudSketch/invalidSketchName',
+            'The name must consist of basic letters, numbers, or underscores. The maximum length is 36 characters.'
+          );
+        },
+      },
+      this.labelProvider
+    ).open();
+  }
+}
+export namespace NewCloudSketch {
+  export namespace Commands {
+    export const NEW_CLOUD_SKETCH: Command = {
+      id: 'arduino-new-cloud-sketch',
+    };
+  }
+}
+
+function isConflict(err: unknown): boolean {
+  return isErrorWithStatusOf(err, 409);
+}
+function isNotFound(err: unknown): boolean {
+  return isErrorWithStatusOf(err, 404);
+}
+function isErrorWithStatusOf(
+  err: unknown,
+  status: number
+): err is Error & { status: number } {
+  if (err instanceof Error) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const object = err as any;
+    return 'status' in object && object.status === status;
+  }
+  return false;
+}

--- a/arduino-ide-extension/src/browser/contributions/new-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/new-sketch.ts
@@ -21,7 +21,7 @@ export class NewSketch extends SketchContribution {
   override registerMenus(registry: MenuModelRegistry): void {
     registry.registerMenuAction(ArduinoMenus.FILE__SKETCH_GROUP, {
       commandId: NewSketch.Commands.NEW_SKETCH.id,
-      label: nls.localize('arduino/sketch/new', 'New'),
+      label: nls.localize('arduino/sketch/new', 'New Sketch'),
       order: '0',
     });
   }

--- a/arduino-ide-extension/src/browser/contributions/open-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch.ts
@@ -54,7 +54,7 @@ export class OpenSketch extends SketchContribution {
     registry.registerMenuAction(ArduinoMenus.FILE__SKETCH_GROUP, {
       commandId: OpenSketch.Commands.OPEN_SKETCH.id,
       label: nls.localize('vscode/workspaceActions/openFileFolder', 'Open...'),
-      order: '1',
+      order: '2',
     });
   }
 

--- a/arduino-ide-extension/src/browser/contributions/save-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/save-sketch.ts
@@ -24,7 +24,7 @@ export class SaveSketch extends SketchContribution {
     registry.registerMenuAction(ArduinoMenus.FILE__SKETCH_GROUP, {
       commandId: SaveSketch.Commands.SAVE_SKETCH.id,
       label: nls.localize('vscode/fileCommands/save', 'Save'),
-      order: '6',
+      order: '7',
     });
   }
 

--- a/arduino-ide-extension/src/browser/create/create-uri.ts
+++ b/arduino-ide-extension/src/browser/create/create-uri.ts
@@ -7,7 +7,9 @@ export namespace CreateUri {
   export const scheme = 'arduino-create';
   export const root = toUri(posix.sep);
 
-  export function toUri(posixPathOrResource: string | Create.Resource): URI {
+  export function toUri(
+    posixPathOrResource: string | Create.Resource | Create.Sketch
+  ): URI {
     const posixPath =
       typeof posixPathOrResource === 'string'
         ? posixPathOrResource

--- a/arduino-ide-extension/src/browser/local-cache/local-cache-fs-provider.ts
+++ b/arduino-ide-extension/src/browser/local-cache/local-cache-fs-provider.ts
@@ -34,7 +34,6 @@ export class LocalCacheFsProvider
   @inject(AuthenticationClientService)
   protected readonly authenticationService: AuthenticationClientService;
 
-  // TODO: do we need this? Cannot we `await` on the `init` call from `registerFileSystemProviders`?
   readonly ready = new Deferred<void>();
 
   private _localCacheRoot: URI;
@@ -153,7 +152,7 @@ export class LocalCacheFsProvider
     return uri;
   }
 
-  private toUri(session: AuthenticationSession): URI {
+  toUri(session: AuthenticationSession): URI {
     // Hack: instead of getting the UUID only, we get `auth0|UUID` after the authentication. `|` cannot be part of filesystem path or filename.
     return this._localCacheRoot.resolve(session.id.split('|')[1]);
   }

--- a/arduino-ide-extension/src/browser/style/dialogs.css
+++ b/arduino-ide-extension/src/browser/style/dialogs.css
@@ -80,10 +80,8 @@
     opacity: .4;
 }
 
-
 @media only screen and (max-height: 560px) {
     .p-Widget.dialogOverlay .dialogBlock {
         max-height: 400px;
     }
 }
-    

--- a/arduino-ide-extension/src/browser/style/sketchbook.css
+++ b/arduino-ide-extension/src/browser/style/sketchbook.css
@@ -33,6 +33,22 @@
   height: 100%;
 }
 
+.sketchbook-trees-container .create-new {
+  min-height: 58px;
+  height: 58px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+/*
+By default, theia-button has a left-margin. IDE2 does not need the left margin
+for the _New Remote? Sketch_. Otherwise, the button does not fit the default
+widget width.
+*/
+.sketchbook-trees-container .create-new .theia-button {
+  margin-left: unset;
+}
+
 .sketchbook-tree__opts {
   background-color: var(--theia-foreground);
   -webkit-mask: url(./sketchbook-opts-icon.svg);

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree-widget.tsx
@@ -1,5 +1,5 @@
 import * as React from '@theia/core/shared/react';
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { TreeModel } from '@theia/core/lib/browser/tree/tree-model';
 import { CloudSketchbookTreeModel } from './cloud-sketchbook-tree-model';
 import { AuthenticationClientService } from '../../auth/authentication-client-service';
@@ -26,12 +26,6 @@ export class CloudSketchbookTreeWidget extends SketchbookTreeWidget {
 
   @inject(CloudSketchbookTree)
   protected readonly cloudSketchbookTree: CloudSketchbookTree;
-
-  @postConstruct()
-  protected override async init(): Promise<void> {
-    await super.init();
-    this.addClass('tree-container'); // Adds `height: 100%` to the tree. Otherwise you cannot see it.
-  }
 
   protected override renderTree(model: TreeModel): React.ReactNode {
     if (this.shouldShowWelcomeView()) return this.renderViewWelcome();

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-tree.ts
@@ -136,7 +136,7 @@ export class CloudSketchbookTree extends SketchbookTree {
         return;
       }
     }
-    this.runWithState(node, 'pulling', async (node) => {
+    return this.runWithState(node, 'pulling', async (node) => {
       const commandsCopy = node.commands;
       node.commands = [];
 
@@ -196,7 +196,7 @@ export class CloudSketchbookTree extends SketchbookTree {
         return;
       }
     }
-    this.runWithState(node, 'pushing', async (node) => {
+    return this.runWithState(node, 'pushing', async (node) => {
       if (!CloudSketchbookTree.CloudSketchTreeNode.isSynced(node)) {
         throw new Error(
           nls.localize(
@@ -269,7 +269,7 @@ export class CloudSketchbookTree extends SketchbookTree {
         return prev;
       }
 
-      // do not map "do_not_sync" files/directoris and their descendants
+      // do not map "do_not_sync" files/directories and their descendants
       const segments = path[1].split(posix.sep) || [];
       if (
         segments.some((segment) => Create.do_not_sync_files.includes(segment))

--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-widget.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketchbook-widget.ts
@@ -2,6 +2,7 @@ import { inject, injectable, postConstruct } from '@theia/core/shared/inversify'
 import { CloudSketchbookCompositeWidget } from './cloud-sketchbook-composite-widget';
 import { SketchbookWidget } from '../sketchbook/sketchbook-widget';
 import { ArduinoPreferences } from '../../arduino-preferences';
+import { BaseSketchbookCompositeWidget } from '../sketchbook/sketchbook-composite-widget';
 
 @injectable()
 export class CloudSketchbookWidget extends SketchbookWidget {
@@ -19,8 +20,8 @@ export class CloudSketchbookWidget extends SketchbookWidget {
   override getTreeWidget(): any {
     const widget: any = this.sketchbookTreesContainer.selectedWidgets().next();
 
-    if (widget && typeof widget.getTreeWidget !== 'undefined') {
-      return (widget as CloudSketchbookCompositeWidget).getTreeWidget();
+    if (widget instanceof BaseSketchbookCompositeWidget) {
+      return widget.treeWidget;
     }
     return widget;
   }
@@ -30,7 +31,7 @@ export class CloudSketchbookWidget extends SketchbookWidget {
       this.sketchbookTreesContainer.activateWidget(this.widget);
     } else {
       this.sketchbookTreesContainer.activateWidget(
-        this.localSketchbookTreeWidget
+        this.sketchbookCompositeWidget
       );
     }
     this.setDocumentMode();

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/create-new.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/create-new.tsx
@@ -1,0 +1,20 @@
+import * as React from '@theia/core/shared/react';
+
+export class CreateNew extends React.Component<CreateNew.Props> {
+  override render(): React.ReactNode {
+    return (
+      <div className="create-new">
+        <button className="theia-button secondary" onClick={this.props.onClick}>
+          {this.props.label}
+        </button>
+      </div>
+    );
+  }
+}
+
+export namespace CreateNew {
+  export interface Props {
+    readonly label: string;
+    readonly onClick: () => void;
+  }
+}

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-composite-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-composite-widget.tsx
@@ -1,0 +1,93 @@
+import * as React from '@theia/core/shared/react';
+import * as ReactDOM from '@theia/core/shared/react-dom';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { nls } from '@theia/core/lib/common/nls';
+import { Widget } from '@theia/core/shared/@phosphor/widgets';
+import { Message, MessageLoop } from '@theia/core/shared/@phosphor/messaging';
+import { Disposable } from '@theia/core/lib/common/disposable';
+import { BaseWidget } from '@theia/core/lib/browser/widgets/widget';
+import { CommandService } from '@theia/core/lib/common/command';
+import { SketchbookTreeWidget } from './sketchbook-tree-widget';
+import { CreateNew } from '../sketchbook/create-new';
+
+@injectable()
+export abstract class BaseSketchbookCompositeWidget<
+  TW extends SketchbookTreeWidget
+> extends BaseWidget {
+  @inject(CommandService)
+  protected readonly commandService: CommandService;
+
+  private readonly compositeNode: HTMLElement;
+  private readonly footerNode: HTMLElement;
+
+  constructor() {
+    super();
+    this.compositeNode = document.createElement('div');
+    this.compositeNode.classList.add('composite-node');
+    this.footerNode = document.createElement('div');
+    this.footerNode.classList.add('footer-node');
+    this.compositeNode.appendChild(this.footerNode);
+    this.node.appendChild(this.compositeNode);
+    this.title.closable = false;
+  }
+
+  abstract get treeWidget(): TW;
+  protected abstract renderFooter(footerNode: HTMLElement): void;
+  protected updateFooter(): void {
+    this.renderFooter(this.footerNode);
+  }
+
+  protected override onAfterAttach(message: Message): void {
+    super.onAfterAttach(message);
+    Widget.attach(this.treeWidget, this.compositeNode);
+    this.renderFooter(this.footerNode);
+    this.toDisposeOnDetach.push(
+      Disposable.create(() => Widget.detach(this.treeWidget))
+    );
+  }
+
+  protected override onActivateRequest(message: Message): void {
+    super.onActivateRequest(message);
+    // Sending a resize message is needed because otherwise the tree widget would render empty
+    this.onResize(Widget.ResizeMessage.UnknownSize);
+  }
+
+  protected override onResize(message: Widget.ResizeMessage): void {
+    super.onResize(message);
+    MessageLoop.sendMessage(this.treeWidget, Widget.ResizeMessage.UnknownSize);
+  }
+}
+
+@injectable()
+export class SketchbookCompositeWidget extends BaseSketchbookCompositeWidget<SketchbookTreeWidget> {
+  @inject(SketchbookTreeWidget)
+  private readonly sketchbookTreeWidget: SketchbookTreeWidget;
+
+  constructor() {
+    super();
+    this.id = 'sketchbook-composite-widget';
+    this.title.caption = nls.localize(
+      'arduino/sketch/titleLocalSketchbook',
+      'Local Sketchbook'
+    );
+    this.title.iconClass = 'sketchbook-tree-icon';
+  }
+
+  get treeWidget(): SketchbookTreeWidget {
+    return this.sketchbookTreeWidget;
+  }
+
+  protected renderFooter(footerNode: HTMLElement): void {
+    ReactDOM.render(
+      <CreateNew
+        label={nls.localize('arduino/sketchbook/newSketch', 'New Sketch')}
+        onClick={this.onDidClickCreateNew}
+      />,
+      footerNode
+    );
+  }
+
+  private onDidClickCreateNew: () => void = () => {
+    this.commandService.executeCommand('arduino-new-sketch');
+  };
+}

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
@@ -59,6 +59,7 @@ export class SketchbookTreeWidget extends FileTreeWidget {
       'Local Sketchbook'
     );
     this.title.closable = false;
+    this.addClass('tree-container'); // Adds `height: 100%` to the tree. Otherwise you cannot see it.
   }
 
   @postConstruct()

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget.tsx
@@ -11,15 +11,21 @@ import { Disposable } from '@theia/core/lib/common/disposable';
 import { BaseWidget } from '@theia/core/lib/browser/widgets/widget';
 import { SketchbookTreeWidget } from './sketchbook-tree-widget';
 import { nls } from '@theia/core/lib/common';
-import { CloudSketchbookCompositeWidget } from '../cloud-sketchbook/cloud-sketchbook-composite-widget';
 import { URI } from '../../contributions/contribution';
+import {
+  BaseSketchbookCompositeWidget,
+  SketchbookCompositeWidget,
+} from './sketchbook-composite-widget';
 
 @injectable()
 export class SketchbookWidget extends BaseWidget {
-  static LABEL = nls.localize('arduino/sketch/titleSketchbook', 'Sketchbook');
+  static readonly LABEL = nls.localize(
+    'arduino/sketch/titleSketchbook',
+    'Sketchbook'
+  );
 
-  @inject(SketchbookTreeWidget)
-  protected readonly localSketchbookTreeWidget: SketchbookTreeWidget;
+  @inject(SketchbookCompositeWidget)
+  protected readonly sketchbookCompositeWidget: SketchbookCompositeWidget;
 
   protected readonly sketchbookTreesContainer: DockPanel;
 
@@ -36,7 +42,7 @@ export class SketchbookWidget extends BaseWidget {
 
   @postConstruct()
   protected init(): void {
-    this.sketchbookTreesContainer.addWidget(this.localSketchbookTreeWidget);
+    this.sketchbookTreesContainer.addWidget(this.sketchbookCompositeWidget);
   }
 
   protected override onAfterAttach(message: Message): void {
@@ -48,7 +54,7 @@ export class SketchbookWidget extends BaseWidget {
   }
 
   getTreeWidget(): SketchbookTreeWidget {
-    return this.localSketchbookTreeWidget;
+    return this.sketchbookCompositeWidget.treeWidget;
   }
 
   activeTreeWidgetId(): string | undefined {
@@ -80,8 +86,8 @@ export class SketchbookWidget extends BaseWidget {
       if (widget instanceof SketchbookTreeWidget) {
         return widget;
       }
-      if (widget instanceof CloudSketchbookCompositeWidget) {
-        return widget.getTreeWidget();
+      if (widget instanceof BaseSketchbookCompositeWidget) {
+        return widget.treeWidget;
       }
       return undefined;
     };

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -119,6 +119,9 @@
       "syncEditSketches": "Sync and edit your Arduino Cloud Sketches",
       "visitArduinoCloud": "Visit Arduino Cloud to create Cloud Sketches."
     },
+    "cloudSketch": {
+      "new": "New Remote Sketch"
+    },
     "common": {
       "all": "All",
       "contributed": "Contributed",
@@ -299,6 +302,12 @@
       "unableToCloseWebSocket": "Unable to close websocket",
       "unableToConnectToWebSocket": "Unable to connect to websocket"
     },
+    "newCloudSketch": {
+      "invalidSketchName": "The name must consist of basic letters, numbers, or underscores. The maximum length is 36 characters.",
+      "newSketchTitle": "Name of a new Remote Sketch",
+      "notFound": "Could not pull the remote sketch '{0}'. It does not exist.",
+      "sketchAlreadyExists": "Remote sketch '{0}' already exists."
+    },
     "portProtocol": {
       "network": "Network",
       "serial": "Serial"
@@ -388,7 +397,7 @@
       "exportBinary": "Export Compiled Binary",
       "moving": "Moving",
       "movingMsg": "The file \"{0}\" needs to be inside a sketch folder named \"{1}\".\nCreate this folder, move the file, and continue?",
-      "new": "New",
+      "new": "New Sketch",
       "openFolder": "Open Folder",
       "openRecent": "Open Recent",
       "openSketchInNewWindow": "Open Sketch in New Window",
@@ -406,6 +415,10 @@
       "userFieldsNotFoundError": "Can't find user fields for connected board",
       "verify": "Verify",
       "verifyOrCompile": "Verify/Compile"
+    },
+    "sketchbook": {
+      "newRemoteSketch": "New Remote Sketch",
+      "newSketch": "New Sketch"
     },
     "survey": {
       "answerSurvey": "Answer survey",


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To create a remote sketch from IDE2 without opening https://create.arduino.cc/editor in a browser.

### Change description
<!-- What does your code do? -->

 - `File` > `New` has been renamed to `File` > `New Sketch`.
 - New menu item to create a remote sketch from IDE2: `File` > `New Remote Sketch`.
    <img width="215" alt="Screen Shot 2022-10-31 at 16 09 17" src="https://user-images.githubusercontent.com/1405703/199042079-30fb59f5-17c5-4ad4-ab6a-9cc5001b9212.png">
    - If not signed into Arduino Cloud, the menu item is disabled.
        <img width="340" alt="Screen Shot 2022-10-31 at 16 13 47" src="https://user-images.githubusercontent.com/1405703/199042451-8d8b00fc-6a7d-40b5-83c0-7e6bed297ce6.png">
    - If the _Remote Sketchbook_ is hidden, the menu item is not visible. (`Advanced` > `Show/Hide Remote Sketchbook` or `"arduino.cloud.enabled": false` in `settings.json`)
        <img width="568" alt="Screen Shot 2022-10-31 at 16 17 44" src="https://user-images.githubusercontent.com/1405703/199043332-e27d7311-5052-46f1-b3f9-f2b012d20ef6.png">
 - Can create a new sketch from the sketchbook.

    https://user-images.githubusercontent.com/1405703/199044937-c482cb79-d827-4ecc-8e79-371a97b568fc.mp4
 - When logged in to Arduino Cloud and the _Remote Sketchbook_ is not hidden, can create a new remote sketch from the Sketchbook.
 
    https://user-images.githubusercontent.com/1405703/199046522-ba14d353-b954-4237-9135-032577720fee.mp4
 - Remote sketch creation gracefully handles conflicts (HTTP 409)

    https://user-images.githubusercontent.com/1405703/199047963-d63fe099-6e74-4053-b583-f22bacb9ec0f.mp4

 - ~After creating the new remote sketch, IDE2 asks if the sketch has to be pulled and opened in a new window.~
 
    <!-- <img width="619" alt="Screen Shot 2022-10-31 at 16 40 10" src="https://user-images.githubusercontent.com/1405703/199048786-4703efdf-ff2b-479b-94cd-c4ad1939d0a0.png"> -->

   - ~`Yes` will pull the remote sketch content and open the sketch in a new window.~
   - ~Select `Always` if you want to pull the remote sketch automatically and open it in a new window.~
   - ~Select `Never` to never do anything automatically after the remote sketch creation. Don't worry, you can still pull your sketch manually and open it.~
   - ~You can re-configure the behavior of the notification by tuning the new `arduino.cloud.sketchOpenStrategy` [advanced setting](https://github.com/arduino/arduino-ide/blob/main/docs/advanced-usage.md). The possible values are `"Ask"`, `"Never"`, and `"Always"`. The default is `"Ask"`.~
        <!-- <img width="357" alt="Screen Shot 2022-10-31 at 16 49 39" src="https://user-images.githubusercontent.com/1405703/199050596-555545e3-8e7a-48aa-91fa-d741006b5efb.png"> -->
 - After creating the new remote sketch, IDE2 pulls and opens it in a new window.
 - After the remote sketch creation, IDE2 pulls the content, opens the new window, and reveals the sketch in the _Remote Sketchbook_ widget.

    https://user-images.githubusercontent.com/1405703/199052586-08b28a54-3241-4387-8072-991a183fa498.mp4
 - Handles gracefully when there is a mid-air deletion before the pull and open.

    https://user-images.githubusercontent.com/1405703/199054133-da5b920c-6bcd-49da-9a8c-ca969067fced.mp4

### Other information
<!-- Any additional information that could help the review process -->

Closes #1580

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)