### PR TITLE
bump arduino-fwuploader to `2.2.2`

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -162,7 +162,7 @@
       "version": "0.28.0"
     },
     "fwuploader": {
-      "version": "2.2.0"
+      "version": "2.2.2"
     },
     "clangd": {
       "version": "14.0.0"


### PR DESCRIPTION
### Motivation
Bump `arduino-fwuploader` to version [`2.2.2`](https://github.com/arduino/arduino-fwuploader/releases/tag/2.2.2)

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)