### PR TITLE
Migrate workflows from deprecated `set-output` commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
           OUTPUT_SAFE_BODY="${BODY//'%'/'%25'}"
           OUTPUT_SAFE_BODY="${OUTPUT_SAFE_BODY//$'\n'/'%0A'}"
           OUTPUT_SAFE_BODY="${OUTPUT_SAFE_BODY//$'\r'/'%0D'}"
-          echo "::set-output name=BODY::$OUTPUT_SAFE_BODY"
+          echo "BODY=$OUTPUT_SAFE_BODY" >> $GITHUB_OUTPUT
           echo "$BODY" > CHANGELOG.txt
 
       - name: Upload Changelog [GitHub Actions]
@@ -228,7 +228,7 @@ jobs:
       - name: Get Tag
         id: tag_name
         run: |
-          echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
+          echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Publish Release [GitHub]
         uses: svenstaro/upload-release-action@2.3.0

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -108,7 +108,7 @@ jobs:
           echo "Certificate expiration date: $EXPIRATION_DATE"
           echo "Days remaining before expiration: $DAYS_BEFORE_EXPIRATION"
 
-          echo "::set-output name=days::$DAYS_BEFORE_EXPIRATION"
+          echo "days=$DAYS_BEFORE_EXPIRATION" >> $GITHUB_OUTPUT
 
       - name: Check if expiration notification period has been reached
         id: check-expiration

--- a/.github/workflows/compose-full-changelog.yml
+++ b/.github/workflows/compose-full-changelog.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Get Tag
         id: tag_name
         run: |
-          echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
+          echo "TAG_NAME=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
       - name: Create full changelog
         id: full-changelog

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           # Use of this flag in the github-label-sync command will cause it to only check the validity of the
           # configuration.
-          echo "::set-output name=flag::--dry-run"
+          echo "flag=--dry-run" >> $GITHUB_OUTPUT
 
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
### Motivation

GitHub Actions provides the capability for workflow authors to use the capabilities of the GitHub Actions ToolKit package directly in the `run` keys of workflows via "[workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions)". One such command is `set-output`, which allows data to be passed out of a workflow step as an output.

It has been determined that this command has potential to be a security risk in some applications. For this reason, GitHub has deprecated the command and a warning of this is shown in the workflow run summary page of any workflow using it:

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

The identical capability is now provided in a safer form via the GitHub Actions "[environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files)" system.

### Change description

Migrate the use of the deprecated workflow commands to use the `GITHUB_OUTPUT` environment file to fix any potential vulnerabilities in the workflows, resolve the warnings, and avoid the eventual complete breakage of the workflows that would result from [GitHub's planned removal of the `set-output` workflow command 2023-05-31](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#:~:text=fully%20disable%20them%20on%2031st%20May%202023.).

### Other information

Upstream migration of the "template" workflows: https://github.com/arduino/tooling-project-assets/pull/281

Equivalent migration for Arduino CLI repository: https://github.com/arduino/arduino-cli/pull/1940

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)