### PR TITLE
Configure Dependabot to check for outdated actions used in workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/assets/dependabot/README.md
+  # See: https://docs.github.com/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    assignees:
+      - per1234
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"


### PR DESCRIPTION
### Motivation

[GitHub Actions workflows](https://docs.github.com/actions/using-workflows/about-workflows) are an important part of this project's infrastructure.

[GitHub Actions actions](https://docs.github.com/actions/learn-github-actions/understanding-github-actions#actions) are used for common tasks in these workflows. The workflows specify a Git ref from the action's repository to indicate which version of the action should be used. These refs have not been maintained, resulting in significantly outdated versions of some actions being used by the workflows.

GitHub is now deprecating the use of the Node.js 12.x runtime by actions:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Some of the outdated action versions in use are configured to use this deprecated Node.js. That currently produces warnings on the workflow run summary page, but would eventually result in the complete breakage of the workflows.

[Dependabot](https://docs.github.com/en/code-security/dependabot) is the most efficient way to maintain the action dependencies of GitHub Actions workflows, and is already in use for this purpose in >100 of Arduino's repositories.

### Change description

Configure Dependabot to periodically check the versions of all actions used in the repository's workflows. If any are found to be outdated, it will submit a pull request to update them.

### Other information

NOTE: Dependabot's PRs will occasionally propose to pin to the patch version of the action (e.g., updating `uses: foo/bar@v1` to `uses: foo/bar@v2.3.4`). When the action author has [provided a major version ref](https://docs.github.com/actions/creating-actions/about-custom-actions#using-release-management-for-actions), use that instead (e.g., `uses: foo/bar@v2`). Once the major version has been updated in the workflow, Dependabot should not submit an update PR again until the next major version bump.

So even when the PRs from Dependabot are not exactly correct, they still have value in bringing the maintainer's attention to the fact that the action version in use is outdated. Dependabot will automatically close its PR once the workflow has been updated.

More information:
https://docs.github.com/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)