### PR TITLE
fix: Handle gracefully when trying to detect invalid sketch name error and folder is missing on filesystem

### DIFF
--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -28,6 +28,7 @@ import {
   SHOW_PLOTTER_WINDOW,
 } from '../../common/ipc-communication';
 import isValidPath = require('is-valid-path');
+import { ErrnoException } from '../../node/utils/errors';
 
 app.commandLine.appendSwitch('disable-http-cache');
 
@@ -172,7 +173,7 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
     try {
       stats = await fs.stat(path);
     } catch (err) {
-      if ('code' in err && err.code === 'ENOENT') {
+      if (ErrnoException.isENOENT(err)) {
         return undefined;
       }
       throw err;
@@ -215,7 +216,7 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
       const resolved = await fs.realpath(resolve(cwd, maybePath));
       return resolved;
     } catch (err) {
-      if ('code' in err && err.code === 'ENOENT') {
+      if (ErrnoException.isENOENT(err)) {
         return undefined;
       }
       throw err;

--- a/arduino-ide-extension/src/node/arduino-daemon-impl.ts
+++ b/arduino-ide-extension/src/node/arduino-daemon-impl.ts
@@ -16,6 +16,7 @@ import { BackendApplicationContribution } from '@theia/core/lib/node/backend-app
 import { ArduinoDaemon, NotificationServiceServer } from '../common/protocol';
 import { CLI_CONFIG } from './cli-config';
 import { getExecPath, spawnCommand } from './exec-util';
+import { ErrnoException } from './utils/errors';
 
 @injectable()
 export class ArduinoDaemonImpl
@@ -184,7 +185,7 @@ export class ArduinoDaemonImpl
       }
       return false;
     } catch (error) {
-      if ('code' in error && error.code === 'ENOENT') {
+      if (ErrnoException.isENOENT(error)) {
         return false;
       }
       throw error;

--- a/arduino-ide-extension/src/node/config-service-impl.ts
+++ b/arduino-ide-extension/src/node/config-service-impl.ts
@@ -26,6 +26,7 @@ import { DefaultCliConfig, CLI_CONFIG } from './cli-config';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { deepClone } from '@theia/core';
+import { ErrnoException } from './utils/errors';
 
 const deepmerge = require('deepmerge');
 
@@ -146,7 +147,7 @@ export class ConfigServiceImpl
       const fallbackModel = await this.getFallbackCliConfig();
       return deepmerge(fallbackModel, model) as DefaultCliConfig;
     } catch (error) {
-      if ('code' in error && error.code === 'ENOENT') {
+      if (ErrnoException.isENOENT(error)) {
         if (initializeIfAbsent) {
           await this.initCliConfigTo(dirname(cliConfigPath));
           return this.loadCliConfig(false);

--- a/arduino-ide-extension/src/node/sketches-service-impl.ts
+++ b/arduino-ide-extension/src/node/sketches-service-impl.ts
@@ -33,6 +33,7 @@ import {
   TempSketchPrefix,
 } from './is-temp-sketch';
 import { join } from 'path';
+import { ErrnoException } from './utils/errors';
 
 const RecentSketches = 'recent-sketches.json';
 const DefaultIno = `void setup() {
@@ -278,7 +279,7 @@ export class SketchesServiceImpl
         );
       }
     } catch (err) {
-      if ('code' in err && err.code === 'ENOENT') {
+      if (ErrnoException.isENOENT(err)) {
         this.logger.debug(
           `<<< '${RecentSketches}' does not exist yet. This is normal behavior. Falling back to empty data.`
         );
@@ -666,7 +667,7 @@ export class SketchesServiceImpl
 
       return this.tryParse(raw);
     } catch (err) {
-      if ('code' in err && err.code === 'ENOENT') {
+      if (ErrnoException.isENOENT(err)) {
         return undefined;
       }
       throw err;
@@ -695,7 +696,7 @@ export class SketchesServiceImpl
             });
             this.inoContent.resolve(inoContent);
           } catch (err) {
-            if ('code' in err && err.code === 'ENOENT') {
+            if (ErrnoException.isENOENT(err)) {
               // Ignored. The custom `.ino` blueprint file is optional.
             } else {
               throw err;
@@ -763,7 +764,7 @@ async function isInvalidSketchNameError(
             .map((name) => path.join(requestSketchPath, name))[0]
         );
       } catch (err) {
-        if ('code' in err && err.code === 'ENOTDIR') {
+        if (ErrnoException.isENOENT(err) || ErrnoException.isENOTDIR(err)) {
           return undefined;
         }
         throw err;

--- a/arduino-ide-extension/src/node/utils/errors.ts
+++ b/arduino-ide-extension/src/node/utils/errors.ts
@@ -1,0 +1,34 @@
+export type ErrnoException = Error & { code: string; errno: number };
+export namespace ErrnoException {
+  export function is(arg: unknown): arg is ErrnoException {
+    if (arg instanceof Error) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const error = arg as any;
+      return (
+        'code' in error &&
+        'errno' in error &&
+        typeof error['code'] === 'string' &&
+        typeof error['errno'] === 'number'
+      );
+    }
+    return false;
+  }
+
+  /**
+   *  (No such file or directory): Commonly raised by `fs` operations to indicate that a component of the specified pathname does not exist — no entity (file or directory) could be found by the given path.
+   */
+  export function isENOENT(
+    arg: unknown
+  ): arg is ErrnoException & { code: 'ENOENT' } {
+    return is(arg) && arg.code === 'ENOENT';
+  }
+
+  /**
+   * (Not a directory): A component of the given pathname existed, but was not a directory as expected. Commonly raised by `fs.readdir`.
+   */
+  export function isENOTDIR(
+    arg: unknown
+  ): arg is ErrnoException & { code: 'ENOTDIR' } {
+    return is(arg) && arg.code === 'ENOTDIR';
+  }
+}

--- a/scripts/i18n/transifex-pull.js
+++ b/scripts/i18n/transifex-pull.js
@@ -54,7 +54,7 @@ const requestTranslationDownload = async (relationships) => {
 
 const getTranslationDownloadStatus = async (language, downloadRequestId) => {
     // The download request status must be asked from time to time, if it's
-    // still pending we try again using exponentional backoff starting from 2.5 seconds.
+    // still pending we try again using exponential backoff starting from 2.5 seconds.
     let backoffMs = 2500;
     while (true) {
         const url = transifex.url(


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To fix missing `Open Recent` menu items in IDE2 when `~/arduinoIDE/recent-sketches.json` contains non-existing sketches.

### Change description
<!-- What does your code do? -->
The PR consists of three noteworthy changes:
 - IDE2 gracefully handles `ENOENT` (No such file or directory) error when trying to detect if the `NotFound` error received from the CLI is an _"invalid sketch name"_ error.  See: #1563.
 - Generalized `ErrnoException`([`errno(3)`](https://man7.org/linux/man-pages/man3/errno.3.html)) detection in IDE2.
 - Relaxed when IDE2 tries to detect the _"invalid sketch name"_ error. IDE2 must access the filesystem to detect this error. From now on, the special error detection code must be explicitly requested by clients. This change does not affect IDE2's service APIs and recovery behavior. Still, for example, when populating the `Open Recent` menus, it does not matter if the missing sketch was deleted or (incorrectly) renamed by the user. Hence the special error detection code does not run.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1596

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)