### PR TITLE
fix: avoid ENOTDIR when opening second instance. 

### DIFF
--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -355,10 +355,7 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
     argv: string[],
     cwd: string
   ): Promise<void> {
-    if (
-      !os.isOSX &&
-      (await this.launchFromArgs({ cwd, argv, secondInstance: true }))
-    ) {
+    if (await this.launchFromArgs({ cwd, argv, secondInstance: true })) {
       // Application has received a file in its arguments
       return;
     }

--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -180,8 +180,8 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
     if (!stats) {
       return undefined;
     }
-    if (stats.isFile() && path.endsWith('.ino')) {
-      return path;
+    if (stats.isFile()) {
+      return path.endsWith('.ino') ? path : undefined;
     }
     try {
       const entries = await fs.readdir(path, { withFileTypes: true });


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To allow opening a second sketch from the command line.

### Change description
<!-- What does your code do? -->

 - Fix incorrect logic when detecting if the arg is a valid sketch,
 - Allow opening a second instance on macOS.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1590

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)