### PR TITLE
fix: relaxed condition to check if resource exists

### DIFF
--- a/arduino-ide-extension/src/node/sketches-service-impl.ts
+++ b/arduino-ide-extension/src/node/sketches-service-impl.ts
@@ -647,7 +647,7 @@ export class SketchesServiceImpl
 
   private async exists(pathLike: string): Promise<boolean> {
     try {
-      await fs.access(pathLike, constants.R_OK | constants.W_OK);
+      await fs.access(pathLike, constants.R_OK);
       return true;
     } catch {
       return false;


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To open built-in examples from an AppImage.

### Change description
<!-- What does your code do? -->

Relaxed the condition to check if a resource exists.
The original (`fs-extra`-based) implementation did not check if the file is writable either.
Resources are not writable in mounted AppImages.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1586

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)