### PR TITLE
fix: escaped regex chars in pattern

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -45,7 +45,6 @@
     "@types/deepmerge": "^2.2.0",
     "@types/glob": "^7.2.0",
     "@types/google-protobuf": "^3.7.2",
-    "@types/is-valid-path": "^0.1.0",
     "@types/js-yaml": "^3.12.2",
     "@types/keytar": "^4.4.0",
     "@types/lodash.debounce": "^4.0.6",

--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -27,7 +27,6 @@ import {
   CLOSE_PLOTTER_WINDOW,
   SHOW_PLOTTER_WINDOW,
 } from '../../common/ipc-communication';
-import isValidPath = require('is-valid-path');
 import { ErrnoException } from '../../node/utils/errors';
 
 app.commandLine.appendSwitch('disable-http-cache');
@@ -206,9 +205,6 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
     maybePath: string,
     cwd: string
   ): Promise<string | undefined> {
-    if (!isValidPath(maybePath)) {
-      return undefined;
-    }
     if (isAbsolute(maybePath)) {
       return maybePath;
     }

--- a/arduino-ide-extension/src/node/sketches-service-impl.ts
+++ b/arduino-ide-extension/src/node/sketches-service-impl.ts
@@ -26,6 +26,7 @@ import {
   LoadSketchRequest,
 } from './cli-protocol/cc/arduino/cli/commands/v1/commands_pb';
 import { Deferred } from '@theia/core/lib/common/promise-util';
+import { escapeRegExpCharacters } from '@theia/core/lib/common/strings';
 import { ServiceError } from './service-error';
 import {
   IsTempSketch,
@@ -158,7 +159,7 @@ export class SketchesServiceImpl
       const sketchName = segments[segments.length - 2];
       const sketchFilename = segments[segments.length - 1];
       const sketchFileExtension = segments[segments.length - 1].replace(
-        new RegExp(sketchName),
+        new RegExp(escapeRegExpCharacters(sketchName)),
         ''
       );
       if (sketchFileExtension !== '.ino' && sketchFileExtension !== '.pde') {
@@ -746,10 +747,12 @@ async function isInvalidSketchNameError(
     if (ino) {
       const sketchFolderPath = path.dirname(requestSketchPath);
       const sketchName = path.basename(sketchFolderPath);
-      const pattern = `${invalidSketchNameErrorRegExpPrefix}${path.join(
-        sketchFolderPath,
-        `${sketchName}.ino`
-      )}`.replace(/\\/g, '\\\\'); // make windows path separator with \\ to have a valid regexp.
+      const pattern = escapeRegExpCharacters(
+        `${invalidSketchNameErrorRegExpPrefix}${path.join(
+          sketchFolderPath,
+          `${sketchName}.ino`
+        )}`
+      );
       if (new RegExp(pattern, 'i').test(cliErr.details)) {
         try {
           await fs.access(requestSketchPath);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3118,11 +3118,6 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
 
-"@types/is-valid-path@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@types/is-valid-path/-/is-valid-path-0.1.0.tgz#d5c6e96801303112c9626d44268c6fabc72d272f"
-  integrity sha512-2ontWtpN8O2nf5S7EjDDJ0DwrRa2t7wmS3Wmo322yWYG6yFBYC1QCaLhz4Iz+mzJy8Kf4zP5yVyEd1ANPDmOFQ==
-
 "@types/js-yaml@^3.12.2":
   version "3.12.7"
   resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.7.tgz#330c5d97a3500e9c903210d6e49f02964af04a0e"


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

If regex patterns are not correctly escaped, they will break. Such as the `File` > `Sketchbook` issue when there is a sketch with the following invalid name: `bar++`.

### Change description
<!-- What does your code do? -->

 - Reuse the regex pattern escape mechanism from VS Code.
 - Remove strict [`is-valid-path`](https://www.npmjs.com/package/is-valid-path) check. Otherwise, on Windows, it's impossible to open a sketch in the following way: `"Arduino IDE.exe" "..\\..\\Documents\\Arduino\\bar++"` input will give a false negative result.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1600

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)