### PR TITLE
fix: do not trim stdout of `clang-format` process

### DIFF
--- a/arduino-ide-extension/src/node/exec-util.ts
+++ b/arduino-ide-extension/src/node/exec-util.ts
@@ -62,7 +62,7 @@ export function spawnCommand(
     });
     cp.on('exit', (code, signal) => {
       if (code === 0) {
-        const result = Buffer.concat(outBuffers).toString('utf8').trim();
+        const result = Buffer.concat(outBuffers).toString('utf8');
         resolve(result);
         return;
       }


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To avoid hitting a _no newline at the end of file_ problem with the formatted.

### Change description
<!-- What does your code do? -->

Do not trim the stdout of `clang-format` process.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1487

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)