### PR TITLE
fix: flawed timing issue when opening editors

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
@@ -102,7 +102,7 @@ export class OpenSketchFiles extends SketchContribution {
   ): Promise<Sketch | undefined> {
     const { invalidMainSketchUri } = err.data;
     requestAnimationFrame(() => this.messageService.error(err.message));
-    await wait(10); // let IDE2 toast the error message.
+    await wait(250); // let IDE2 open the editor and toast the error message, then open the modal dialog
     const movedSketch = await promptMoveSketch(invalidMainSketchUri, {
       fileService: this.fileService,
       sketchService: this.sketchService,

--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -9,7 +9,7 @@ import {
 import { fork } from 'child_process';
 import { AddressInfo } from 'net';
 import { join, isAbsolute, resolve } from 'path';
-import { promises as fs, Stats } from 'fs';
+import { promises as fs } from 'fs';
 import { MaybePromise } from '@theia/core/lib/common/types';
 import { ElectronSecurityToken } from '@theia/core/lib/electron-common/electron-token';
 import { FrontendApplicationConfig } from '@theia/application-package/lib/application-props';
@@ -28,6 +28,7 @@ import {
   SHOW_PLOTTER_WINDOW,
 } from '../../common/ipc-communication';
 import { ErrnoException } from '../../node/utils/errors';
+import { isAccessibleSketchPath } from '../../node/sketches-service-impl';
 
 app.commandLine.appendSwitch('disable-http-cache');
 
@@ -145,7 +146,10 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
         event.preventDefault();
         const resolvedPath = await this.resolvePath(path, cwd);
         if (resolvedPath) {
-          const sketchFolderPath = await this.isValidSketchPath(resolvedPath);
+          const sketchFolderPath = await isAccessibleSketchPath(
+            resolvedPath,
+            true
+          );
           if (sketchFolderPath) {
             this.openFilePromise.reject(new InterruptWorkspaceRestoreError());
             await this.openSketch(sketchFolderPath);
@@ -155,49 +159,6 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
       setTimeout(() => this.openFilePromise.resolve(), 500);
     } else {
       this.openFilePromise.resolve();
-    }
-  }
-
-  /**
-   * The `path` argument is valid, if accessible and either pointing to a `.ino` file,
-   * or it's a directory, and one of the files in the directory is an `.ino` file.
-   *
-   * If `undefined`, `path` was pointing to neither an accessible sketch file nor a sketch folder.
-   *
-   * The sketch folder name and sketch file name can be different. This method is not sketch folder name compliant.
-   * The `path` must be an absolute, resolved path.
-   */
-  private async isValidSketchPath(path: string): Promise<string | undefined> {
-    let stats: Stats | undefined = undefined;
-    try {
-      stats = await fs.stat(path);
-    } catch (err) {
-      if (ErrnoException.isENOENT(err)) {
-        return undefined;
-      }
-      throw err;
-    }
-    if (!stats) {
-      return undefined;
-    }
-    if (stats.isFile()) {
-      return path.endsWith('.ino') ? path : undefined;
-    }
-    try {
-      const entries = await fs.readdir(path, { withFileTypes: true });
-      const sketchFilename = entries
-        .filter((entry) => entry.isFile() && entry.name.endsWith('.ino'))
-        .map(({ name }) => name)
-        .sort((left, right) => left.localeCompare(right))[0];
-      if (sketchFilename) {
-        return join(path, sketchFilename);
-      }
-      // If no sketches found in the folder, but the folder exists,
-      // return with the path of the empty folder and let IDE2's frontend
-      // figure out the workspace root.
-      return path;
-    } catch (err) {
-      throw err;
     }
   }
 
@@ -253,7 +214,10 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
         if (!resolvedPath) {
           continue;
         }
-        const sketchFolderPath = await this.isValidSketchPath(resolvedPath);
+        const sketchFolderPath = await isAccessibleSketchPath(
+          resolvedPath,
+          true
+        );
         if (sketchFolderPath) {
           workspace.file = sketchFolderPath;
           if (this.isTempSketch.is(workspace.file)) {
@@ -284,7 +248,7 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
       if (!resolvedPath) {
         continue;
       }
-      const sketchFolderPath = await this.isValidSketchPath(resolvedPath);
+      const sketchFolderPath = await isAccessibleSketchPath(resolvedPath, true);
       if (sketchFolderPath) {
         path = sketchFolderPath;
         break;


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

This PR is to fix the flawed timing issue when opening editors.

### Change description
<!-- What does your code do? -->

 - From now on, the editor widget open promise resolution does not rely on internal Theia events but solely on @phosphor's `isAttached`/`isVisible` properties. The editor widget promise resolves with the next task after a navigation frame so the browser can render the widget.
 - Generalized the invalid sketch name error handling and removed the CLI error messaging parsing logic due to arduino/arduino-cli#1968.

### Other information
<!-- Any additional information that could help the review process -->

For the testing, please use the [1612-sketches.zip](https://github.com/arduino/arduino-ide/files/9961315/1612-sketches.zip) archive. (However, you're allowed to use your own setup.)

`1612-sketches.zip`:

```
.
├── invalid-sketches
│   ├── Bar
│   │   └── xxx.ino
│   └── foo
│       └── Foo.ino
└── valid-sketches
    └── Errors1234567
        ├── CTab.c
        ├── CppTab.cpp
        ├── Errors1234567.ino
        ├── HTab.h
        ├── InoTab.ino
        └── src
            └── HFile.h

6 directories, 8 files
```

Expected behavior:
 - Editors open quickly for the first time (#1612).
    - Start the valid sketch with multiple files: it opens "quickly". At least the performance loss mentioned in. #1612 is OK.
        ```
        ./Arduino\ IDE.app/Contents/MacOS/Arduino\ IDE ./1612-sketches/valid-sketches/Errors1234567/
        ```
 - No regression with #1563
    - After opening an invalid sketch, IDE2 prompts a sketch move
    - The fallback sketch editor is already opened in IDE2 when the modal dialog prompts the move (this is important to preserve the 1.x behavior in IDE2)
    - The error message is toasted when the IDE2 prompts with the modal dialog.
        ```
        ./Arduino\ IDE.app/Contents/MacOS/Arduino\ IDE ./1612-sketches/invalid-sketches/Bar 
        ```
       <img width="866" alt="Screen Shot 2022-11-08 at 13 55 07" src="https://user-images.githubusercontent.com/1405703/200572106-efb54b6e-a832-4307-917c-e447266a3796.png">

        ```
        ./Arduino\ IDE.app/Contents/MacOS/Arduino\ IDE ./1612-sketches/invalid-sketches/foo
        ```
       <img width="865" alt="Screen Shot 2022-11-08 at 13 55 32" src="https://user-images.githubusercontent.com/1405703/200572168-d49aafc8-c060-44f7-ac99-46451d14611c.png">

> * The fallback sketch editor is already opened in IDE2 when the modal dialog prompts the move (this is important to preserve the 1.x behavior in IDE2)
> * The error message is toasted when the IDE2 prompts with the modal dialog.

If one of these 👆 is not working due to a slower or different env OS, please let me know, and I will adjust the timings.

Closes #1612

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)