### PR TITLE
[NO-MERGE] Generate builds with tester version of Arduino CLI

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -158,7 +158,11 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.28.0"
+      "version": {
+        "owner": "cmaglie",
+        "repo": "arduino-cli",
+        "commitish": "2b708b6690f5e511290c14f59958929ac2b52891"
+      }
     },
     "fwuploader": {
       "version": "2.2.2"


### PR DESCRIPTION
### Motivation

Arduino IDE users are being affected by an Arduino CLI panic: https://github.com/arduino/arduino-cli/issues/1970

Tooling Team members have not been able to reliably reproduce the problem, so we are hoping to get assistance from the community in testing a potential fix (https://github.com/arduino/arduino-cli/pull/1972). The availability of builds of Arduino IDE with the patched version of Arduino CLI bundled will facilitate that testing.

### Change description

Bundle the tester version of Arduino CLI from https://github.com/arduino/arduino-cli/pull/1972

### Other information

This pull request is only intended to produce tester builds. It should not be merged.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)