### PR TITLE
chore: Switched to `window.zoomLevel` preference 

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
+++ b/arduino-ide-extension/src/browser/arduino-frontend-contribution.tsx
@@ -31,7 +31,7 @@ import { EditorCommands, EditorMainMenu } from '@theia/editor/lib/browser';
 import { MonacoMenus } from '@theia/monaco/lib/browser/monaco-menu';
 import { FileNavigatorCommands } from '@theia/navigator/lib/browser/navigator-contribution';
 import { TerminalMenus } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
-import { ArduinoPreferences } from './arduino-preferences';
+import { ElectronWindowPreferences } from '@theia/core/lib/electron-browser/window/electron-window-preferences';
 import { BoardsServiceProvider } from './boards/boards-service-provider';
 import { BoardsToolBarItem } from './boards/boards-toolbar-item';
 import { ArduinoMenus } from './menu/arduino-menus';
@@ -58,8 +58,8 @@ export class ArduinoFrontendContribution
   @inject(CommandRegistry)
   private readonly commandRegistry: CommandRegistry;
 
-  @inject(ArduinoPreferences)
-  private readonly arduinoPreferences: ArduinoPreferences;
+  @inject(ElectronWindowPreferences)
+  private readonly electronWindowPreferences: ElectronWindowPreferences;
 
   @inject(FrontendApplicationStateService)
   private readonly appStateService: FrontendApplicationStateService;
@@ -78,10 +78,10 @@ export class ArduinoFrontendContribution
   }
 
   onStart(app: FrontendApplication): void {
-    this.arduinoPreferences.onPreferenceChanged((event) => {
+    this.electronWindowPreferences.onPreferenceChanged((event) => {
       if (event.newValue !== event.oldValue) {
         switch (event.preferenceName) {
-          case 'arduino.window.zoomLevel':
+          case 'window.zoomLevel':
             if (typeof event.newValue === 'number') {
               const webContents = remote.getCurrentWebContents();
               webContents.setZoomLevel(event.newValue || 0);
@@ -91,11 +91,10 @@ export class ArduinoFrontendContribution
       }
     });
     this.appStateService.reachedState('ready').then(() =>
-      this.arduinoPreferences.ready.then(() => {
+      this.electronWindowPreferences.ready.then(() => {
         const webContents = remote.getCurrentWebContents();
-        const zoomLevel = this.arduinoPreferences.get(
-          'arduino.window.zoomLevel'
-        );
+        const zoomLevel =
+          this.electronWindowPreferences.get('window.zoomLevel');
         webContents.setZoomLevel(zoomLevel);
       })
     );

--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -114,11 +114,12 @@ export const ArduinoConfigSchema: PreferenceSchema = {
     },
     'arduino.window.zoomLevel': {
       type: 'number',
-      description: nls.localize(
-        'arduino/preferences/window.zoomLevel',
-        'Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity.'
-      ),
+      description: '',
       default: 0,
+      deprecationMessage: nls.localize(
+        'arduino/preferences/window.zoomLevel/deprecationMessage',
+        "Deprecated. Use 'window.zoomLevel' instead."
+      ),
     },
     'arduino.ide.updateChannel': {
       type: 'string',
@@ -270,7 +271,6 @@ export interface ArduinoConfiguration {
   'arduino.upload.verbose': boolean;
   'arduino.upload.verify': boolean;
   'arduino.window.autoScale': boolean;
-  'arduino.window.zoomLevel': number;
   'arduino.ide.updateChannel': UpdateChannel;
   'arduino.ide.updateBaseUrl': string;
   'arduino.board.certificates': string;

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
@@ -28,16 +28,17 @@ import { ElectronCommands } from '@theia/core/lib/electron-browser/menu/electron
 import { DefaultTheme } from '@theia/application-package/lib/application-props';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 
+export const WINDOW_SETTING = 'window';
 export const EDITOR_SETTING = 'editor';
 export const FONT_SIZE_SETTING = `${EDITOR_SETTING}.fontSize`;
 export const AUTO_SAVE_SETTING = `files.autoSave`;
 export const QUICK_SUGGESTIONS_SETTING = `${EDITOR_SETTING}.quickSuggestions`;
 export const ARDUINO_SETTING = 'arduino';
-export const WINDOW_SETTING = `${ARDUINO_SETTING}.window`;
+export const ARDUINO_WINDOW_SETTING = `${ARDUINO_SETTING}.window`;
 export const COMPILE_SETTING = `${ARDUINO_SETTING}.compile`;
 export const UPLOAD_SETTING = `${ARDUINO_SETTING}.upload`;
 export const SKETCHBOOK_SETTING = `${ARDUINO_SETTING}.sketchbook`;
-export const AUTO_SCALE_SETTING = `${WINDOW_SETTING}.autoScale`;
+export const AUTO_SCALE_SETTING = `${ARDUINO_WINDOW_SETTING}.autoScale`;
 export const ZOOM_LEVEL_SETTING = `${WINDOW_SETTING}.zoomLevel`;
 export const COMPILE_VERBOSE_SETTING = `${COMPILE_SETTING}.verbose`;
 export const COMPILE_WARNINGS_SETTING = `${COMPILE_SETTING}.warnings`;
@@ -55,7 +56,7 @@ export interface Settings {
   currentLanguage: string;
 
   autoScaleInterface: boolean; // `arduino.window.autoScale`
-  interfaceScale: number; // `arduino.window.zoomLevel` https://github.com/eclipse-theia/theia/issues/8751
+  interfaceScale: number; // `window.zoomLevel`
   verboseOnCompile: boolean; // `arduino.compile.verbose`
   compilerWarnings: CompilerWarnings; // `arduino.compile.warnings`
   verboseOnUpload: boolean; // `arduino.upload.verbose`

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
@@ -290,7 +290,6 @@ export class SettingsService {
       this.savePreference('editor.quickSuggestions', quickSuggestions),
       this.savePreference(AUTO_SCALE_SETTING, autoScaleInterface),
       this.savePreference(ZOOM_LEVEL_SETTING, interfaceScale),
-      this.savePreference(ZOOM_LEVEL_SETTING, interfaceScale),
       this.savePreference(COMPILE_VERBOSE_SETTING, verboseOnCompile),
       this.savePreference(COMPILE_WARNINGS_SETTING, compilerWarnings),
       this.savePreference(UPLOAD_VERBOSE_SETTING, verboseOnUpload),

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -371,7 +371,9 @@
       "upload.verbose": "True for verbose upload output. False by default.",
       "verifyAfterUpload": "Verify code after upload",
       "window.autoScale": "True if the user interface automatically scales with the font size.",
-      "window.zoomLevel": "Adjust the zoom level of the window. The original size is 0 and each increment above (e.g. 1) or below (e.g. -1) represents zooming 20% larger or smaller. You can also enter decimals to adjust the zoom level with a finer granularity."
+      "window.zoomLevel": {
+        "deprecationMessage": "Deprecated. Use 'window.zoomLevel' instead."
+      }
     },
     "replaceMsg": "Replace the existing version of {0}?",
     "selectZip": "Select a zip file containing the library you'd like to add",


### PR DESCRIPTION
**Depends on #1662**

----

### Motivation
<!-- Why this pull request? -->

To align the IDE2 codebase with the preferences provided by the Theia framework.

### Change description

**Breaking**
 - Users' `arduino.window.zoomLevel` setting will be ignored. Users have to set the preferred zoom level in one of the following ways:
    - <kbd>Ctrl/⌘</kbd>+<kbd>=</kbd> and <kbd>Ctrl/⌘</kbd>+<kbd>-</kbd>,
    - `File` > `Increase Font Size` and `File` > `Decrease Font Size` (assuming that the interface scale is automatic),
    - Open the Settings dialog, and use the _Interface Scale_ stepper
to readjust the desired scale level.

Alternatively, users can restore the interface scale value via the [_Adcanced Settings_](https://github.com/arduino/arduino-ide/blob/main/docs/advanced-usage.md#advanced-settings):

Currently, when opening the `settings.json` in the file, there is a deprecation message for the old settings key:

<img width="407" alt="Screen Shot 2022-11-14 at 17 25 04" src="https://user-images.githubusercontent.com/1405703/201717249-087baa55-9bd1-4247-bcc5-0370429c7a1f.png">

https://user-images.githubusercontent.com/1405703/201717400-7760b155-24f1-4dbb-93c6-da0066d056f4.mp4

The behavior of the `window.zoomLevel` setting is the same as the deprecated `arduino.window.zoomLevel`.

This also fixes a bug that triggered saving the `zoomLevel` twice.

### Other information

Closes #1657

If required, I can remove the deprecation message of the `arduino.window.zoomLevel`. Users will see this in the `settings.json` editor:

<img width="461" alt="Screen Shot 2022-11-14 at 17 17 00" src="https://user-images.githubusercontent.com/1405703/201718226-c7a5fc1f-0900-4fed-ae83-eeaf57da049e.png">


### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)