### PR TITLE
Don't update the Monitor with unrelated information

### DIFF
--- a/arduino-ide-extension/src/browser/monitor-model.ts
+++ b/arduino-ide-extension/src/browser/monitor-model.ts
@@ -88,9 +88,6 @@ export class MonitorModel implements FrontendApplicationContribution {
   set autoscroll(autoscroll: boolean) {
     if (autoscroll === this._autoscroll) return;
     this._autoscroll = autoscroll;
-    this.monitorManagerProxy.changeSettings({
-      monitorUISettings: { autoscroll },
-    });
     this.storeState().then(() => {
       this.onChangeEmitter.fire({
         property: 'autoscroll',
@@ -110,9 +107,6 @@ export class MonitorModel implements FrontendApplicationContribution {
   set timestamp(timestamp: boolean) {
     if (timestamp === this._timestamp) return;
     this._timestamp = timestamp;
-    this.monitorManagerProxy.changeSettings({
-      monitorUISettings: { timestamp },
-    });
     this.storeState().then(() =>
       this.onChangeEmitter.fire({
         property: 'timestamp',
@@ -132,9 +126,6 @@ export class MonitorModel implements FrontendApplicationContribution {
   set lineEnding(lineEnding: MonitorModel.EOL) {
     if (lineEnding === this._lineEnding) return;
     this._lineEnding = lineEnding;
-    this.monitorManagerProxy.changeSettings({
-      monitorUISettings: { lineEnding },
-    });
     this.storeState().then(() =>
       this.onChangeEmitter.fire({
         property: 'lineEnding',
@@ -150,9 +141,6 @@ export class MonitorModel implements FrontendApplicationContribution {
   set interpolate(interpolate: boolean) {
     if (interpolate === this._interpolate) return;
     this._interpolate = interpolate;
-    this.monitorManagerProxy.changeSettings({
-      monitorUISettings: { interpolate },
-    });
     this.storeState().then(() =>
       this.onChangeEmitter.fire({
         property: 'interpolate',
@@ -168,9 +156,6 @@ export class MonitorModel implements FrontendApplicationContribution {
   set darkTheme(darkTheme: boolean) {
     if (darkTheme === this._darkTheme) return;
     this._darkTheme = darkTheme;
-    this.monitorManagerProxy.changeSettings({
-      monitorUISettings: { darkTheme },
-    });
     this.onChangeEmitter.fire({
       property: 'darkTheme',
       value: this._darkTheme,
@@ -184,9 +169,6 @@ export class MonitorModel implements FrontendApplicationContribution {
   set wsPort(wsPort: number) {
     if (wsPort === this._wsPort) return;
     this._wsPort = wsPort;
-    this.monitorManagerProxy.changeSettings({
-      monitorUISettings: { wsPort },
-    });
     this.onChangeEmitter.fire({
       property: 'wsPort',
       value: this._wsPort,
@@ -200,9 +182,6 @@ export class MonitorModel implements FrontendApplicationContribution {
   set serialPort(serialPort: string) {
     if (serialPort === this._serialPort) return;
     this._serialPort = serialPort;
-    this.monitorManagerProxy.changeSettings({
-      monitorUISettings: { serialPort },
-    });
     this.storeState().then(() =>
       this.onChangeEmitter.fire({
         property: 'serialPort',
@@ -218,9 +197,6 @@ export class MonitorModel implements FrontendApplicationContribution {
   set connected(connected: boolean) {
     if (connected === this._connected) return;
     this._connected = connected;
-    this.monitorManagerProxy.changeSettings({
-      monitorUISettings: { connected },
-    });
     this.onChangeEmitter.fire({
       property: 'connected',
       value: this._connected,


### PR DESCRIPTION
### Motivation
I am working on this issue, which has multiple fixes in various components:
https://github.com/arduino/arduino-ide/issues/375

### Change description
Right now, The IDE sends redundant CONFIGURE commands via the serial monitor for many state changes in the GUI, making the above issue worse.  You can see this by the many CONFIGURE messages in the console.  This fix removes the updates for all the events which do not affect the serial communication state.  (For example, dark mode, line endings, etc.)

### Other information
Ideally, this fix would also filter the notifications to only reset the baudRate when the baudRate pulldown is selected.  Right now, it appears that every commState parameter is updated in a sequence, even when only one is changed.  (I expect to see one CONFIGURE statement in the console.)  I couldn't figure out how to do that - maybe there is a better fix which would include this.
Specifically this function:
https://github.com/arduino/arduino-ide/blob/main/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx#L240
calls changeSettings() which even has comments indicating it should only change one thing:
https://github.com/arduino/arduino-ide/blob/main/arduino-ide-extension/src/node/monitor-service.ts#L485
And yet all of them seem to change?

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)