### PR TITLE
Fix nightly build links in issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -30,7 +30,7 @@ body:
       description: |
         Which version of the Arduino IDE are you using?
         See **Help > About Arduino IDE** in the Arduino IDE menus (**Arduino IDE > About Arduino IDE** on macOS).
-        This should be the latest [nightly build](https://github.com/arduino/arduino-ide#nightly-builds).
+        This should be the latest [nightly build](https://www.arduino.cc/en/software#nightly-builds).
     validations:
       required: true
   - type: dropdown
@@ -68,7 +68,7 @@ body:
       options:
         - label: I searched for previous reports in [the issue tracker](https://github.com/arduino/arduino-ide/issues?q=)
           required: true
-        - label: I verified the problem still occurs when using the latest [nightly build](https://github.com/arduino/arduino-ide#nightly-builds)
+        - label: I verified the problem still occurs when using the latest [nightly build](https://www.arduino.cc/en/software#nightly-builds)
           required: true
         - label: My report contains all necessary details
           required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -25,7 +25,7 @@ body:
       description: |
         Which version of the Arduino IDE are you using?
         See **Help > About Arduino IDE** in the Arduino IDE menus (**Arduino IDE > About Arduino IDE** on macOS).
-        This should be the latest [nightly build](https://github.com/arduino/arduino-ide#nightly-builds).
+        This should be the latest [nightly build](https://www.arduino.cc/en/software#nightly-builds).
     validations:
       required: true
   - type: dropdown
@@ -63,7 +63,7 @@ body:
       options:
         - label: I searched for previous requests in [the issue tracker](https://github.com/arduino/arduino-ide/issues?q=)
           required: true
-        - label: I verified the feature was still missing when using the latest [nightly build](https://github.com/arduino/arduino-ide#nightly-builds)
+        - label: I verified the feature was still missing when using the latest [nightly build](https://www.arduino.cc/en/software#nightly-builds)
           required: true
         - label: My request contains all necessary details
           required: true


### PR DESCRIPTION
### Motivation

The project's [issue forms](https://docs.github.com/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#creating-issue-forms) are configured to request the contributor to test using the [nightly build of Arduino IDE](https://www.arduino.cc/en/software#nightly-builds) before submitting an issue in order to make sure the bug or feature request has not already been resolved.

Some time ago, the repository's readme contained a table of download links. The links in the issue forms pointed there. That table was replaced with a link to [the official "Software" page](https://www.arduino.cc/en/software) in order to reduce unnecessary verbosity and maintenance burden of the project's documentation content (https://github.com/arduino/arduino-ide/commit/59ca91d8055008b0637164a216b27a93abc8c888).

The issue form links were not updated at that time. The resulting additional link in the chain made obtaining the nightly build less convenient for the contributor to obtain.

### Change description

Update the links to point directly to the list of nightly build download links on the [arduino.cc](https://www.arduino.cc/) "Software" page.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)