### PR TITLE
Fix keybindings to switch between tabs on MacOs

### DIFF
--- a/arduino-ide-extension/src/browser/theia/core/common-frontend-contribution.ts
+++ b/arduino-ide-extension/src/browser/theia/core/common-frontend-contribution.ts
@@ -6,6 +6,8 @@ import {
 } from '@theia/core/lib/browser/common-frontend-contribution';
 import { CommandRegistry } from '@theia/core/lib/common/command';
 import type { OnWillStopAction } from '@theia/core/lib/browser/frontend-application';
+import { KeybindingRegistry } from '@theia/core/lib/browser';
+import { isOSX } from '@theia/core';
 
 @injectable()
 export class CommonFrontendContribution extends TheiaCommonFrontendContribution {
@@ -47,6 +49,36 @@ export class CommonFrontendContribution extends TheiaCommonFrontendContribution 
       CommonCommands.SAVE_WITHOUT_FORMATTING, // Patched for https://github.com/eclipse-theia/theia/pull/8877
     ]) {
       registry.unregisterMenuAction(command);
+    }
+  }
+
+  override registerKeybindings(registry: KeybindingRegistry): void {
+    super.registerKeybindings(registry);
+    // Workaround for https://github.com/eclipse-theia/theia/issues/11875
+    if (isOSX) {
+      registry.unregisterKeybinding('ctrlcmd+tab');
+      registry.unregisterKeybinding('ctrlcmd+alt+d');
+      registry.unregisterKeybinding('ctrlcmd+shift+tab');
+      registry.unregisterKeybinding('ctrlcmd+alt+a');
+
+      registry.registerKeybindings(
+        {
+          command: CommonCommands.NEXT_TAB.id,
+          keybinding: 'ctrl+tab',
+        },
+        {
+          command: CommonCommands.NEXT_TAB.id,
+          keybinding: 'ctrl+alt+d',
+        },
+        {
+          command: CommonCommands.PREVIOUS_TAB.id,
+          keybinding: 'ctrl+shift+tab',
+        },
+        {
+          command: CommonCommands.PREVIOUS_TAB.id,
+          keybinding: 'ctrl+alt+a',
+        }
+      );
     }
   }
 


### PR DESCRIPTION
### Motivation
Shortcuts to switch between tabs not working on MacOS

### Change description
Change the keybindings to switch between tabs from `ctrlcmd+...` to `ctrl+...` on MacOS.

### Other information
Closes #1685 

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)