### PR TITLE
Close WebSocket connection after closing Serial Plotter

### DIFF
--- a/arduino-ide-extension/src/browser/monitor-manager-proxy-client-impl.ts
+++ b/arduino-ide-extension/src/browser/monitor-manager-proxy-client-impl.ts
@@ -46,6 +46,7 @@ export class MonitorManagerProxyClientImpl
   private wsPort?: number;
   private lastConnectedBoard: BoardsConfig.Config;
   private onBoardsConfigChanged: Disposable | undefined;
+  private isMonitorWidgetOpen = false;
 
   getWebSocketPort(): number | undefined {
     return this.wsPort;
@@ -172,6 +173,14 @@ export class MonitorManagerProxyClientImpl
 
   getCurrentSettings(board: Board, port: Port): Promise<MonitorSettings> {
     return this.server().getCurrentSettings(board, port);
+  }
+
+  setMonitorWidgetStatus(value: boolean): void {
+    this.isMonitorWidgetOpen = value;
+  }
+
+  getMonitorWidgetStatus(): boolean {
+    return this.isMonitorWidgetOpen;
   }
 
   send(message: string): void {

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
@@ -74,6 +74,10 @@ export class MonitorWidget extends ReactWidget {
     this.monitorManagerProxy.startMonitor();
   }
 
+  protected override onAfterAttach(msg: Message): void {
+    this.monitorManagerProxy.setMonitorWidgetStatus(this.isAttached);
+  }
+
   onMonitorSettingsDidChange(settings: MonitorSettings): void {
     this.settings = {
       ...this.settings,
@@ -91,6 +95,7 @@ export class MonitorWidget extends ReactWidget {
   }
 
   override dispose(): void {
+    this.monitorManagerProxy.setMonitorWidgetStatus(this.isAttached);
     super.dispose();
   }
 

--- a/arduino-ide-extension/src/browser/serial/plotter/plotter-frontend-contribution.ts
+++ b/arduino-ide-extension/src/browser/serial/plotter/plotter-frontend-contribution.ts
@@ -65,6 +65,9 @@ export class PlotterFrontendContribution extends Contribution {
 
     ipcRenderer.on(CLOSE_PLOTTER_WINDOW, async () => {
       if (!!this.window) {
+        if (!this.monitorManagerProxy.getMonitorWidgetStatus()) {
+          this.monitorManagerProxy.disconnect();
+        }
         this.window = null;
       }
     });

--- a/arduino-ide-extension/src/common/protocol/monitor-service.ts
+++ b/arduino-ide-extension/src/common/protocol/monitor-service.ts
@@ -37,6 +37,8 @@ export interface MonitorManagerProxyClient {
   isWSConnected(): Promise<boolean>;
   startMonitor(settings?: PluggableMonitorSettings): Promise<void>;
   getCurrentSettings(board: Board, port: Port): Promise<MonitorSettings>;
+  setMonitorWidgetStatus(value: boolean): void;
+  getMonitorWidgetStatus(): boolean;
   send(message: string): void;
   changeSettings(settings: MonitorSettings): void;
 }


### PR DESCRIPTION
### Motivation
After closing the Serial Plotter the serial port remains open.

### Change description
Disconnect WebSocket when closing Serial Plotter window.

### Other information
Closes #1423.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)