### PR TITLE
fix: remote sketch creation if tree is not active

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/new-cloud-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/new-cloud-sketch.ts
@@ -202,11 +202,12 @@ export class NewCloudSketch extends Contribution {
   private treeModelFrom(
     widget: SketchbookWidget
   ): CloudSketchbookTreeModel | undefined {
-    const treeWidget = widget.getTreeWidget();
-    if (treeWidget instanceof CloudSketchbookTreeWidget) {
-      const model = treeWidget.model;
-      if (model instanceof CloudSketchbookTreeModel) {
-        return model;
+    for (const treeWidget of widget.getTreeWidgets()) {
+      if (treeWidget instanceof CloudSketchbookTreeWidget) {
+        const model = treeWidget.model;
+        if (model instanceof CloudSketchbookTreeModel) {
+          return model;
+        }
       }
     }
     return undefined;

--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-widget.tsx
@@ -53,8 +53,26 @@ export class SketchbookWidget extends BaseWidget {
     );
   }
 
+  /**
+   * The currently selected sketchbook tree widget inside the view.
+   */
   getTreeWidget(): SketchbookTreeWidget {
     return this.sketchbookCompositeWidget.treeWidget;
+  }
+
+  /**
+   * An array of all sketchbook tree widgets managed by the view.
+   */
+  getTreeWidgets(): SketchbookTreeWidget[] {
+    return toArray(this.sketchbookTreesContainer.widgets()).reduce(
+      (acc, curr) => {
+        if (curr instanceof BaseSketchbookCompositeWidget) {
+          acc.push(curr.treeWidget);
+        }
+        return acc;
+      },
+      [] as SketchbookTreeWidget[]
+    );
   }
 
   activeTreeWidgetId(): string | undefined {


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The new remote sketch creation must work from `File` > `New Remote Sketch` or <kbd>Ctrl/Cmd</kbd>+<kbd>Alt</kbd>+<kbd>N</kbd> when a user is logged in, but the _Remote Sketchbook_ is not the active tree inside the _Sketchbook_ view.

### Change description
<!-- What does your code do? -->

New API to access all widgets besides the currently selected one.

### Other information
Closes #1715

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)