### PR TITLE
fix: editor widget resolving when creating new tab

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
@@ -184,7 +184,7 @@ export class OpenSketchFiles extends SketchContribution {
         // The editor is expected to be attached to the shell and visible in the UI.
         // The deferred promise does not have to wait for the `editorManager#onCreated` event.
         // It can resolve earlier.
-        if (!widget) {
+        if (widget) {
           deferred.resolve(editorWidget);
         }
       });


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Fix bug when ensuring that an already editor is opened.

### Change description
<!-- What does your code do? -->

I have corrected the condition so that the promise can correctly resolve immediately. It did not cause a performance issue, as no callers have been awaiting the promise.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1718

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)