### PR TITLE
Fix formatting of generated release notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,10 +180,14 @@ jobs:
             fi
           fi
           echo -e "$BODY"
-          OUTPUT_SAFE_BODY="${BODY//'%'/'%25'}"
-          OUTPUT_SAFE_BODY="${OUTPUT_SAFE_BODY//$'\n'/'%0A'}"
-          OUTPUT_SAFE_BODY="${OUTPUT_SAFE_BODY//$'\r'/'%0D'}"
-          echo "BODY=$OUTPUT_SAFE_BODY" >> $GITHUB_OUTPUT
+
+          # Set workflow step output
+          # See: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+          DELIMITER="$RANDOM"
+          echo "BODY<<$DELIMITER" >> $GITHUB_OUTPUT
+          echo "$BODY" >> $GITHUB_OUTPUT
+          echo "$DELIMITER" >> $GITHUB_OUTPUT
+
           echo "$BODY" > CHANGELOG.txt
 
       - name: Upload Changelog [GitHub Actions]


### PR DESCRIPTION
### Motivation

The "Arduino IDE" [GitHub Actions workflow](https://docs.github.com/actions/using-workflows/about-workflows) generates a changelog from the commits since the last tag.

This changelog is published in multiple ways:

- Printed to workflow run logs
- Uploaded to Arduino's download server (mostly useful for the [nightly builds](https://www.arduino.cc/en/software#nightly-builds))
- Initial version of [release notes](https://github.com/arduino/arduino-ide/releases)

For the last, the changelog text must be passed from the dedicated changelog generation workflow step to the release step. This is done via a workflow job output.

At the time the system was set up, outputs for workflow `run` steps were set using the `set-output` workflow command. That "workflow command" system was later determined by GitHub to have potential security vulnerabilities, so [it was replaced with a `GITHUB_OUTPUT` environment file](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

The "Arduino IDE" workflow was migrated to the new "environment file" approach (https://github.com/arduino/arduino-ide/pull/1604). It was later discovered that there was an undocumented breaking change in the method for handling multi-line strings in workflow step outputs between the old "workflow command" system and the new "environment file". This resulted in the initial release notes having an incorrect format. For example, what would previously have been formatted like this:

```markdown
- Updated translation files (#1606) [23c7f5f]
- Use 0.29.0 CLI in IDE2 (#1683) [f1144ef]
```

Was now formatted like this:

```markdown
- Updated translation files (#1606) [23c7f5f]%0A - Use 0.29.0 CLI in IDE2 (#1683) [f1144ef]%0A
```

### Change description

The solution is to remove [the commands that did the escaping](https://github.com/orgs/community/discussions/26288#discussioncomment-3251220) of the changelog text in a manner that is no longer supported and replace them with the "[here document](https://tldp.org/LDP/abs/html/here-docs.html)"-style format [supported for storing multiline strings in environment files](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings).

A [random number](https://tldp.org/LDP/abs/html/randomvar.html) is used as the "delimiter" (limit string) per [the security recommendations](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings:~:text=Make%20sure%20the%20delimiter%20you%27re%20using%20is%20randomly%20generated%20and%20unique) in the official GitHub documentation. Note that even though the multiline strings handling documentation was placed under [the environment variable section](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-environment-variable) of the documentation, it also applies to setting outputs.

### Other information

Demonstration release in my fork using the updated workflow:

https://github.com/per1234/arduino-ide/releases/tag/2.0.3-rc.1

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)