### PR TITLE
fix: theme service binding

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -323,8 +323,8 @@ import { NewCloudSketch } from './contributions/new-cloud-sketch';
 import { SketchbookCompositeWidget } from './widgets/sketchbook/sketchbook-composite-widget';
 import { WindowTitleUpdater } from './theia/core/window-title-updater';
 import { WindowTitleUpdater as TheiaWindowTitleUpdater } from '@theia/core/lib/browser/window/window-title-updater';
-import { ThemeService } from './theia/core/theming';
-import { ThemeService as TheiaThemeService } from '@theia/core/lib/browser/theming';
+import { ThemeServiceWithDB } from './theia/core/theming';
+import { ThemeServiceWithDB as TheiaThemeServiceWithDB } from '@theia/monaco/lib/browser/monaco-indexed-db';
 import { MonacoThemingService } from './theia/monaco/monaco-theming-service';
 import { MonacoThemingService as TheiaMonacoThemingService } from '@theia/monaco/lib/browser/monaco-theming-service';
 import { TypeHierarchyServiceProvider } from './theia/typehierarchy/type-hierarchy-service';
@@ -959,8 +959,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   rebind(TheiaWindowTitleUpdater).toService(WindowTitleUpdater);
 
   // register Arduino themes
-  bind(ThemeService).toSelf().inSingletonScope();
-  rebind(TheiaThemeService).toService(ThemeService);
+  bind(ThemeServiceWithDB).toSelf().inSingletonScope();
+  rebind(TheiaThemeServiceWithDB).toService(ThemeServiceWithDB);
   bind(MonacoThemingService).toSelf().inSingletonScope();
   rebind(TheiaMonacoThemingService).toService(MonacoThemingService);
 

--- a/arduino-ide-extension/src/browser/theia/core/theming.ts
+++ b/arduino-ide-extension/src/browser/theia/core/theming.ts
@@ -1,6 +1,6 @@
-import { ThemeService as TheiaThemeService } from '@theia/core/lib/browser/theming';
 import type { Theme } from '@theia/core/lib/common/theme';
 import { injectable } from '@theia/core/shared/inversify';
+import { ThemeServiceWithDB as TheiaThemeServiceWithDB } from '@theia/monaco/lib/browser/monaco-indexed-db';
 
 export namespace ArduinoThemes {
   export const Light: Theme = {
@@ -18,7 +18,7 @@ export namespace ArduinoThemes {
 }
 
 @injectable()
-export class ThemeService extends TheiaThemeService {
+export class ThemeServiceWithDB extends TheiaThemeServiceWithDB {
   protected override init(): void {
     this.register(ArduinoThemes.Light, ArduinoThemes.Dark);
     super.init();

--- a/arduino-ide-extension/src/browser/utils/window.ts
+++ b/arduino-ide-extension/src/browser/utils/window.ts
@@ -5,11 +5,3 @@
 export function setURL(url: URL, data: any = {}): void {
   history.pushState(data, '', url);
 }
-
-/**
- * If available from the `window` object, then it means, the IDE2 has successfully patched the `MonacoThemingService#init` static method,
- * and can wait the custom theme registration.
- */
-export const MonacoThemeServiceIsReady = Symbol(
-  '@arduino-ide#monaco-theme-service-is-ready'
-);


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Copy and use custom VS Code themes in IDE2.

### Change description
<!-- What does your code do? -->

Fixed dependency injection of the theme service. With the correct theme service binding, IDE2 can access themes from the [`indexedDB`](https://developer.mozilla.org/en-US/docs/Web/API/indexedDB).

To verify:
 - download a VS Code theme VSIX. (I used this for the verification: https://marketplace.visualstudio.com/items?itemName=N7n.n7-vscode-themes),
 - rename the downloaded `.vsix` to `.zip`, unarchive it, and copy it under the `resources/app/plugins` folder. On macOS, it looks like this.
    <img width="314" alt="Screen Shot 2022-12-06 at 16 40 50" src="https://user-images.githubusercontent.com/1405703/205956919-75263e84-dbd6-4f13-b790-eb1a9b12c5fe.png">
- Start IDE2 and open the settings dialog,
- You can see the new themes in the themes dropdown.
    <img width="265" alt="Screen Shot 2022-12-06 at 16 42 48" src="https://user-images.githubusercontent.com/1405703/205957400-d342cf4a-e2e6-4dca-ab02-707022f5825c.png">
- When you select it, it works.
- Restart IDE2. The current custom theme is what you have selected.


### Other information
<!-- Any additional information that could help the review process -->

Closes #1742

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)