### PR TITLE
Restore certificate check compatibility w/ RC2-40-CBC encrypted PKS#12

### DIFF
--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -59,7 +59,9 @@ jobs:
           (
             openssl pkcs12 \
               -in "${{ env.CERTIFICATE_PATH }}" \
-              -noout -passin env:CERTIFICATE_PASSWORD
+              -legacy \
+              -noout \
+              -passin env:CERTIFICATE_PASSWORD
           ) || (
             echo "::error::Verification of ${{ matrix.certificate.identifier }} failed!!!"
             exit 1
@@ -87,6 +89,7 @@ jobs:
               openssl pkcs12 \
                 -in "${{ env.CERTIFICATE_PATH }}" \
                 -clcerts \
+                -legacy \
                 -nodes \
                 -passin env:CERTIFICATE_PASSWORD
             ) | (


### PR DESCRIPTION
### Motivation

The "Check Certificates" GitHub Actions workflow uses [**OpenSSL**](https://www.openssl.org/) to check for problems with the project's signing certificates.

Certificates exported to [PKS #12](https://en.wikipedia.org/wiki/PKCS_12) archive files using older tools may have been encrypted using the ["RC2-40-CBC" algorithm](https://en.wikipedia.org/wiki/RC2).

Due to the availability of more secure modern alternatives, [default support for RC2-40-CBC encryption was dropped in **OpenSSL** 3.x](https://www.openssl.org/docs/man3.0/man7/migration_guide.html#PKCS-12-API-updates).

The macOS signing certificate uses this RC2-40-CBC encryption.

The "Check Certificates" GitHub Actions workflow runs on [the `ubuntu-latest` runner](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#choosing-github-hosted-runners). Previously, this runner used Ubuntu 20.04. [This has now changed to Ubuntu 22.04](https://github.blog/changelog/2022-12-01-github-actions-larger-runners-using-ubuntu-latest-label-will-now-use-ubuntu-22-04/). With the operating system update came an **OpenSSL** update from 1.1.1f to 3.0.2. This caused the workflow runs to fail on the macOS certificate job:

https://github.com/arduino/arduino-ide/actions/runs/3637803834/jobs/6139239158#step:5:16

```text
Error outputting keys and certificates
80FBB0C5087F0000:error:0308010C:digital envelope routines:inner_evp_generic_fetch:unsupported:../crypto/evp/evp_fetch.c:349:Global default library context, Algorithm (RC2-40-CBC : 0), Properties ()
```

### Change description

Even though no longer done by default, **OpenSSL** still supports RC2-40-CBC encryption via its "legacy" [provider](https://www.openssl.org/docs/man3.0/man7/migration_guide.html#Providers-and-FIPS-support). So compatibility with the certificate is restored by adding [the `-legacy` flag](https://www.openssl.org/docs/man3.0/man1/openssl-pkcs12.html#legacy) to the `openssl pkcs12` commands.

### Other information

Passing "Check Certificates" workflow run from the commit proposed in this PR:

https://github.com/arduino/arduino-ide/actions/runs/3638084494

Identical change applied to the Arduino CLI repository to fix the same bug: https://github.com/arduino/arduino-cli/pull/2002

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)