### PR TITLE
feat: show the selected board config value on menu

### DIFF
--- a/arduino-ide-extension/src/browser/boards/boards-data-menu-updater.ts
+++ b/arduino-ide-extension/src/browser/boards/boards-data-menu-updater.ts
@@ -80,16 +80,16 @@ export class BoardsDataMenuUpdater implements FrontendApplicationContribution {
                 string,
                 Disposable & { label: string }
               >();
+              let selectedValue = '';
               for (const value of values) {
                 const id = `${fqbn}-${option}--${value.value}`;
                 const command = { id };
-                const selectedValue = value.value;
                 const handler = {
                   execute: () =>
                     this.boardsDataStore.selectConfigOption({
                       fqbn,
                       option,
-                      selectedValue,
+                      selectedValue: value.value,
                     }),
                   isToggled: () => value.selected,
                 };
@@ -100,8 +100,14 @@ export class BoardsDataMenuUpdater implements FrontendApplicationContribution {
                     { label: value.label }
                   )
                 );
+                if (value.selected) {
+                  selectedValue = value.label;
+                }
               }
-              this.menuRegistry.registerSubmenu(menuPath, label);
+              this.menuRegistry.registerSubmenu(
+                menuPath,
+                `${label}${selectedValue ? `: "${selectedValue}"` : ''}`
+              );
               this.toDisposeOnBoardChange.pushAll([
                 ...commands.values(),
                 Disposable.create(() =>


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

As per request from #343, IDE2 shows the selected board config value on the menu item.


https://user-images.githubusercontent.com/1405703/206217908-c99d066a-cad9-4c6a-867c-7150554439e9.mp4



### Change description
<!-- What does your code do? -->

Append the selected board config value to the menu label.

### Other information
<!-- Any additional information that could help the review process -->

Closes #343

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)