### PR TITLE
fix: list view filtering when opening the view

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/component-list/filterable-list-container.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/filterable-list-container.tsx
@@ -32,7 +32,7 @@ export class FilterableListContainer<
   }
 
   override componentDidMount(): void {
-    this.search = debounce(this.search, 500);
+    this.search = debounce(this.search, 500, { trailing: true });
     this.search(this.state.searchOptions);
     this.props.searchOptionsDidChange((newSearchOptions) => {
       const { searchOptions } = this.state;


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Fix the search options behavior of the library and boards manager widget when programmatically opening them.

### Change description
<!-- What does your code do? -->

 - When the widget is opened the first time with any search options, the widget might miss the refresh event as it does not happen at instantiation time. This PR ensures that all list widget refresh events wait until the React component is rendered and is visible in the UI.
 - This change also ensures that the debounced search will run with the most recent search options by setting the `trailing` property of the debounced function to `true`.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1740

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)