### PR TITLE
fix: menu item enablement issues

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/contribution.ts
+++ b/arduino-ide-extension/src/browser/contributions/contribution.ts
@@ -61,6 +61,7 @@ import { BoardsDataStore } from '../boards/boards-data-store';
 import { NotificationManager } from '../theia/messages/notifications-manager';
 import { MessageType } from '@theia/core/lib/common/message-service-protocol';
 import { WorkspaceService } from '../theia/workspace/workspace-service';
+import { MainMenuManager } from '../../common/main-menu-manager';
 
 export {
   Command,
@@ -105,6 +106,9 @@ export abstract class Contribution
 
   @inject(FrontendApplicationStateService)
   protected readonly appStateService: FrontendApplicationStateService;
+
+  @inject(MainMenuManager)
+  protected readonly menuManager: MainMenuManager;
 
   @postConstruct()
   protected init(): void {

--- a/arduino-ide-extension/src/browser/contributions/examples.ts
+++ b/arduino-ide-extension/src/browser/contributions/examples.ts
@@ -12,7 +12,6 @@ import {
 } from '@theia/core/lib/common/disposable';
 import { OpenSketch } from './open-sketch';
 import { ArduinoMenus, PlaceholderMenuNode } from '../menu/arduino-menus';
-import { MainMenuManager } from '../../common/main-menu-manager';
 import { BoardsServiceProvider } from '../boards/boards-service-provider';
 import { ExamplesService } from '../../common/protocol/examples-service';
 import {
@@ -38,9 +37,6 @@ export abstract class Examples extends SketchContribution {
 
   @inject(MenuModelRegistry)
   private readonly menuRegistry: MenuModelRegistry;
-
-  @inject(MainMenuManager)
-  protected readonly menuManager: MainMenuManager;
 
   @inject(ExamplesService)
   protected readonly examplesService: ExamplesService;

--- a/arduino-ide-extension/src/browser/contributions/interface-scale.ts
+++ b/arduino-ide-extension/src/browser/contributions/interface-scale.ts
@@ -1,31 +1,17 @@
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { injectable } from '@theia/core/shared/inversify';
 import {
   Contribution,
   Command,
   MenuModelRegistry,
   KeybindingRegistry,
 } from './contribution';
-import { ArduinoMenus, PlaceholderMenuNode } from '../menu/arduino-menus';
-import {
-  CommandRegistry,
-  DisposableCollection,
-  MaybePromise,
-  nls,
-} from '@theia/core/lib/common';
-
+import { ArduinoMenus } from '../menu/arduino-menus';
+import { CommandRegistry, MaybePromise, nls } from '@theia/core/lib/common';
 import { Settings } from '../dialogs/settings/settings';
-import { MainMenuManager } from '../../common/main-menu-manager';
 import debounce = require('lodash.debounce');
 
 @injectable()
 export class InterfaceScale extends Contribution {
-  @inject(MenuModelRegistry)
-  private readonly menuRegistry: MenuModelRegistry;
-
-  @inject(MainMenuManager)
-  private readonly mainMenuManager: MainMenuManager;
-
-  private readonly menuActionsDisposables = new DisposableCollection();
   private fontScalingEnabled: InterfaceScale.FontScalingEnabled = {
     increase: true,
     decrease: true,
@@ -62,63 +48,22 @@ export class InterfaceScale extends Contribution {
   }
 
   override registerMenus(registry: MenuModelRegistry): void {
-    this.menuActionsDisposables.dispose();
-    const increaseFontSizeMenuAction = {
+    registry.registerMenuAction(ArduinoMenus.EDIT__FONT_CONTROL_GROUP, {
       commandId: InterfaceScale.Commands.INCREASE_FONT_SIZE.id,
       label: nls.localize(
         'arduino/editor/increaseFontSize',
         'Increase Font Size'
       ),
       order: '0',
-    };
-    const decreaseFontSizeMenuAction = {
+    });
+    registry.registerMenuAction(ArduinoMenus.EDIT__FONT_CONTROL_GROUP, {
       commandId: InterfaceScale.Commands.DECREASE_FONT_SIZE.id,
       label: nls.localize(
         'arduino/editor/decreaseFontSize',
         'Decrease Font Size'
       ),
       order: '1',
-    };
-
-    if (this.fontScalingEnabled.increase) {
-      this.menuActionsDisposables.push(
-        registry.registerMenuAction(
-          ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
-          increaseFontSizeMenuAction
-        )
-      );
-    } else {
-      this.menuActionsDisposables.push(
-        registry.registerMenuNode(
-          ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
-          new PlaceholderMenuNode(
-            ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
-            increaseFontSizeMenuAction.label,
-            { order: increaseFontSizeMenuAction.order }
-          )
-        )
-      );
-    }
-    if (this.fontScalingEnabled.decrease) {
-      this.menuActionsDisposables.push(
-        this.menuRegistry.registerMenuAction(
-          ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
-          decreaseFontSizeMenuAction
-        )
-      );
-    } else {
-      this.menuActionsDisposables.push(
-        this.menuRegistry.registerMenuNode(
-          ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
-          new PlaceholderMenuNode(
-            ArduinoMenus.EDIT__FONT_CONTROL_GROUP,
-            decreaseFontSizeMenuAction.label,
-            { order: decreaseFontSizeMenuAction.order }
-          )
-        )
-      );
-    }
-    this.mainMenuManager.update();
+    });
   }
 
   private updateFontScalingEnabled(): void {
@@ -153,7 +98,7 @@ export class InterfaceScale extends Contribution {
     );
     if (isChanged) {
       this.fontScalingEnabled = fontScalingEnabled;
-      this.registerMenus(this.menuRegistry);
+      this.menuManager.update();
     }
   }
 

--- a/arduino-ide-extension/src/browser/contributions/new-cloud-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/new-cloud-sketch.ts
@@ -17,7 +17,6 @@ import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { WorkspaceInputDialogProps } from '@theia/workspace/lib/browser/workspace-input-dialog';
 import { v4 } from 'uuid';
-import { MainMenuManager } from '../../common/main-menu-manager';
 import type { AuthenticationSession } from '../../node/auth/types';
 import { AuthenticationClientService } from '../auth/authentication-client-service';
 import { CreateApi } from '../create/create-api';
@@ -41,8 +40,6 @@ export class NewCloudSketch extends Contribution {
   private readonly widgetContribution: SketchbookWidgetContribution;
   @inject(AuthenticationClientService)
   private readonly authenticationService: AuthenticationClientService;
-  @inject(MainMenuManager)
-  private readonly mainMenuManager: MainMenuManager;
 
   private readonly toDispose = new DisposableCollection();
   private _session: AuthenticationSession | undefined;
@@ -54,7 +51,7 @@ export class NewCloudSketch extends Contribution {
         const oldSession = this._session;
         this._session = session;
         if (!!oldSession !== !!this._session) {
-          this.mainMenuManager.update();
+          this.menuManager.update();
         }
       }),
       this.preferences.onPreferenceChanged(({ preferenceName, newValue }) => {
@@ -62,7 +59,7 @@ export class NewCloudSketch extends Contribution {
           const oldEnabled = this._enabled;
           this._enabled = Boolean(newValue);
           if (this._enabled !== oldEnabled) {
-            this.mainMenuManager.update();
+            this.menuManager.update();
           }
         }
       }),
@@ -70,7 +67,7 @@ export class NewCloudSketch extends Contribution {
     this._enabled = this.preferences['arduino.cloud.enabled'];
     this._session = this.authenticationService.session;
     if (this._session) {
-      this.mainMenuManager.update();
+      this.menuManager.update();
     }
   }
 

--- a/arduino-ide-extension/src/browser/contributions/open-settings.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-settings.ts
@@ -1,6 +1,5 @@
 import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { MainMenuManager } from '../../common/main-menu-manager';
 import type { Settings } from '../dialogs/settings/settings';
 import { SettingsDialog } from '../dialogs/settings/settings-dialog';
 import { ArduinoMenus } from '../menu/arduino-menus';
@@ -16,8 +15,6 @@ import {
 export class OpenSettings extends SketchContribution {
   @inject(SettingsDialog)
   private readonly settingsDialog: SettingsDialog;
-  @inject(MainMenuManager)
-  private readonly menuManager: MainMenuManager;
 
   private settingsOpened = false;
 

--- a/arduino-ide-extension/src/browser/contributions/upload-firmware.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-firmware.ts
@@ -21,9 +21,11 @@ export class UploadFirmware extends Contribution {
       execute: async () => {
         try {
           this.dialogOpened = true;
+          this.menuManager.update();
           await this.dialog.open();
         } finally {
           this.dialogOpened = false;
+          this.menuManager.update();
         }
       },
       isEnabled: () => !this.dialogOpened,

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -106,6 +106,7 @@ export class UploadSketch extends CoreServiceContribution {
       // toggle the toolbar button and menu item state.
       // uploadInProgress will be set to false whether the upload fails or not
       this.uploadInProgress = true;
+      this.menuManager.update();
       this.boardsServiceProvider.snapshotBoardDiscoveryOnUpload();
       this.onDidChangeEmitter.fire();
       this.clearVisibleNotification();
@@ -150,6 +151,7 @@ export class UploadSketch extends CoreServiceContribution {
       this.handleError(e);
     } finally {
       this.uploadInProgress = false;
+      this.menuManager.update();
       this.boardsServiceProvider.attemptPostUploadAutoSelect();
       this.onDidChangeEmitter.fire();
     }

--- a/arduino-ide-extension/src/browser/theia/core/common-frontend-contribution.ts
+++ b/arduino-ide-extension/src/browser/theia/core/common-frontend-contribution.ts
@@ -46,7 +46,8 @@ export class CommonFrontendContribution extends TheiaCommonFrontendContribution 
       CommonCommands.SELECT_ICON_THEME,
       CommonCommands.SELECT_COLOR_THEME,
       CommonCommands.ABOUT_COMMAND,
-      CommonCommands.SAVE_WITHOUT_FORMATTING, // Patched for https://github.com/eclipse-theia/theia/pull/8877
+      CommonCommands.SAVE_WITHOUT_FORMATTING, // Patched for https://github.com/eclipse-theia/theia/pull/8877,
+      CommonCommands.NEW_UNTITLED_FILE,
     ]) {
       registry.unregisterMenuAction(command);
     }


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Fixes the `Sketch` > `Upload`/`Upload Using Programmer` menu items enablement. This PR is related to arduino/arduino-ide#1735 and covers arduino/arduino-ide#1533.

---- 

IDE2 switched from always-enabled menu items to dynamic ones with [this](https://github.com/arduino/arduino-ide/commit/7d6a2d5e3340aabc1e635d508509dc92a4000fdc#diff-2635a822041da8b5a20323e233457da36a84db3817c6bd3ba9e7e944fefca04aR155-R157) change and [here](https://github.com/arduino/arduino-ide/commit/7d6a2d5e3340aabc1e635d508509dc92a4000fdc#diff-2635a822041da8b5a20323e233457da36a84db3817c6bd3ba9e7e944fefca04aR245) is the crucial part.

Without rebuilding the entire menu, there is no way to support a dynamic menu in an electron app. So in Theia, the menu is calculated at startup, and all menu items are always enabled even though the underlying commands could be disabled. The menu remains the same for the app session—no need to rebuild anything, but the command enablement can change at runtime. If a menu is enabled and the underlying command is disabled, nothing happens when the user clicks on the menu item. This is the vanilla Theia behavior.

IDE2 heavily relies on dynamic menus. IDE2 has to recalculate the menu on board attach/detach, selection change, library/platform installation uninstallation, etc., events. A dynamic menu with the correct menu items enablement state is something IDE2 could provide without much additional effort if it were done correctly. See arduino/arduino-ide#1533.

This PR cleans up the placeholder menu items, makes the menu items rely on the command enablement state, and "manually" updates the menus when needed. 

### Change description
<!-- What does your code do? -->

The following logic was changed:
 - `Edit` > `Increase Font Size`/`Decrease Font Size` (no behavior change is expected),
 - `Tools` > `Upload SSL Root Certificates` (disabled when the dialog is opened),
 - `Tools` > `WiFi101 / WiFiNINA Firmware Updater` (disabled when the dialog is opened),
 - `Sketch` > `Verify/Compile` (disabled when verifying),
 - `Sketch` > `Export Compiled Binary` (disabled when verifying),
 - `Sketch` > `Upload` (disabled when uploading),
 - `Sketch` > `Configure and Upload` (disabled when uploading), and
 - `Sketch` > `Upload Using Programmer` (disabled when uploading)

Other expected behavior changes (my PR is a proposal, I am happy to adjust if required)
 - When `Sketch` > `Verify/Compile` is disabled, `Sketch` > `Export Compiled Binary` is also disabled and vice versa.
 - When `Sketch` > `Upload` is disabled, `Sketch` > `Upload Using Programmer` is also disabled and vice versa. The same is true for `Sketch` > `Configure and Upload`.
 - When an upload is running, for the (automatic) verify part, the `Sketch` > `Verify/Compile` and `Sketch` > `Export Compiled Binary` are disabled.
 - When the upload is running, but the (automatic) compilation part has already passed, the `Sketch` > `Verify/Compile` and `Sketch` > `Export Compiled Binary` menu items are enabled, but the `Sketch` > `Upload`, `Sketch` > `Upload Using Programmer`, and `Sketch` > `Configure and Upload` menu items are still disabled until the end of the upload command.

Finally, this PR eliminates the following warning on macOS, maybe on other OSs too. Can be reproduced when starting the IDE2 from a terminal, and the `window` receives a `blur` and then `focus` event. (Lose focus from IDE2 app, set focus to IDE2 app):

```
DEBUG Skipping menu item with missing command: "workbench.action.files.newUntitledFile".
```

This PR has no intention changing anything regarding the command/menu enablement in the toolbar.

### Other information
<!-- Any additional information that could help the review process -->

Closes arduino/arduino-ide#1533
Closes arduino/arduino-ide#1722

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)