### PR TITLE
Fix corruption of incoming UTF-8-encoded serial data

### DIFF
--- a/arduino-ide-extension/src/node/monitor-service.ts
+++ b/arduino-ide-extension/src/node/monitor-service.ts
@@ -80,7 +80,7 @@ export class MonitorService extends CoreClientAware implements Disposable {
   private readonly board: Board;
   private readonly port: Port;
   private readonly monitorID: string;
-  private streamingTextDecoder = new TextDecoder('utf8');
+  private readonly streamingTextDecoder = new TextDecoder('utf8');
 
   /**
    * The lightweight representation of the port configuration currently in use for the running monitor.

--- a/arduino-ide-extension/src/node/monitor-service.ts
+++ b/arduino-ide-extension/src/node/monitor-service.ts
@@ -80,6 +80,7 @@ export class MonitorService extends CoreClientAware implements Disposable {
   private readonly board: Board;
   private readonly port: Port;
   private readonly monitorID: string;
+  private streamingTextDecoder = new TextDecoder('utf8');
 
   /**
    * The lightweight representation of the port configuration currently in use for the running monitor.
@@ -319,7 +320,7 @@ export class MonitorService extends CoreClientAware implements Disposable {
               const message =
                 typeof data === 'string'
                   ? data
-                  : new TextDecoder('utf8').decode(data);
+                  : this.streamingTextDecoder.decode(data, {stream:true});
               this.messages.push(...splitLines(message));
             },
           },


### PR DESCRIPTION
### Motivation
Fix for #589

### Change description
Fix corruption of incoming UTF8-encoded serial data

### Other information
Serial data is received in chunks.  When a UTF8-encoded symbol is multibyte, it cannot be decoded properly until all the bytes are available.  If an attempt at decoding is made, it will fail and the symbol for UTF-8 "Replacement Character" � is inserted into the stream.  TextDecoder has a "stream" option to buffer any bytes that cannot be decoded yet, for exactly this reason.  This fix creates an instance of TextDecoder which is persistent for the life of the connection, and then uses that decoder with the stream option to decode UTF8-encoded data properly.

Note - this assumes we expect UTF8 encoded data from the serial port.  Generally speaking, this happens if we have the sketch editor in UTF8 mode, which appears to be the default, and then UTF8 encoded characters are included in a print() statement.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)