### PR TITLE
feat: configure sketchbook location without restart

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -343,6 +343,7 @@ import { DebugWidget } from '@theia/debug/lib/browser/view/debug-widget';
 import { DebugViewModel } from '@theia/debug/lib/browser/view/debug-view-model';
 import { DebugSessionWidget } from '@theia/debug/lib/browser/view/debug-session-widget';
 import { DebugConfigurationWidget } from '@theia/debug/lib/browser/view/debug-configuration-widget';
+import { ConfigServiceClient } from './config/config-service-client';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
   // Commands and toolbar items
@@ -404,6 +405,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
       )
     )
     .inSingletonScope();
+  bind(ConfigServiceClient).toSelf().inSingletonScope();
+  bind(FrontendApplicationContribution).toService(ConfigServiceClient);
 
   // Boards service
   bind(BoardsService)

--- a/arduino-ide-extension/src/browser/config/config-service-client.ts
+++ b/arduino-ide-extension/src/browser/config/config-service-client.ts
@@ -1,0 +1,106 @@
+import { FrontendApplicationContribution } from '@theia/core/lib/browser/frontend-application';
+import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { deepClone } from '@theia/core/lib/common/objects';
+import URI from '@theia/core/lib/common/uri';
+import {
+  inject,
+  injectable,
+  postConstruct,
+} from '@theia/core/shared/inversify';
+import { ConfigService, ConfigState } from '../../common/protocol';
+import { NotificationCenter } from '../notification-center';
+
+@injectable()
+export class ConfigServiceClient implements FrontendApplicationContribution {
+  @inject(ConfigService)
+  private readonly delegate: ConfigService;
+  @inject(NotificationCenter)
+  private readonly notificationCenter: NotificationCenter;
+  @inject(FrontendApplicationStateService)
+  private readonly appStateService: FrontendApplicationStateService;
+  @inject(MessageService)
+  private readonly messageService: MessageService;
+
+  private readonly didChangeSketchDirUriEmitter = new Emitter<
+    URI | undefined
+  >();
+  private readonly didChangeDataDirUriEmitter = new Emitter<URI | undefined>();
+  private readonly toDispose = new DisposableCollection(
+    this.didChangeSketchDirUriEmitter,
+    this.didChangeDataDirUriEmitter
+  );
+
+  private config: ConfigState | undefined;
+
+  @postConstruct()
+  protected init(): void {
+    this.appStateService.reachedState('ready').then(async () => {
+      const config = await this.fetchConfig();
+      this.use(config);
+    });
+  }
+
+  onStart(): void {
+    this.notificationCenter.onConfigDidChange((config) => this.use(config));
+  }
+
+  onStop(): void {
+    this.toDispose.dispose();
+  }
+
+  get onDidChangeSketchDirUri(): Event<URI | undefined> {
+    return this.didChangeSketchDirUriEmitter.event;
+  }
+
+  get onDidChangeDataDirUri(): Event<URI | undefined> {
+    return this.didChangeDataDirUriEmitter.event;
+  }
+
+  async fetchConfig(): Promise<ConfigState> {
+    return this.delegate.getConfiguration();
+  }
+
+  /**
+   * CLI config related error messages if any.
+   */
+  tryGetMessages(): string[] | undefined {
+    return this.config?.messages;
+  }
+
+  /**
+   * `directories.user`
+   */
+  tryGetSketchDirUri(): URI | undefined {
+    return this.config?.config?.sketchDirUri
+      ? new URI(this.config?.config?.sketchDirUri)
+      : undefined;
+  }
+
+  /**
+   * `directories.data`
+   */
+  tryGetDataDirUri(): URI | undefined {
+    return this.config?.config?.dataDirUri
+      ? new URI(this.config?.config?.dataDirUri)
+      : undefined;
+  }
+
+  private use(config: ConfigState): void {
+    const oldConfig = deepClone(this.config);
+    this.config = config;
+    if (oldConfig?.config?.sketchDirUri !== this.config?.config?.sketchDirUri) {
+      this.didChangeSketchDirUriEmitter.fire(this.tryGetSketchDirUri());
+    }
+    if (oldConfig?.config?.dataDirUri !== this.config?.config?.dataDirUri) {
+      this.didChangeDataDirUriEmitter.fire(this.tryGetDataDirUri());
+    }
+    if (this.config.messages?.length) {
+      const message = this.config.messages.join(' ');
+      // toast the error later otherwise it might not show up in IDE2
+      setTimeout(() => this.messageService.error(message), 1_000);
+    }
+  }
+}

--- a/arduino-ide-extension/src/browser/contributions/add-zip-library.ts
+++ b/arduino-ide-extension/src/browser/contributions/add-zip-library.ts
@@ -2,7 +2,6 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import * as remote from '@theia/core/electron-shared/@electron/remote';
 import URI from '@theia/core/lib/common/uri';
 import { ConfirmDialog } from '@theia/core/lib/browser/dialogs';
-import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { LibraryService, ResponseServiceClient } from '../../common/protocol';
 import { ExecuteWithProgress } from '../../common/protocol/progressible';
@@ -16,9 +15,6 @@ import { nls } from '@theia/core/lib/common';
 
 @injectable()
 export class AddZipLibrary extends SketchContribution {
-  @inject(EnvVariablesServer)
-  private readonly envVariableServer: EnvVariablesServer;
-
   @inject(ResponseServiceClient)
   private readonly responseService: ResponseServiceClient;
 

--- a/arduino-ide-extension/src/browser/contributions/archive-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/archive-sketch.ts
@@ -1,7 +1,6 @@
 import { injectable } from '@theia/core/shared/inversify';
 import * as remote from '@theia/core/electron-shared/@electron/remote';
 import * as dateFormat from 'dateformat';
-import URI from '@theia/core/lib/common/uri';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import {
   SketchContribution,
@@ -29,10 +28,7 @@ export class ArchiveSketch extends SketchContribution {
   }
 
   private async archiveSketch(): Promise<void> {
-    const [sketch, config] = await Promise.all([
-      this.sketchServiceClient.currentSketch(),
-      this.configService.getConfiguration(),
-    ]);
+    const sketch = await this.sketchServiceClient.currentSketch();
     if (!CurrentSketch.isValid(sketch)) {
       return;
     }
@@ -40,9 +36,9 @@ export class ArchiveSketch extends SketchContribution {
       new Date(),
       'yymmdd'
     )}a.zip`;
-    const defaultPath = await this.fileService.fsPath(
-      new URI(config.sketchDirUri).resolve(archiveBasename)
-    );
+    const defaultContainerUri = await this.defaultUri();
+    const defaultUri = defaultContainerUri.resolve(archiveBasename);
+    const defaultPath = await this.fileService.fsPath(defaultUri);
     const { filePath, canceled } = await remote.dialog.showSaveDialog(
       remote.getCurrentWindow(),
       {

--- a/arduino-ide-extension/src/browser/contributions/board-selection.ts
+++ b/arduino-ide-extension/src/browser/contributions/board-selection.ts
@@ -155,10 +155,7 @@ PID: ${PID}`;
     );
 
     // Ports submenu
-    const portsSubmenuPath = [
-      ...ArduinoMenus.TOOLS__BOARD_SELECTION_GROUP,
-      '2_ports',
-    ];
+    const portsSubmenuPath = ArduinoMenus.TOOLS__PORTS_SUBMENU;
     const portsSubmenuLabel = config.selectedPort?.address;
     this.menuModelRegistry.registerSubmenu(
       portsSubmenuPath,

--- a/arduino-ide-extension/src/browser/contributions/contribution.ts
+++ b/arduino-ide-extension/src/browser/contributions/contribution.ts
@@ -12,6 +12,7 @@ import { MaybePromise } from '@theia/core/lib/common/types';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
 import { MessageService } from '@theia/core/lib/common/message-service';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { open, OpenerService } from '@theia/core/lib/browser/opener-service';
 
 import {
@@ -43,7 +44,6 @@ import {
 } from '../../common/protocol/sketches-service-client-impl';
 import {
   SketchesService,
-  ConfigService,
   FileSystemExt,
   Sketch,
   CoreService,
@@ -62,6 +62,7 @@ import { NotificationManager } from '../theia/messages/notifications-manager';
 import { MessageType } from '@theia/core/lib/common/message-service-protocol';
 import { WorkspaceService } from '../theia/workspace/workspace-service';
 import { MainMenuManager } from '../../common/main-menu-manager';
+import { ConfigServiceClient } from '../config/config-service-client';
 
 export {
   Command,
@@ -142,8 +143,8 @@ export abstract class SketchContribution extends Contribution {
   @inject(FileSystemExt)
   protected readonly fileSystemExt: FileSystemExt;
 
-  @inject(ConfigService)
-  protected readonly configService: ConfigService;
+  @inject(ConfigServiceClient)
+  protected readonly configService: ConfigServiceClient;
 
   @inject(SketchesService)
   protected readonly sketchService: SketchesService;
@@ -160,6 +161,9 @@ export abstract class SketchContribution extends Contribution {
   @inject(OutputChannelManager)
   protected readonly outputChannelManager: OutputChannelManager;
 
+  @inject(EnvVariablesServer)
+  protected readonly envVariableServer: EnvVariablesServer;
+
   protected async sourceOverride(): Promise<Record<string, string>> {
     const override: Record<string, string> = {};
     const sketch = await this.sketchServiceClient.currentSketch();
@@ -172,6 +176,25 @@ export abstract class SketchContribution extends Contribution {
       }
     }
     return override;
+  }
+
+  /**
+   * Defaults to `directories.user` if defined and not CLI config errors were detected.
+   * Otherwise, the URI of the user home directory.
+   */
+  protected async defaultUri(): Promise<URI> {
+    const errors = this.configService.tryGetMessages();
+    let defaultUri = this.configService.tryGetSketchDirUri();
+    if (!defaultUri || errors?.length) {
+      // Fall back to user home when the `directories.user` is not available or there are known CLI config errors
+      defaultUri = new URI(await this.envVariableServer.getHomeDirUri());
+    }
+    return defaultUri;
+  }
+
+  protected async defaultPath(): Promise<string> {
+    const defaultUri = await this.defaultUri();
+    return this.fileService.fsPath(defaultUri);
   }
 }
 

--- a/arduino-ide-extension/src/browser/contributions/examples.ts
+++ b/arduino-ide-extension/src/browser/contributions/examples.ts
@@ -29,6 +29,7 @@ import {
   CoreService,
 } from '../../common/protocol';
 import { nls } from '@theia/core/lib/common';
+import { unregisterSubmenu } from '../menu/arduino-menus';
 
 @injectable()
 export abstract class Examples extends SketchContribution {
@@ -36,7 +37,7 @@ export abstract class Examples extends SketchContribution {
   private readonly commandRegistry: CommandRegistry;
 
   @inject(MenuModelRegistry)
-  private readonly menuRegistry: MenuModelRegistry;
+  protected readonly menuRegistry: MenuModelRegistry;
 
   @inject(ExamplesService)
   protected readonly examplesService: ExamplesService;
@@ -47,12 +48,21 @@ export abstract class Examples extends SketchContribution {
   @inject(BoardsServiceProvider)
   protected readonly boardsServiceClient: BoardsServiceProvider;
 
+  @inject(NotificationCenter)
+  protected readonly notificationCenter: NotificationCenter;
+
   protected readonly toDispose = new DisposableCollection();
 
   protected override init(): void {
     super.init();
     this.boardsServiceClient.onBoardsConfigChanged(({ selectedBoard }) =>
       this.handleBoardChanged(selectedBoard)
+    );
+    this.notificationCenter.onDidReinitialize(() =>
+      this.update({
+        board: this.boardsServiceClient.boardsConfig.selectedBoard,
+        // No force refresh. The core client was already refreshed.
+      })
     );
   }
 
@@ -120,6 +130,11 @@ export abstract class Examples extends SketchContribution {
         const { label } = sketchContainerOrPlaceholder;
         submenuPath = [...menuPath, label];
         this.menuRegistry.registerSubmenu(submenuPath, label, subMenuOptions);
+        this.toDispose.push(
+          Disposable.create(() =>
+            unregisterSubmenu(submenuPath, this.menuRegistry)
+          )
+        );
         sketches.push(...sketchContainerOrPlaceholder.sketches);
         children.push(...sketchContainerOrPlaceholder.children);
       } else {
@@ -239,9 +254,6 @@ export class BuiltInExamples extends Examples {
 
 @injectable()
 export class LibraryExamples extends Examples {
-  @inject(NotificationCenter)
-  private readonly notificationCenter: NotificationCenter;
-
   private readonly queue = new PQueue({ autoStart: true, concurrency: 1 });
 
   override onStart(): void {

--- a/arduino-ide-extension/src/browser/contributions/include-library.ts
+++ b/arduino-ide-extension/src/browser/contributions/include-library.ts
@@ -53,6 +53,7 @@ export class IncludeLibrary extends SketchContribution {
     this.notificationCenter.onLibraryDidUninstall(() =>
       this.updateMenuActions()
     );
+    this.notificationCenter.onDidReinitialize(() => this.updateMenuActions());
   }
 
   override async onReady(): Promise<void> {

--- a/arduino-ide-extension/src/browser/contributions/open-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch.ts
@@ -82,10 +82,7 @@ export class OpenSketch extends SketchContribution {
   }
 
   private async selectSketch(): Promise<Sketch | undefined> {
-    const config = await this.configService.getConfiguration();
-    const defaultPath = await this.fileService.fsPath(
-      new URI(config.sketchDirUri)
-    );
+    const defaultPath = await this.defaultPath();
     const { filePaths } = await remote.dialog.showOpenDialog(
       remote.getCurrentWindow(),
       {

--- a/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
@@ -58,10 +58,7 @@ export class SaveAsSketch extends SketchContribution {
       markAsRecentlyOpened,
     }: SaveAsSketch.Options = SaveAsSketch.Options.DEFAULT
   ): Promise<boolean> {
-    const [sketch, configuration] = await Promise.all([
-      this.sketchServiceClient.currentSketch(),
-      this.configService.getConfiguration(),
-    ]);
+    const sketch = await this.sketchServiceClient.currentSketch();
     if (!CurrentSketch.isValid(sketch)) {
       return false;
     }
@@ -72,7 +69,7 @@ export class SaveAsSketch extends SketchContribution {
     }
 
     const sketchUri = new URI(sketch.uri);
-    const sketchbookDirUri = new URI(configuration.sketchDirUri);
+    const sketchbookDirUri = await this.defaultUri();
     // If the sketch is temp, IDE2 proposes the default sketchbook folder URI.
     // If the sketch is not temp, but not contained in the default sketchbook folder, IDE2 proposes the default location.
     // Otherwise, it proposes the parent folder of the current sketch.

--- a/arduino-ide-extension/src/browser/contributions/sketchbook.ts
+++ b/arduino-ide-extension/src/browser/contributions/sketchbook.ts
@@ -11,6 +11,7 @@ import { nls } from '@theia/core/lib/common/nls';
 export class Sketchbook extends Examples {
   override onStart(): void {
     this.sketchServiceClient.onSketchbookDidChange(() => this.update());
+    this.configService.onDidChangeSketchDirUri(() => this.update());
   }
 
   override async onReady(): Promise<void> {

--- a/arduino-ide-extension/src/browser/menu/arduino-menus.ts
+++ b/arduino-ide-extension/src/browser/menu/arduino-menus.ts
@@ -97,6 +97,11 @@ export namespace ArduinoMenus {
   export const TOOLS__BOARD_SELECTION_GROUP = [...TOOLS, '2_board_selection'];
   // Core settings, such as `Processor` and `Programmers` for the board and `Burn Bootloader`
   export const TOOLS__BOARD_SETTINGS_GROUP = [...TOOLS, '3_board_settings'];
+  // `Tool` > `Ports` (always visible https://github.com/arduino/arduino-ide/issues/655)
+  export const TOOLS__PORTS_SUBMENU = [
+    ...ArduinoMenus.TOOLS__BOARD_SELECTION_GROUP,
+    '2_ports',
+  ];
 
   // -- Help
   // `Getting Started`, `Environment`, `Troubleshooting`, etc.

--- a/arduino-ide-extension/src/browser/notification-center.ts
+++ b/arduino-ide-extension/src/browser/notification-center.ts
@@ -18,7 +18,7 @@ import {
   AttachedBoardsChangeEvent,
   BoardsPackage,
   LibraryPackage,
-  Config,
+  ConfigState,
   Sketch,
   ProgressMessage,
 } from '../common/protocol';
@@ -37,6 +37,7 @@ export class NotificationCenter
   @inject(FrontendApplicationStateService)
   private readonly appStateService: FrontendApplicationStateService;
 
+  private readonly didReinitializeEmitter = new Emitter<void>();
   private readonly indexUpdateDidCompleteEmitter =
     new Emitter<IndexUpdateDidCompleteParams>();
   private readonly indexUpdateWillStartEmitter =
@@ -47,9 +48,7 @@ export class NotificationCenter
     new Emitter<IndexUpdateDidFailParams>();
   private readonly daemonDidStartEmitter = new Emitter<string>();
   private readonly daemonDidStopEmitter = new Emitter<void>();
-  private readonly configDidChangeEmitter = new Emitter<{
-    config: Config | undefined;
-  }>();
+  private readonly configDidChangeEmitter = new Emitter<ConfigState>();
   private readonly platformDidInstallEmitter = new Emitter<{
     item: BoardsPackage;
   }>();
@@ -71,6 +70,7 @@ export class NotificationCenter
     new Emitter<FrontendApplicationState>();
 
   private readonly toDispose = new DisposableCollection(
+    this.didReinitializeEmitter,
     this.indexUpdateWillStartEmitter,
     this.indexUpdateDidProgressEmitter,
     this.indexUpdateDidCompleteEmitter,
@@ -85,6 +85,7 @@ export class NotificationCenter
     this.attachedBoardsDidChangeEmitter
   );
 
+  readonly onDidReinitialize = this.didReinitializeEmitter.event;
   readonly onIndexUpdateDidComplete = this.indexUpdateDidCompleteEmitter.event;
   readonly onIndexUpdateWillStart = this.indexUpdateWillStartEmitter.event;
   readonly onIndexUpdateDidProgress = this.indexUpdateDidProgressEmitter.event;
@@ -115,6 +116,10 @@ export class NotificationCenter
     this.toDispose.dispose();
   }
 
+  notifyDidReinitialize(): void {
+    this.didReinitializeEmitter.fire();
+  }
+
   notifyIndexUpdateWillStart(params: IndexUpdateWillStartParams): void {
     this.indexUpdateWillStartEmitter.fire(params);
   }
@@ -139,7 +144,7 @@ export class NotificationCenter
     this.daemonDidStopEmitter.fire();
   }
 
-  notifyConfigDidChange(event: { config: Config | undefined }): void {
+  notifyConfigDidChange(event: ConfigState): void {
     this.configDidChangeEmitter.fire(event);
   }
 

--- a/arduino-ide-extension/src/browser/theia/core/tab-bar-decorator.ts
+++ b/arduino-ide-extension/src/browser/theia/core/tab-bar-decorator.ts
@@ -1,30 +1,35 @@
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { Title, Widget } from '@theia/core/shared/@phosphor/widgets';
-import { ILogger } from '@theia/core/lib/common/logger';
 import { EditorWidget } from '@theia/editor/lib/browser';
 import { WidgetDecoration } from '@theia/core/lib/browser/widget-decoration';
 import { TabBarDecoratorService as TheiaTabBarDecoratorService } from '@theia/core/lib/browser/shell/tab-bar-decorator';
-import { ConfigService } from '../../../common/protocol/config-service';
+import { ConfigServiceClient } from '../../config/config-service-client';
+import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 
 @injectable()
 export class TabBarDecoratorService extends TheiaTabBarDecoratorService {
-  @inject(ConfigService)
-  protected readonly configService: ConfigService;
+  @inject(ConfigServiceClient)
+  private readonly configService: ConfigServiceClient;
+  @inject(FrontendApplicationStateService)
+  private readonly appStateService: FrontendApplicationStateService;
 
-  @inject(ILogger)
-  protected readonly logger: ILogger;
-
-  protected dataDirUri: URI | undefined;
+  private dataDirUri: URI | undefined;
 
   @postConstruct()
   protected init(): void {
-    this.configService
-      .getConfiguration()
-      .then(({ dataDirUri }) => (this.dataDirUri = new URI(dataDirUri)))
-      .catch((err) =>
-        this.logger.error(`Failed to determine the data directory: ${err}`)
-      );
+    const fireDidChange = () =>
+      this.appStateService
+        .reachedState('ready')
+        .then(() => this.fireDidChangeDecorations());
+    this.dataDirUri = this.configService.tryGetDataDirUri();
+    this.configService.onDidChangeDataDirUri((dataDirUri) => {
+      this.dataDirUri = dataDirUri;
+      fireDidChange();
+    });
+    if (this.dataDirUri) {
+      fireDidChange();
+    }
   }
 
   override getDecorations(title: Title<Widget>): WidgetDecoration.Data[] {

--- a/arduino-ide-extension/src/browser/theia/markers/problem-manager.ts
+++ b/arduino-ide-extension/src/browser/theia/markers/problem-manager.ts
@@ -5,31 +5,23 @@ import {
 } from '@theia/core/shared/inversify';
 import { Diagnostic } from '@theia/core/shared/vscode-languageserver-types';
 import URI from '@theia/core/lib/common/uri';
-import { ILogger } from '@theia/core';
 import { Marker } from '@theia/markers/lib/common/marker';
 import { ProblemManager as TheiaProblemManager } from '@theia/markers/lib/browser/problem/problem-manager';
-import { ConfigService } from '../../../common/protocol/config-service';
+import { ConfigServiceClient } from '../../config/config-service-client';
 import debounce = require('lodash.debounce');
 
 @injectable()
 export class ProblemManager extends TheiaProblemManager {
-  @inject(ConfigService)
-  protected readonly configService: ConfigService;
+  @inject(ConfigServiceClient)
+  private readonly configService: ConfigServiceClient;
 
-  @inject(ILogger)
-  protected readonly logger: ILogger;
-
-  protected dataDirUri: URI | undefined;
+  private dataDirUri: URI | undefined;
 
   @postConstruct()
   protected override init(): void {
     super.init();
-    this.configService
-      .getConfiguration()
-      .then(({ dataDirUri }) => (this.dataDirUri = new URI(dataDirUri)))
-      .catch((err) =>
-        this.logger.error(`Failed to determine the data directory: ${err}`)
-      );
+    this.dataDirUri = this.configService.tryGetDataDirUri();
+    this.configService.onDidChangeDataDirUri((uri) => (this.dataDirUri = uri));
   }
 
   override setMarkers(

--- a/arduino-ide-extension/src/common/protocol/config-service.ts
+++ b/arduino-ide-extension/src/common/protocol/config-service.ts
@@ -6,10 +6,12 @@ export interface ConfigService {
   getVersion(): Promise<
     Readonly<{ version: string; commit: string; status?: string }>
   >;
-  getCliConfigFileUri(): Promise<string>;
-  getConfiguration(): Promise<Config>;
+  getConfiguration(): Promise<ConfigState>;
   setConfiguration(config: Config): Promise<void>;
 }
+export type ConfigState =
+  | { config: undefined; messages: string[] }
+  | { config: Config; messages?: string[] };
 
 export interface Daemon {
   readonly port: string | number;
@@ -119,7 +121,16 @@ export interface Config {
   readonly network: Network;
 }
 export namespace Config {
-  export function sameAs(left: Config, right: Config): boolean {
+  export function sameAs(
+    left: Config | undefined,
+    right: Config | undefined
+  ): boolean {
+    if (!left) {
+      return !right;
+    }
+    if (!right) {
+      return false;
+    }
     const leftUrls = left.additionalUrls.sort();
     const rightUrls = right.additionalUrls.sort();
     if (leftUrls.length !== rightUrls.length) {
@@ -150,7 +161,16 @@ export namespace AdditionalUrls {
   export function stringify(additionalUrls: AdditionalUrls): string {
     return additionalUrls.join(',');
   }
-  export function sameAs(left: AdditionalUrls, right: AdditionalUrls): boolean {
+  export function sameAs(
+    left: AdditionalUrls | undefined,
+    right: AdditionalUrls | undefined
+  ): boolean {
+    if (!left) {
+      return !right;
+    }
+    if (!right) {
+      return false;
+    }
     if (left.length !== right.length) {
       return false;
     }

--- a/arduino-ide-extension/src/common/protocol/notification-service.ts
+++ b/arduino-ide-extension/src/common/protocol/notification-service.ts
@@ -2,7 +2,7 @@ import type { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-facto
 import type {
   AttachedBoardsChangeEvent,
   BoardsPackage,
-  Config,
+  ConfigState,
   ProgressMessage,
   Sketch,
   IndexType,
@@ -39,6 +39,11 @@ export interface IndexUpdateDidFailParams extends IndexUpdateParams {
 }
 
 export interface NotificationServiceClient {
+  // The cached state of the core client. Libraries, examples, etc. has been updated.
+  // This can happen without an index update. For example, changing the `directories.user` location.
+  // An index update always implicitly involves a re-initialization without notifying via this method.
+  notifyDidReinitialize(): void;
+
   // Index
   notifyIndexUpdateWillStart(params: IndexUpdateWillStartParams): void;
   notifyIndexUpdateDidProgress(progressMessage: ProgressMessage): void;
@@ -50,7 +55,7 @@ export interface NotificationServiceClient {
   notifyDaemonDidStop(): void;
 
   // CLI config
-  notifyConfigDidChange(event: { config: Config | undefined }): void;
+  notifyConfigDidChange(event: ConfigState): void;
 
   // Platforms
   notifyPlatformDidInstall(event: { item: BoardsPackage }): void;

--- a/arduino-ide-extension/src/node/clang-formatter.ts
+++ b/arduino-ide-extension/src/node/clang-formatter.ts
@@ -79,9 +79,12 @@ export class ClangFormatter implements Formatter {
     return `-style="${style(toClangOptions(options))}"`;
   }
 
-  private async dataDirPath(): Promise<string> {
-    const { dataDirUri } = await this.configService.getConfiguration();
-    return FileUri.fsPath(dataDirUri);
+  private async dataDirPath(): Promise<string | undefined> {
+    const { config } = await this.configService.getConfiguration();
+    if (!config?.dataDirUri) {
+      return undefined;
+    }
+    return FileUri.fsPath(config.dataDirUri);
   }
 
   private async configDirPath(): Promise<string> {
@@ -90,9 +93,13 @@ export class ClangFormatter implements Formatter {
   }
 
   private async clangConfigPath(
-    folderUri: MaybePromise<string>
+    folderUri: MaybePromise<string | undefined>
   ): Promise<string | undefined> {
-    const folderPath = FileUri.fsPath(await folderUri);
+    const uri = await folderUri;
+    if (!uri) {
+      return undefined;
+    }
+    const folderPath = FileUri.fsPath(uri);
     const clangFormatPath = join(folderPath, ClangFormatFile);
     try {
       await fs.access(clangFormatPath, constants.R_OK);

--- a/arduino-ide-extension/src/node/notification-service-server.ts
+++ b/arduino-ide-extension/src/node/notification-service-server.ts
@@ -5,7 +5,7 @@ import type {
   AttachedBoardsChangeEvent,
   BoardsPackage,
   LibraryPackage,
-  Config,
+  ConfigState,
   Sketch,
   ProgressMessage,
   IndexUpdateWillStartParams,
@@ -18,6 +18,10 @@ export class NotificationServiceServerImpl
   implements NotificationServiceServer
 {
   private readonly clients: NotificationServiceClient[] = [];
+
+  notifyDidReinitialize(): void {
+    this.clients.forEach((client) => client.notifyDidReinitialize());
+  }
 
   notifyIndexUpdateWillStart(params: IndexUpdateWillStartParams): void {
     this.clients.forEach((client) => client.notifyIndexUpdateWillStart(params));
@@ -69,7 +73,7 @@ export class NotificationServiceServerImpl
     );
   }
 
-  notifyConfigDidChange(event: { config: Config | undefined }): void {
+  notifyConfigDidChange(event: ConfigState): void {
     this.clients.forEach((client) => client.notifyConfigDidChange(event));
   }
 

--- a/arduino-ide-extension/src/node/sketches-service-impl.ts
+++ b/arduino-ide-extension/src/node/sketches-service-impl.ts
@@ -80,6 +80,15 @@ export class SketchesServiceImpl
 
   async getSketches({ uri }: { uri?: string }): Promise<SketchContainer> {
     const root = await this.root(uri);
+    if (!root) {
+      this.logger.warn(`Could not derive sketchbook root from ${uri}.`);
+      return SketchContainer.create('');
+    }
+    const exists = await this.exists(root);
+    if (!exists) {
+      this.logger.warn(`Sketchbook root ${root} does not exist.`);
+      return SketchContainer.create('');
+    }
     const pathToAllSketchFiles = await new Promise<string[]>(
       (resolve, reject) => {
         glob(
@@ -179,13 +188,23 @@ export class SketchesServiceImpl
     return container;
   }
 
-  private async root(uri?: string | undefined): Promise<string> {
-    return FileUri.fsPath(uri ?? (await this.sketchbookUri()));
+  private async root(uri?: string | undefined): Promise<string | undefined> {
+    if (uri) {
+      return FileUri.fsPath(uri);
+    }
+    const sketchbookUri = await this.sketchbookUri();
+    if (sketchbookUri) {
+      return FileUri.fsPath(sketchbookUri);
+    }
+    return undefined;
   }
 
-  private async sketchbookUri(): Promise<string> {
-    const { sketchDirUri } = await this.configService.getConfiguration();
-    return sketchDirUri;
+  private async sketchbookUri(): Promise<string | undefined> {
+    const { config, messages } = await this.configService.getConfiguration();
+    if (!config?.sketchDirUri || messages?.length) {
+      return undefined;
+    }
+    return config.sketchDirUri;
   }
 
   async loadSketch(uri: string): Promise<SketchWithDetails> {
@@ -454,8 +473,10 @@ export class SketchesServiceImpl
     const sketchBaseName = `sketch_${
       monthNames[today.getMonth()]
     }${today.getDate()}`;
-    const config = await this.configService.getConfiguration();
-    const sketchbookPath = FileUri.fsPath(config.sketchDirUri);
+    const { config } = await this.configService.getConfiguration();
+    const sketchbookPath = config?.sketchDirUri
+      ? FileUri.fsPath(config?.sketchDirUri)
+      : os.homedir();
     let sketchName: string | undefined;
 
     // If it's another day, reset the count of sketches created today

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -157,6 +157,11 @@
       "uninstallMsg": "Do you want to uninstall {0}?",
       "version": "Version {0}"
     },
+    "configuration": {
+      "cli": {
+        "inaccessibleDirectory": "Could not access the sketchbook location at '{0}': {1}"
+      }
+    },
     "contributions": {
       "addFile": "Add File",
       "fileAdded": "One file added to the sketch.",
@@ -352,6 +357,7 @@
       "manualProxy": "Manual proxy configuration",
       "network": "Network",
       "newSketchbookLocation": "Select new sketchbook location",
+      "noCliConfig": "Could not load the CLI configuration",
       "noProxy": "No proxy",
       "proxySettings": {
         "hostname": "Host name",


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

 - Handle invalid `directories.user` path in `arduino-cli.yaml` at app startup.
 - Change the sketchbook location from IDE2 without a restart.
 - Show the `File` > `Sketchbook` menu item even if no sketches are in the folder.
 - Show the `Tools` > `Port` menu item even if there are no available ports.

Preview:

https://user-images.githubusercontent.com/1405703/207853423-3c1e3502-9904-49d2-b2af-8ef01367af19.mp4


### Change description

 - IDE2 can start when `directories.user` is invalid or does not exist.
 - If `directories.user` is not a valid directory, IDE2 toasts an error message at startup.
 - `Save As...`, `Open`, `Archive Sketch`, and `Add .ZIP Library...` are fully functional when there is no valid `directories.user` value is set.
 - If `directories.user` does not exist, IDE2 tries to create the folder.
 - It's possible to change the `directories.user` location from the IDE2's _Settings_ dialog.
 - When the user changes the `directories.user`, `File` > `Sketchbook`, `File` > `Examples`, and `Sketch` > Include Library` submenus update.
 - When the `directories.user` is invalid or empty, `File` > `Sketchbook` is visible but disabled.
 - `Tools` > `Port` is visible but disabled when no available ports are detected.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1764
Closes #796
Closes #569
Closes #655

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)