### PR TITLE
Replace socks with socks5 in proxy protocol

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
@@ -406,7 +406,7 @@ export class SettingsComponent extends React.Component<
                 }
                 onChange={this.socksProtocolDidChange}
               />
-              SOCKS
+              SOCKS5
             </label>
           </form>
           <div className="flex-line proxy-settings">
@@ -682,7 +682,7 @@ export class SettingsComponent extends React.Component<
   ): void => {
     if (this.state.network !== 'none') {
       const network = this.cloneProxySettings;
-      network.protocol = event.target.checked ? 'http' : 'socks';
+      network.protocol = event.target.checked ? 'http' : 'socks5';
       this.setState({ network });
     }
   };
@@ -692,7 +692,7 @@ export class SettingsComponent extends React.Component<
   ): void => {
     if (this.state.network !== 'none') {
       const network = this.cloneProxySettings;
-      network.protocol = event.target.checked ? 'socks' : 'http';
+      network.protocol = event.target.checked ? 'socks5' : 'http';
       this.setState({ network });
     }
   };


### PR DESCRIPTION
### Motivation
Fixes #1769
The net/http package in arduino-cli supports `socks5` as scheme rather than `socks`. This PR replaces `socks` with `socks5` in proxy protocol to make socks proxy work.

### Change description
1. Replaces `socks` with `socks5` in proxy protocol
2. Show `SOCKS5` in `Preferences`->`Network`

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)