### PR TITLE
Remove trailing colon when parsing the protocol from URL

### DIFF
--- a/arduino-ide-extension/src/common/protocol/config-service.ts
+++ b/arduino-ide-extension/src/common/protocol/config-service.ts
@@ -60,8 +60,10 @@ export namespace Network {
     try {
       // Patter: PROTOCOL://USER:PASS@HOSTNAME:PORT/
       const { protocol, hostname, password, username, port } = new URL(raw);
+      // protocol in URL object contains a trailing colon
+      const newProtocol = protocol.replace(/:$/, '');
       return {
-        protocol,
+        newProtocol,
         hostname,
         password,
         username,

--- a/arduino-ide-extension/src/common/protocol/config-service.ts
+++ b/arduino-ide-extension/src/common/protocol/config-service.ts
@@ -63,7 +63,7 @@ export namespace Network {
       // protocol in URL object contains a trailing colon
       const newProtocol = protocol.replace(/:$/, '');
       return {
-        newProtocol,
+        protocol: newProtocol,
         hostname,
         password,
         username,


### PR DESCRIPTION
### Motivation
This PR should fix #1775

### Change description
Remove the trailing colon when parsing the protocol in URL string

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)