### PR TITLE
feat: no remote fetch when IDE gets CLI version

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/about.ts
+++ b/arduino-ide-extension/src/browser/contributions/about.ts
@@ -41,22 +41,16 @@ export class About extends Contribution {
   }
 
   async showAbout(): Promise<void> {
-    const {
-      version,
-      commit,
-      status: cliStatus,
-    } = await this.configService.getVersion();
+    const version = await this.configService.getVersion();
     const buildDate = this.buildDate;
     const detail = (showAll: boolean) =>
       nls.localize(
         'arduino/about/detail',
-        'Version: {0}\nDate: {1}{2}\nCLI Version: {3}{4} [{5}]\n\n{6}',
+        'Version: {0}\nDate: {1}{2}\nCLI Version: {3}\n\n{4}',
         remote.app.getVersion(),
         buildDate ? buildDate : nls.localize('', 'dev build'),
         buildDate && showAll ? ` (${this.ago(buildDate)})` : '',
         version,
-        cliStatus ? ` ${cliStatus}` : '',
-        commit,
         nls.localize(
           'arduino/about/copyright',
           'Copyright © {0} Arduino SA',

--- a/arduino-ide-extension/src/common/protocol/config-service.ts
+++ b/arduino-ide-extension/src/common/protocol/config-service.ts
@@ -3,9 +3,7 @@ import { RecursivePartial } from '@theia/core/lib/common/types';
 export const ConfigServicePath = '/services/config-service';
 export const ConfigService = Symbol('ConfigService');
 export interface ConfigService {
-  getVersion(): Promise<
-    Readonly<{ version: string; commit: string; status?: string }>
-  >;
+  getVersion(): Promise<Readonly<string>>;
   getConfiguration(): Promise<ConfigState>;
   setConfiguration(config: Config): Promise<void>;
 }

--- a/arduino-ide-extension/src/node/arduino-daemon-impl.ts
+++ b/arduino-ide-extension/src/node/arduino-daemon-impl.ts
@@ -15,7 +15,7 @@ import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
 import { ArduinoDaemon, NotificationServiceServer } from '../common/protocol';
 import { CLI_CONFIG } from './cli-config';
-import { getExecPath, spawnCommand } from './exec-util';
+import { getExecPath } from './exec-util';
 import { ErrnoException } from './utils/errors';
 
 @injectable()
@@ -124,28 +124,6 @@ export class ArduinoDaemonImpl
     }
     this._execPath = await getExecPath('arduino-cli', this.onError.bind(this));
     return this._execPath;
-  }
-
-  async getVersion(): Promise<
-    Readonly<{ version: string; commit: string; status?: string }>
-  > {
-    const execPath = await this.getExecPath();
-    const raw = await spawnCommand(
-      `"${execPath}"`,
-      ['version', '--format', 'json'],
-      this.onError.bind(this)
-    );
-    try {
-      // The CLI `Info` object: https://github.com/arduino/arduino-cli/blob/17d24eb901b1fdaa5a4ec7da3417e9e460f84007/version/version.go#L31-L34
-      const { VersionString, Commit, Status } = JSON.parse(raw);
-      return {
-        version: VersionString,
-        commit: Commit,
-        status: Status,
-      };
-    } catch {
-      return { version: raw, commit: raw };
-    }
   }
 
   protected async getSpawnArgs(): Promise<string[]> {

--- a/arduino-ide-extension/src/node/config-service-impl.ts
+++ b/arduino-ide-extension/src/node/config-service-impl.ts
@@ -131,10 +131,8 @@ export class ConfigServiceImpl
     return this.configChangeEmitter.event;
   }
 
-  async getVersion(): Promise<
-    Readonly<{ version: string; commit: string; status?: string }>
-  > {
-    return this.daemon.getVersion();
+  async getVersion(): Promise<string> {
+    return require('../../package.json').arduino?.cli?.version || '';
   }
 
   private async initConfig(): Promise<void> {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,7 +1,7 @@
 {
   "arduino": {
     "about": {
-      "detail": "Version: {0}\nDate: {1}{2}\nCLI Version: {3}{4} [{5}]\n\n{6}",
+      "detail": "Version: {0}\nDate: {1}{2}\nCLI Version: {3}\n\n{4}",
       "label": "About {0}"
     },
     "board": {


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To speed up the load time of the _About_ dialog in IDE2. As requested in #1572, IDE2 reads the CLI version from the `package.json`.

### Change description
<!-- What does your code do? -->

 - 2.0.3:

     <img width="259" alt="Screen Shot 2023-01-06 at 09 59 43" src="https://user-images.githubusercontent.com/1405703/210972070-a9ac3ef7-cb6b-4bc8-ab1e-c481e0be10ab.png">


 - A dev build with the changes:

     <img width="257" alt="Screen Shot 2023-01-06 at 10 06 39" src="https://user-images.githubusercontent.com/1405703/210972041-a7cc8327-c0e7-4b6a-abc9-9237a5f3f4aa.png">


 - Local IDE2 build with the changes:

    <img width="256" alt="Screen Shot 2023-01-06 at 10 24 32" src="https://user-images.githubusercontent.com/1405703/210971994-f0bfe036-e0d1-4a10-b06d-68ac9a2c24fe.png">

### Other information
<!-- Any additional information that could help the review process -->

If the CLI version is a pinned commitish and not a semver, IDE2 will show the commitsh.

Assuming the following pinned CLI version:

```diff
diff --git a/arduino-ide-extension/package.json b/arduino-ide-extension/package.json
index 1b7cc2de..ab4414ea 100644
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -159,7 +159,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.29.0"
+      "version": "alma"
     },
     "fwuploader": {
       "version": "2.2.2"
```

The expected _About_ dialog (with a dev build) is:

<img width="259" alt="Screen Shot 2023-01-06 at 10 07 45" src="https://user-images.githubusercontent.com/1405703/210972799-d2a30994-576c-4739-ac2a-87143701ef7c.png">

Closes #1572

----

It should be possible to run `arduino-cli version --no-fetch` or similar to avoid checking for updates. I have never used a CLI tool before that does a silent remote fetch when getting the only version. If there is a good example, please let me know. CLIs usually warn about the outdated version (`brew`, `npm`, `yarn`, etc.) when users execute a command that requires the Intenet connection. The Arduino CLI ought to warn the user on `core index-update` or `lib install` but not on `version`.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)