### PR TITLE
feat: removed encoding from the status bar

### DIFF
--- a/arduino-ide-extension/src/browser/theia/editor/editor-contribution.ts
+++ b/arduino-ide-extension/src/browser/theia/editor/editor-contribution.ts
@@ -10,4 +10,12 @@ export class EditorContribution extends TheiaEditorContribution {
   ): void {
     // NOOP
   }
+
+  protected override updateEncodingStatus(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars, unused-imports/no-unused-vars
+    editor: TextEditor | undefined
+  ): void {
+    // https://github.com/arduino/arduino-ide/issues/1393
+    // NOOP
+  }
 }


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The editor encoding is not represented on the status bar anymore.

### Change description
<!-- What does your code do? -->

Start IDE, and see that the encoding is not present in the UI:

<img width="675" alt="Screen Shot 2023-01-06 at 13 38 10" src="https://user-images.githubusercontent.com/1405703/211014136-8ee2b3a3-1e8b-4c0a-bb9a-1db0be6cf5ec.png">


### Other information
<!-- Any additional information that could help the review process -->

Closes #1393

### Reviewer checklist



* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)