### PR TITLE
fix: aligned `Add File...` behavior with IDE 1.x

### DIFF
--- a/arduino-ide-extension/src/common/protocol/sketches-service.ts
+++ b/arduino-ide-extension/src/common/protocol/sketches-service.ts
@@ -162,18 +162,9 @@ export namespace Sketch {
   }
   export namespace Extensions {
     export const MAIN = ['.ino', '.pde'];
-    export const SOURCE = ['.c', '.cpp', '.s'];
-    export const ADDITIONAL = [
-      '.h',
-      '.c',
-      '.hpp',
-      '.hh',
-      '.cpp',
-      '.S',
-      '.json',
-      '.md',
-      '.adoc',
-    ];
+    export const SOURCE = ['.c', '.cpp', '.S'];
+    export const CODE_FILES = [...MAIN, ...SOURCE, '.h', '.hh', '.hpp'];
+    export const ADDITIONAL = [...CODE_FILES, '.json', '.md', '.adoc'];
     export const ALL = Array.from(new Set([...MAIN, ...SOURCE, ...ADDITIONAL]));
   }
   export function isInSketch(uri: string | URI, sketch: Sketch): boolean {


### PR DESCRIPTION

### Motivation
<!-- Why this pull request? -->

As asked for in #284, IDE2 can now add source files to the sketch folder root. Other files go into the `data` folder in the sketch folder root.

### Change description
<!-- What does your code do? -->

 - code files will be copied to the sketch folder root
 - other files go under the `data` folder in the sketch folder root
 - after adding code files to the sketch, new files are expected to open in an editor.


https://user-images.githubusercontent.com/1405703/211023968-00185533-0f4f-426a-8e7c-104dca267070.mp4



### Other information
<!-- Any additional information that could help the review process -->

Closes #284

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)