### PR TITLE
fix: update Examples and Include Library menu after ZIP install

### DIFF
--- a/arduino-ide-extension/src/browser/notification-center.ts
+++ b/arduino-ide-extension/src/browser/notification-center.ts
@@ -56,7 +56,7 @@ export class NotificationCenter
     item: BoardsPackage;
   }>();
   private readonly libraryDidInstallEmitter = new Emitter<{
-    item: LibraryPackage;
+    item: LibraryPackage | 'zip-install';
   }>();
   private readonly libraryDidUninstallEmitter = new Emitter<{
     item: LibraryPackage;
@@ -156,7 +156,9 @@ export class NotificationCenter
     this.platformDidUninstallEmitter.fire(event);
   }
 
-  notifyLibraryDidInstall(event: { item: LibraryPackage }): void {
+  notifyLibraryDidInstall(event: {
+    item: LibraryPackage | 'zip-install';
+  }): void {
     this.libraryDidInstallEmitter.fire(event);
   }
 

--- a/arduino-ide-extension/src/common/protocol/notification-service.ts
+++ b/arduino-ide-extension/src/common/protocol/notification-service.ts
@@ -62,7 +62,9 @@ export interface NotificationServiceClient {
   notifyPlatformDidUninstall(event: { item: BoardsPackage }): void;
 
   // Libraries
-  notifyLibraryDidInstall(event: { item: LibraryPackage }): void;
+  notifyLibraryDidInstall(event: {
+    item: LibraryPackage | 'zip-install';
+  }): void;
   notifyLibraryDidUninstall(event: { item: LibraryPackage }): void;
 
   // Boards discovery

--- a/arduino-ide-extension/src/node/notification-service-server.ts
+++ b/arduino-ide-extension/src/node/notification-service-server.ts
@@ -59,7 +59,9 @@ export class NotificationServiceServerImpl
     this.clients.forEach((client) => client.notifyPlatformDidUninstall(event));
   }
 
-  notifyLibraryDidInstall(event: { item: LibraryPackage }): void {
+  notifyLibraryDidInstall(event: {
+    item: LibraryPackage | 'zip-install';
+  }): void {
     this.clients.forEach((client) => client.notifyLibraryDidInstall(event));
   }
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

After installing a library from a ZIP, IDE2 must update the `File` > `Examples` and `Sketch` > `Include Library` menus to show the freshly installed library (if the selected board is appropriate).

Steps to verify:
 - You have the AVR core installed, start IDE2 and select the Uno board,
 - Check `File` > `Examples` and `Sketch` > `Include Library` menus, `ArduinoMDNS` is not present.
 - Follow the steps from https://github.com/arduino/arduino-ide/issues/659, they're excellent, and the get the library from the ZIP,
 - Install it with `Sketch` > `Include Library` > `Add ZIP Library...`
 - After the installation, check the `File` > `Examples` and `Sketch` > `Include Library` menus, `ArduinoMDNS` is present.


https://user-images.githubusercontent.com/1405703/211270612-5e4142bb-6093-431c-9001-697ea7491dbf.mp4


### Change description
<!-- What does your code do? -->

Closes #659

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)