### PR TITLE
feat: handle when starting debug session failed

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/debug.ts
+++ b/arduino-ide-extension/src/browser/contributions/debug.ts
@@ -246,8 +246,10 @@ export class Debug extends SketchContribution {
   ): Promise<boolean> {
     if (err instanceof Error) {
       try {
-        const tempBuildPath = await this.sketchService.tempBuildPath(sketch);
-        return err.message.includes(tempBuildPath);
+        const tempBuildPaths = await this.sketchService.tempBuildPath(sketch);
+        return tempBuildPaths.some((tempBuildPath) =>
+          err.message.includes(tempBuildPath)
+        );
       } catch {
         return false;
       }

--- a/arduino-ide-extension/src/browser/contributions/debug.ts
+++ b/arduino-ide-extension/src/browser/contributions/debug.ts
@@ -3,7 +3,12 @@ import { Event, Emitter } from '@theia/core/lib/common/event';
 import { HostedPluginSupport } from '@theia/plugin-ext/lib/hosted/browser/hosted-plugin';
 import { ArduinoToolbar } from '../toolbar/arduino-toolbar';
 import { NotificationCenter } from '../notification-center';
-import { Board, BoardsService, ExecutableService } from '../../common/protocol';
+import {
+  Board,
+  BoardsService,
+  ExecutableService,
+  Sketch,
+} from '../../common/protocol';
 import { BoardsServiceProvider } from '../boards/boards-service-provider';
 import {
   URI,
@@ -16,9 +21,8 @@ import { MaybePromise, MenuModelRegistry, nls } from '@theia/core/lib/common';
 import { CurrentSketch } from '../../common/protocol/sketches-service-client-impl';
 import { ArduinoMenus } from '../menu/arduino-menus';
 
-import { MainMenuManager } from '../../common/main-menu-manager';
-
 const COMPILE_FOR_DEBUG_KEY = 'arduino-compile-for-debug';
+
 @injectable()
 export class Debug extends SketchContribution {
   @inject(HostedPluginSupport)
@@ -35,9 +39,6 @@ export class Debug extends SketchContribution {
 
   @inject(BoardsServiceProvider)
   private readonly boardsServiceProvider: BoardsServiceProvider;
-
-  @inject(MainMenuManager)
-  private readonly mainMenuManager: MainMenuManager;
 
   /**
    * If `undefined`, debugging is enabled. Otherwise, the reason why it's disabled.
@@ -203,7 +204,28 @@ export class Debug extends SketchContribution {
       sketchPath,
       configPath,
     };
-    return this.commandService.executeCommand('arduino.debug.start', config);
+    try {
+      await this.commandService.executeCommand('arduino.debug.start', config);
+    } catch (err) {
+      if (await this.isSketchNotVerifiedError(err, sketch)) {
+        const yes = nls.localize('vscode/extensionsUtils/yes', 'Yes');
+        const answer = await this.messageService.error(
+          nls.localize(
+            'arduino/debug/sketchIsNotCompiled',
+            "Sketch '{0}' must be verified before starting a debug session. Please verify the sketch and start debugging again. Do you want to verify the sketch now?",
+            sketch.name
+          ),
+          yes
+        );
+        if (answer === yes) {
+          this.commandService.executeCommand('arduino-verify-sketch');
+        }
+      } else {
+        this.messageService.error(
+          err instanceof Error ? err.message : String(err)
+        );
+      }
+    }
   }
 
   get compileForDebug(): boolean {
@@ -215,7 +237,22 @@ export class Debug extends SketchContribution {
     const oldState = this.compileForDebug;
     const newState = !oldState;
     window.localStorage.setItem(COMPILE_FOR_DEBUG_KEY, String(newState));
-    this.mainMenuManager.update();
+    this.menuManager.update();
+  }
+
+  private async isSketchNotVerifiedError(
+    err: unknown,
+    sketch: Sketch
+  ): Promise<boolean> {
+    if (err instanceof Error) {
+      try {
+        const tempBuildPath = await this.sketchService.tempBuildPath(sketch);
+        return err.message.includes(tempBuildPath);
+      } catch {
+        return false;
+      }
+    }
+    return false;
   }
 }
 export namespace Debug {

--- a/arduino-ide-extension/src/common/protocol/sketches-service.ts
+++ b/arduino-ide-extension/src/common/protocol/sketches-service.ts
@@ -105,6 +105,12 @@ export interface SketchesService {
    * Recursively deletes the sketch folder with all its content.
    */
   deleteSketch(sketch: Sketch): Promise<void>;
+
+  /**
+   * This is the JS/TS re-implementation of [`GenBuildPath`](https://github.com/arduino/arduino-cli/blob/c0d4e4407d80aabad81142693513b3306759cfa6/arduino/sketch/sketch.go#L296-L306) of the CLI.
+   * Pass in a sketch and get the build temporary folder filesystem path calculated from the main sketch file location. This method does not check the existence of the sketch.
+   */
+  tempBuildPath(sketch: Sketch): Promise<string>;
 }
 
 export interface SketchRef {

--- a/arduino-ide-extension/src/common/protocol/sketches-service.ts
+++ b/arduino-ide-extension/src/common/protocol/sketches-service.ts
@@ -108,9 +108,14 @@ export interface SketchesService {
 
   /**
    * This is the JS/TS re-implementation of [`GenBuildPath`](https://github.com/arduino/arduino-cli/blob/c0d4e4407d80aabad81142693513b3306759cfa6/arduino/sketch/sketch.go#L296-L306) of the CLI.
-   * Pass in a sketch and get the build temporary folder filesystem path calculated from the main sketch file location. This method does not check the existence of the sketch.
+   * Pass in a sketch and get the build temporary folder filesystem path calculated from the main sketch file location. Can be multiple ones. This method does not check the existence of the sketch.
+   *
+   * The case sensitivity of the drive letter on Windows matters when the CLI calculates the MD5 hash of the temporary build folder.
+   * IDE2 does not know and does not want to rely on how the CLI treats the paths: with lowercase or uppercase drive letters.
+   * Hence, IDE2 has to provide multiple build paths on Windows. This hack will be obsolete when the CLI can provide error codes:
+   * https://github.com/arduino/arduino-cli/issues/1762.
    */
-  tempBuildPath(sketch: Sketch): Promise<string>;
+  tempBuildPath(sketch: Sketch): Promise<string[]>;
 }
 
 export interface SketchRef {

--- a/arduino-ide-extension/src/common/utils.ts
+++ b/arduino-ide-extension/src/common/utils.ts
@@ -13,6 +13,10 @@ export function firstToUpperCase(what: string): string {
   return what.charAt(0).toUpperCase() + what.slice(1);
 }
 
-export function isNullOrUndefined(what: any): what is undefined | null {
+export function startsWithUpperCase(what: string): boolean {
+  return !!what && what.charAt(0) === firstToUpperCase(what.charAt(0));
+}
+
+export function isNullOrUndefined(what: unknown): what is undefined | null {
   return what === undefined || what === null;
 }

--- a/arduino-ide-extension/src/node/is-temp-sketch.ts
+++ b/arduino-ide-extension/src/node/is-temp-sketch.ts
@@ -10,10 +10,10 @@ export const TempSketchPrefix = '.arduinoIDE-unsaved';
 @injectable()
 export class IsTempSketch {
   // If on macOS, the `temp-dir` lib will make sure there is resolved realpath.
-  // If on Windows, the `C:\Users\KITTAA~1\AppData\Local\Temp` path will be resolved and normalized to `C:\Users\kittaakos\AppData\Local\Temp`.
+  // If on Windows, the `C:\Users\KITTAA~1\AppData\Local\Temp` path will be resolved and normalized to `c:\Users\kittaakos\AppData\Local\Temp`.
   // Note: VS Code URI normalizes the drive letter. `C:` will be converted into `c:`.
   // https://github.com/Microsoft/vscode/issues/68325#issuecomment-462239992
-  private readonly tempDirRealpath = isOSX
+  readonly tempDirRealpath = isOSX
     ? tempDir
     : maybeNormalizeDrive(fs.realpathSync.native(tempDir));
 

--- a/arduino-ide-extension/src/node/is-temp-sketch.ts
+++ b/arduino-ide-extension/src/node/is-temp-sketch.ts
@@ -4,7 +4,7 @@ import { isWindows, isOSX } from '@theia/core/lib/common/os';
 import { injectable } from '@theia/core/shared/inversify';
 import { firstToLowerCase } from '../common/utils';
 
-const Win32DriveRegex = /^[a-zA-Z]:\\/;
+export const Win32DriveRegex = /^[a-zA-Z]:\\/;
 export const TempSketchPrefix = '.arduinoIDE-unsaved';
 
 @injectable()

--- a/arduino-ide-extension/src/node/sketches-service-impl.ts
+++ b/arduino-ide-extension/src/node/sketches-service-impl.ts
@@ -566,11 +566,24 @@ export class SketchesServiceImpl
     return FileUri.create(genBuildPath).toString();
   }
 
-  async getIdeTempFolderPath(sketch: Sketch): Promise<string> {
+  private async getIdeTempFolderPath(sketch: Sketch): Promise<string> {
     const sketchPath = FileUri.fsPath(sketch.uri);
     await fs.readdir(sketchPath); // Validates the sketch folder and rejects if not accessible.
     const suffix = crypto.createHash('md5').update(sketchPath).digest('hex');
-    return path.join(os.tmpdir(), `arduino-ide2-${suffix}`);
+    return path.join(
+      this.isTempSketch.tempDirRealpath,
+      `arduino-ide2-${suffix}`
+    );
+  }
+
+  async tempBuildPath(sketch: Sketch): Promise<string> {
+    const sketchPath = FileUri.fsPath(sketch.uri);
+    const hash = crypto
+      .createHash('md5')
+      .update(sketchPath)
+      .digest('hex')
+      .toUpperCase();
+    return join(this.isTempSketch.tempDirRealpath, `arduino-sketch-${hash}`);
   }
 
   async deleteSketch(sketch: Sketch): Promise<void> {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -191,7 +191,8 @@
       "debugWithMessage": "Debug - {0}",
       "debuggingNotSupported": "Debugging is not supported by '{0}'",
       "noPlatformInstalledFor": "Platform is not installed for '{0}'",
-      "optimizeForDebugging": "Optimize for Debugging"
+      "optimizeForDebugging": "Optimize for Debugging",
+      "sketchIsNotCompiled": "Sketch '{0}' must be verified before starting a debug session. Please verify the sketch and start debugging again. Do you want to verify the sketch now?"
     },
     "dialog": {
       "dontAskAgain": "Don't ask again"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "theiaPluginsDir": "plugins",
   "theiaPlugins": {
     "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.52.1/file/vscode.cpp-1.52.1.vsix",
-    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.0.2-beta.5.vsix",
+    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.0.2-beta.7.vsix",
     "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.46.1/file/vscode.json-1.46.1.vsix",
     "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "cortex-debug": "https://downloads.arduino.cc/marus25.cortex-debug/marus25.cortex-debug-1.5.1.vsix",


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

IDE2 should clearly communicate to the user when starting a debug session has failed due to an unverified sketch. In this case, users have to verify the sketch and restart the debug session.

### Change description
<!-- What does your code do? -->

This PR consists of two changes:
 - https://github.com/arduino/vscode-arduino-tools/pull/38
 - Since the error message parsing is unreliable (https://github.com/arduino/arduino-ide/issues/808#issuecomment-1212750132), IDE2 does not try to match English words but instead calculates the expected temp build output mimicking the CLI. If the error message contains the expected temp build path, IDE2 proposes the user to verify the sketch with a command.

https://user-images.githubusercontent.com/1405703/211327627-43a9aed6-ef3e-4dff-9077-c8279aa9ce7d.mp4

Steps to verify:
 - attach your Arduino Zero board to the programming port,
 - create a new sketch,
 - click on the debug in the toolbar,
 - expect the error message,
 - click on the `yes` action to verify the sketch,
 - click on the debug icon in the toolbar,
 - debugger starts.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

Closes #808

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)