### PR TITLE
fix: start the LS with the board specific settings

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/ino-language.ts
+++ b/arduino-ide-extension/src/browser/contributions/ino-language.ts
@@ -3,8 +3,10 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { Mutex } from 'async-mutex';
 import {
   ArduinoDaemon,
+  assertSanitizedFqbn,
   BoardsService,
   ExecutableService,
+  sanitizeFqbn,
 } from '../../common/protocol';
 import { CurrentSketch } from '../../common/protocol/sketches-service-client-impl';
 import { BoardsConfig } from '../boards/boards-config';
@@ -12,6 +14,7 @@ import { BoardsServiceProvider } from '../boards/boards-service-provider';
 import { HostedPluginEvents } from '../hosted-plugin-events';
 import { NotificationCenter } from '../notification-center';
 import { SketchContribution, URI } from './contribution';
+import { BoardsDataStore } from '../boards/boards-data-store';
 
 @injectable()
 export class InoLanguage extends SketchContribution {
@@ -32,6 +35,9 @@ export class InoLanguage extends SketchContribution {
 
   @inject(NotificationCenter)
   private readonly notificationCenter: NotificationCenter;
+
+  @inject(BoardsDataStore)
+  private readonly boardDataStore: BoardsDataStore;
 
   private readonly toDispose = new DisposableCollection();
   private readonly languageServerStartMutex = new Mutex();
@@ -76,6 +82,26 @@ export class InoLanguage extends SketchContribution {
       this.notificationCenter.onPlatformDidInstall(() => forceRestart()),
       this.notificationCenter.onPlatformDidUninstall(() => forceRestart()),
       this.notificationCenter.onDidReinitialize(() => forceRestart()),
+      this.boardDataStore.onChanged((dataChangePerFqbn) => {
+        if (this.languageServerFqbn) {
+          const sanitizedFqbn = sanitizeFqbn(this.languageServerFqbn);
+          if (!sanitizeFqbn) {
+            throw new Error(
+              `Failed to sanitize the FQBN of the running language server. FQBN with the board settings was: ${this.languageServerFqbn}`
+            );
+          }
+          const matchingFqbn = dataChangePerFqbn.find(
+            (fqbn) => sanitizedFqbn === fqbn
+          );
+          const { boardsConfig } = this.boardsServiceProvider;
+          if (
+            matchingFqbn &&
+            boardsConfig.selectedBoard?.fqbn === matchingFqbn
+          ) {
+            start(boardsConfig);
+          }
+        }
+      }),
     ]);
     start(this.boardsServiceProvider.boardsConfig);
   }
@@ -121,11 +147,18 @@ export class InoLanguage extends SketchContribution {
         }
         return;
       }
-      if (!forceStart && fqbn === this.languageServerFqbn) {
+      assertSanitizedFqbn(fqbn);
+      const fqbnWithConfig = await this.boardDataStore.appendConfigToFqbn(fqbn);
+      if (!fqbnWithConfig) {
+        throw new Error(
+          `Failed to append boards config to the FQBN. Original FQBN was: ${fqbn}`
+        );
+      }
+      if (!forceStart && fqbnWithConfig === this.languageServerFqbn) {
         // NOOP
         return;
       }
-      this.logger.info(`Starting language server: ${fqbn}`);
+      this.logger.info(`Starting language server: ${fqbnWithConfig}`);
       const log = this.preferences.get('arduino.language.log');
       const realTimeDiagnostics = this.preferences.get(
         'arduino.language.realTimeDiagnostics'
@@ -161,7 +194,7 @@ export class InoLanguage extends SketchContribution {
             log: currentSketchPath ? currentSketchPath : log,
             cliDaemonInstance: '1',
             board: {
-              fqbn,
+              fqbn: fqbnWithConfig,
               name: name ? `"${name}"` : undefined,
             },
             realTimeDiagnostics,
@@ -170,7 +203,7 @@ export class InoLanguage extends SketchContribution {
         ),
       ]);
     } catch (e) {
-      console.log(`Failed to start language server for ${fqbn}`, e);
+      console.log(`Failed to start language server. Original FQBN: ${fqbn}`, e);
       this.languageServerFqbn = undefined;
     } finally {
       release();

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { Emitter } from '@theia/core/lib/common/event';
-import { CoreService, Port } from '../../common/protocol';
+import { CoreService, Port, sanitizeFqbn } from '../../common/protocol';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { ArduinoToolbar } from '../toolbar/arduino-toolbar';
 import {
@@ -170,7 +170,7 @@ export class UploadSketch extends CoreServiceContribution {
     const [fqbn, { selectedProgrammer: programmer }, verify, verbose] =
       await Promise.all([
         verifyOptions.fqbn, // already decorated FQBN
-        this.boardsDataStore.getData(this.sanitizeFqbn(verifyOptions.fqbn)),
+        this.boardsDataStore.getData(sanitizeFqbn(verifyOptions.fqbn)),
         this.preferences.get('arduino.upload.verify'),
         this.preferences.get('arduino.upload.verbose'),
       ]);
@@ -206,19 +206,6 @@ export class UploadSketch extends CoreServiceContribution {
       }
     }
     return port;
-  }
-
-  /**
-   * Converts the `VENDOR:ARCHITECTURE:BOARD_ID[:MENU_ID=OPTION_ID[,MENU2_ID=OPTION_ID ...]]` FQBN to
-   * `VENDOR:ARCHITECTURE:BOARD_ID` format.
-   * See the details of the `{build.fqbn}` entry in the [specs](https://arduino.github.io/arduino-cli/latest/platform-specification/#global-predefined-properties).
-   */
-  private sanitizeFqbn(fqbn: string | undefined): string | undefined {
-    if (!fqbn) {
-      return undefined;
-    }
-    const [vendor, arch, id] = fqbn.split(':');
-    return `${vendor}:${arch}:${id}`;
   }
 }
 

--- a/arduino-ide-extension/src/common/protocol/boards-service.ts
+++ b/arduino-ide-extension/src/common/protocol/boards-service.ts
@@ -623,3 +623,27 @@ export namespace Board {
     }));
   }
 }
+
+/**
+ * Throws an error if the `fqbn` argument is not sanitized. A sanitized FQBN has the `VENDOR:ARCHITECTURE:BOARD_ID` construct.
+ */
+export function assertSanitizedFqbn(fqbn: string): void {
+  if (fqbn.split(':').length !== 3) {
+    throw new Error(
+      `Expected a sanitized FQBN with three segments in the following format: 'VENDOR:ARCHITECTURE:BOARD_ID'. Got ${fqbn} instead.`
+    );
+  }
+}
+
+/**
+ * Converts the `VENDOR:ARCHITECTURE:BOARD_ID[:MENU_ID=OPTION_ID[,MENU2_ID=OPTION_ID ...]]` FQBN to
+ * `VENDOR:ARCHITECTURE:BOARD_ID` format.
+ * See the details of the `{build.fqbn}` entry in the [specs](https://arduino.github.io/arduino-cli/latest/platform-specification/#global-predefined-properties).
+ */
+export function sanitizeFqbn(fqbn: string | undefined): string | undefined {
+  if (!fqbn) {
+    return undefined;
+  }
+  const [vendor, arch, id] = fqbn.split(':');
+  return `${vendor}:${arch}:${id}`;
+}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The Arduino Language features must incorporate the settings of the selected board.

### Change description
<!-- What does your code do? -->

From now on, the IDE2 starts the LS with the FQBN decorated with the settings. Open the DevTools and check the console if you're interested:

```
INFO Starting language server: teensy:avr:teensy41:usb=serial,speed=600,opt=o2std,keys=en-us
```

Also, from now on, the LS restarts when the user changes the board settings of the currently running LS.

Steps to verify:
 - See the excellent instructions from #1029.
 - Also, the LS updates if you change `Tools` > `USB Type`  from `Serial` to `Raw HID` and vice versa. This can be verified with the [`textDocument/hover`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover) in the editor.

In action:

https://user-images.githubusercontent.com/1405703/211559452-b4d9cd03-4856-444f-80b4-af0ff27cd157.mp4



### Other information
<!-- Any additional information that could help the review process -->

Closes #1029

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)