### PR TITLE
fix: flaky compiler test

### DIFF
--- a/arduino-ide-extension/src/node/core-client-provider.ts
+++ b/arduino-ide-extension/src/node/core-client-provider.ts
@@ -254,8 +254,8 @@ export class CoreClientProvider {
           }
         })
         .on('error', reject)
-        .on('end', () => {
-          const error = this.evaluateErrorStatus(errors);
+        .on('end', async () => {
+          const error = await this.evaluateErrorStatus(errors);
           if (error) {
             reject(error);
             return;
@@ -265,7 +265,10 @@ export class CoreClientProvider {
     });
   }
 
-  private evaluateErrorStatus(status: RpcStatus[]): Error | undefined {
+  private async evaluateErrorStatus(
+    status: RpcStatus[]
+  ): Promise<Error | undefined> {
+    await this.configService.getConfiguration(); // to ensure the CLI config service has been initialized.
     const { cliConfiguration } = this.configService;
     if (!cliConfiguration) {
       // If the CLI config is not available, do not even try to guess what went wrong.


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To fix the flaky test.

### Change description
<!-- What does your code do? -->

 - The gRPC core client provider requires an initialized config service when processing the error message received during the `InitRequest`. The actual fix is [here](https://github.com/arduino/arduino-ide/pull/1835/files#diff-f463d1c276a9080ec522ead62c6dd596e5bf330b093b7d51b71738c9795d0fda).
 - Additional logging in the config service.
 - The tests log into the console.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)