### PR TITLE
Add leading+trailing line break to "Copy for Forum" content

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/edit-contributions.ts
+++ b/arduino-ide-extension/src/browser/contributions/edit-contributions.ts
@@ -57,9 +57,11 @@ export class EditContributions extends Contribution {
       execute: async () => {
         const value = await this.currentValue();
         if (value !== undefined) {
-          this.clipboardService.writeText(`\`\`\`cpp
+          this.clipboardService.writeText(`
+\`\`\`cpp
 ${value}
-\`\`\``);
+\`\`\`
+`);
         }
       },
     });


### PR DESCRIPTION


### Motivation

Arduino IDE's **Edit > Copy for Forum (Markdown)** feature copies the contents of the currently selected editor tab to the clipboard, with ["fenced code block" markup](https://www.markdownguide.org/extended-syntax/#fenced-code-blocks) added to provide correct formatting when the content is posted to a platform supporting [**Markdown**](https://www.markdownguide.org/) language such as [Arduino Forum](https://forum.arduino.cc/), GitHub, Stack Exchange, etc.

One of the most common points of friction between the volunteer helpers on the forum and the newcomers requesting assistance is the failure to use the correct markup when posting code. In the best case scenario the code and thread is made less readable and less convenient to copy to the IDE for further investigation. Components of the code often resemble markup, which causes it to be corrupted by the forum's renderer ([example](https://forum.arduino.cc/t/how-to-get-the-best-out-of-this-forum/679966#use-code-tagsuse-code-tags-21)).

Even in cases where the user was conscientious enough to attempt to add the right markup, which is facilitated by tools such as **Copy for Forum (Markdown)**, they often still don't get it quite right. So it is worthwhile to make efforts to reduce the likelihood of markup being inadvertently invalidated.

"[Fenced code block](https://www.markdownguide.org/extended-syntax/#fenced-code-blocks)" markup must be on its own lines before and after the code content. Someone not familiar with Markdown won't know this fact and may simply paste the content copied via **Copy for Forum (Markdown)** without manually adding a newline before and after. Since the code content is preceded and succeeded by a newline, they will not have any visual indication of a problem.

### Change description

Adding a newline before and after the content added to the clipboard will ensure the markup is valid regardless of the context it is pasted into. In cases where the user did add a newline and this introduces a redundant line break in the forum post source content, it will not have any effect on the rendered content because the additional newlines are ignored by the renderer.

### Other information

Originally suggested at https://forum.arduino.cc/t/where-to-manipulate-serial-monitor-sending-cr-crlf/1085784/11

#### Demo

1. Select **File > New Sketch** from the Arduino IDE menus.
1. Select **Edit > Copy for Forum (Markdown)** from the Arduino IDE menus.
1. Type some introductory prose into a text editor.
1. Without manually adding a newline first, paste the content from the clipboard to the text editor.
1. Without manually adding a newline first, type some additional prose into the text editor.

Before the change proposed here, this will produce a forum post source content with invalid markup:

````markdown
halp me with my ardunio sketch```cpp
void setup() {
  // put your setup code here, to run once:

}

void loop() {
  // put your main code here, to run repeatedly:

}

```it dont work
PLZ HURRY HOMEWORK IZ DUE IN TOO HOURS
````

It will not render as intended:

halp me with my ardunio sketch```cpp
void setup() {
  // put your setup code here, to run once:

}

void loop() {
  // put your main code here, to run repeatedly:

}

```it dont work
PLZ HURRY HOMEWORK IZ DUE IN TOO HOURS

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)