### PR TITLE
fix: added GH token for `vscode-ripgrep` download

### DIFF
--- a/.github/workflows/check-i18n-task.yml
+++ b/.github/workflows/check-i18n-task.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Install dependencies
         run: yarn
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for errors
         run: yarn i18n:check


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Fix internationalization check build failure due to HTTP 403 (rate-limiter) when downloading `vscode-ripgrep`

### Change description
<!-- What does your code do? -->

Added the `GITHUB_TOKEN` environment variable: https://github.com/microsoft/vscode-ripgrep#github-api-limit-note

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)