### PR TITLE
Auto-select boards config with hardwareId if present

### DIFF
--- a/arduino-ide-extension/src/common/protocol/boards-service.ts
+++ b/arduino-ide-extension/src/common/protocol/boards-service.ts
@@ -245,6 +245,7 @@ export interface Port {
   readonly protocol: string;
   readonly protocolLabel: string;
   readonly properties?: Record<string, string>;
+  readonly hardwareId?: string;
 }
 export namespace Port {
   export type Properties = Record<string, string>;
@@ -551,6 +552,22 @@ export namespace Board {
 
   export function equals(left: Board, right: Board): boolean {
     return left.name === right.name && left.fqbn === right.fqbn;
+  }
+
+  export function sameDistinctHardwareAs(
+    left: Board,
+    right: string | Board
+  ): boolean {
+    if (Board.is(right) && left.port && right.port) {
+      const { hardwareId: leftHardwareId } = left.port;
+      const { hardwareId: rightHardwareId } = right.port;
+
+      if (leftHardwareId && rightHardwareId) {
+        return leftHardwareId === rightHardwareId;
+      }
+    }
+
+    return false;
   }
 
   export function sameAs(left: Board, right: string | Board): boolean {

--- a/arduino-ide-extension/src/node/board-discovery.ts
+++ b/arduino-ide-extension/src/node/board-discovery.ts
@@ -323,14 +323,14 @@ export class BoardDiscovery
   }
 
   private fromRpcPort(rpcPort: RpcPort): Port {
-    const port = {
+    return {
       address: rpcPort.getAddress(),
       addressLabel: rpcPort.getLabel(),
       protocol: rpcPort.getProtocol(),
       protocolLabel: rpcPort.getProtocolLabel(),
       properties: Port.Properties.create(rpcPort.getPropertiesMap().toObject()),
+      hardwareId: rpcPort.getHardwareId(), // method to be confirmed
     };
-    return port;
   }
 }
 


### PR DESCRIPTION
### Motivation
To ensure boards not exposing an `fqbn` can still be "auto-selected", considering their `hardwareId`.

### Change description
Retrieves `hardwareId` of a discovered port from the CLI.

Considers `hardwareId` of a discovered port when determining whether or not to "auto-select" a port. 

### Reviewer checklist

* [X] PR addresses a single concern.
* [X]  The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ X] PR title and description are properly filled.
* [ X] Docs have been added / updated (for bug fixes / features)