### PR TITLE
Fix serial monitor not auto-scrolling to bottom

### DIFF
--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -55,6 +55,10 @@ export class SerialMonitorOutput extends React.Component<
     return true;
   }
 
+  override componentDidUpdate(): void {
+    this.scrollToBottom();
+  }
+
   override componentDidMount(): void {
     this.scrollToBottom();
     this.toDisposeBeforeUnmount.pushAll([


### PR DESCRIPTION
### Motivation
The serial monitor auto-scroll doesn't go all the way down, as discussed in #1736

### Change description
`componentDidUpdate()` has been added to the serial monitor code, which calls `scrollToBottom()`. This ensures the serial monitor goes to the bottom whenever new messages are received.

### Other information
I have very little experience with React and TypeScript, so this may not be the best solution. But it works on my end, and no one else seemed to be working on this bug.

### Reviewer checklist

* [x] PR addresses a single concern.
* [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [x] PR title and description are properly filled.
* [x] Docs have been added / updated (for bug fixes / features)