### PR TITLE
Modify tempBuildFolderMD5Hash folderName

### DIFF
--- a/arduino-ide-extension/src/node/sketches-service-impl.ts
+++ b/arduino-ide-extension/src/node/sketches-service-impl.ts
@@ -628,7 +628,7 @@ export class SketchesServiceImpl
       .update(path)
       .digest('hex')
       .toUpperCase();
-    const folderName = `arduino-sketch-${hash}`;
+    const folderName = `arduino/sketches/${hash}`;
     return folderName;
   }
 


### PR DESCRIPTION
### Motivation

As explained in [1809 (Comment)](https://github.com/arduino/arduino-ide/pull/1809#discussion_r1073127475), newer versions of the CLI will require a change in our `sketches-service-impl.ts`. The hashed folder name should be replaced with the newly supported path, pattern `arduino/sketches/<hash>`.

### Change description
Modifies our `folderName` return value for method `tempBuildFolderMD5Hash` of `sketches-service-impl.ts`.

### Reviewer checklist

* [x] PR addresses a single concern.
* [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [x] PR title and description are properly filled.
* [x] Docs have been added / updated (for bug fixes / features)