### PR TITLE
fix: encoding when reading a cloud sketch

### DIFF
--- a/arduino-ide-extension/src/browser/create/create-fs-provider.ts
+++ b/arduino-ide-extension/src/browser/create/create-fs-provider.ts
@@ -29,6 +29,7 @@ import { CreateUri } from './create-uri';
 import { SketchesService } from '../../common/protocol';
 import { ArduinoPreferences } from '../arduino-preferences';
 import { Create } from './typings';
+import { stringToUint8Array } from '../../common/utils';
 
 @injectable()
 export class CreateFsProvider
@@ -154,7 +155,7 @@ export class CreateFsProvider
 
   async readFile(uri: URI): Promise<Uint8Array> {
     const content = await this.getCreateApi.readFile(uri.path.toString());
-    return new TextEncoder().encode(content);
+    return stringToUint8Array(content);
   }
 
   async writeFile(

--- a/arduino-ide-extension/src/common/utils.ts
+++ b/arduino-ide-extension/src/common/utils.ts
@@ -20,3 +20,14 @@ export function startsWithUpperCase(what: string): boolean {
 export function isNullOrUndefined(what: unknown): what is undefined | null {
   return what === undefined || what === null;
 }
+
+// Text encoder can crash in electron browser: https://github.com/arduino/arduino-ide/issues/634#issuecomment-1440039171
+export function unit8ArrayToString(uint8Array: Uint8Array): string {
+  return uint8Array.reduce(
+    (text, byte) => text + String.fromCharCode(byte),
+    ''
+  );
+}
+export function stringToUint8Array(text: string): Uint8Array {
+  return Uint8Array.from(text, (char) => char.charCodeAt(0));
+}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

 - To fix the encoding of invisible, ambiguous, and non-basic ASCII characters when pulling sketches from the cloud (#449)
 - To fix the IDE2 crash when encoding of the cloud sketch content fails (#634)

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Steps to verify:
 - Import the [sketch_feb14c.zip](https://github.com/arduino/arduino-ide/files/10805350/sketch_feb14c.zip) sketch to https://create.arduino.cc/editor/,
 - Open IDE2, log in, and pull the previously imported sketch from the cloud.
 - IDE2 does not crash, and the encoding is correct in the main sketch file.
 - Use the `"arduino.sketchbook.showAllFiles": true` settings, open the `.log` files from the sketch folder in an editor, and copy the below content to the top of the log files. Save your editors if auto-save is not on. Do the same with the `ReadMe.adoc`. Push your sketch to the cloud and verify that the new content is available online:

```
  //❤️🔥
  Serial.println( "examples of normal 1-byte-chars:");
  Serial.println( "---------------------------------");
  Serial.println( "! \" # $ % & ' ( ) * + , - . / ");
  Serial.println( "[ \\ ] ^ _ ` { | } ~"); 
  Serial.println();  
  Serial.println( "examples of (windows-compatible) 2-byte-chars:");
  Serial.println( "---------------------------------");
  Serial.println( "¡ ¢ £ ¤ ¥ ¦ § ¨ © ª « ¬ ­ ® ¯ ° ± ² ³ ´ µ ¶ · ¸ ¹ º » ¼ ½ ¾ ¿");
  Serial.println( "Ä ä Ö ö Ü ü ß ç ñ ò ó ô õ ÷ ø ù ú û ý þ ÿ");
  Serial.println( "Ā ā Ă ă Ą ą Ć ć Ĉ ĉ Ċ ċ Č č Ď ď Đ đ Ē ē Ĕ ĕ Ė ė Ę");
  Serial.println( "т у ф х ц ч ш щ ъ ы ь э ю я ѐ ё ђ ѓ є ѕ і ї ј љ њ ћ ќ ѝ ў џ Ѡ ѡ"); 
  Serial.println();  
  Serial.println( "examples of (windows-compatible) 3-byte-chars:");
  Serial.println( "---------------------------------");
  Serial.println( "ᄀ ᄁ ᄂ ᄃ ᄄ ᄅ ᄆ ᄇ ᄈ ᄉ ᄊ ᄋ ᄌ ᄍ ᄎ ᄏ ᄐ ᄑ ᄒ ᄓ ᄔ ᄕ ᄖ"); 
  Serial.println( "Ꭰ Ꭱ Ꭲ Ꭳ Ꭴ Ꭵ Ꭶ Ꭷ Ꭸ Ꭹ Ꭺ Ꭻ Ꭼ Ꭽ Ꭾ Ꭿ Ꮀ Ꮁ Ꮂ Ꮃ Ꮄ Ꮅ Ꮆ Ꮇ Ꮈ");
  Serial.println( "€ ₭ ₮ ₯ ₰ ₱ ₲ ₳ ₴ ₵ ₸ ₹ ₺ ￠ ￡ ￢ ￣ ￤ ￥ ￦ ￨ ￩ ￪ ￫ ￬ ￭ ￮"); 
  Serial.println();  
  Serial.println( "examples of (windows-compatible) 4-byte-chars:");
  Serial.println( "---------------------------------");
//  Serial.println( "\xf0\x90\x90\x80");
// Serial.println( "𐐀 𐐁 𐐂 𐐃 𐐄 𐐅 𐐆 𐐇 𐐈 𐐉 𐐊 𐐋 𐐌 𐐍 𐐎 𐐏 𐐐 𐐑 𐐒 𐐓 𐐔 𐐕 𐐖 𐐗 𐐘");
//  Serial.println( "𐐙 𐐚 𐐛 𐐜 𐐝 𐐞 𐐟 𐐠 𐐡 𐐢 𐐣 𐐤 𐐥 𐐦 𐐧 𐐨 𐐩 𐐪 𐐫 𐐬 𐐭 𐐮 𐐯 𐐰 𐐱");
//  Serial.println( "𐐲 𐐳 𐐴 𐐵 𐐶 𐐷 𐐸 𐐹 𐐺 𐐻 𐐼 𐐽 𐐾 𐐿 𐑀 𐑁 𐑂 𐑃 𐑄 𐑅 𐑆 𐑇 𐑈 𐑉 𐑊");
//  Serial.println( "𐑋 𐑌 𐑍 𐑎 𐑏 𐒀 𐒁 𐒂 𐒃 𐒄 𐒅 𐒆 𐒇 𐒈 𐒉 𐒊 𐒋 𐒌 𐒍 𐒎 𐒏 𐒐 𐒑 𐒒 𐒓");
//  Serial.println( "𐒔 𐒕 𐒖 𐒗 𐒘 𐒙 𐒚 𐒛 𐒜 𐒝 𐒠 𐒡 𐒢 𐒣 𐒤 𐒥 𐒦 𐒧 𐒨 𐒩");
```

Closes #449
Closes #634

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)