### PR TITLE
build: can force notarization on macOS if not on a CI

### DIFF
--- a/electron/build/scripts/notarize.js
+++ b/electron/build/scripts/notarize.js
@@ -3,8 +3,18 @@ const { notarize } = require('electron-notarize');
 
 exports.default = async function notarizing(context) {
   if (!isCI) {
-    console.log('Skipping notarization: not on CI.');
-    return;
+    if (
+      typeof process.env.MACOS_FORCE_NOTARIZE === 'string' &&
+      /true/i.test(process.env.MACOS_FORCE_NOTARIZE)
+    ) {
+      // Hack for manual M1 signing. Set the MACOS_FORCE_NOTARIZE env variable to true, to force notarization when not on a CI. The 'true' is case insensitive.
+      console.log(
+        `Detected the 'MACOS_FORCE_NOTARIZE' environment variable with '${process.env.MACOS_FORCE_NOTARIZE}' value. Forcing the app notarization, although not on a CI.`
+      );
+    } else {
+      console.log('Skipping notarization: not on CI.');
+      return;
+    }
   }
   if (process.env.CAN_SIGN === 'false') {
     console.log('Skipping the app notarization: certificate was not provided.');


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

IDE2 needs a way to manually sign the application on M1. The 'MACOS_FORCE_NOTARIZE' env variable forces the notarization to proceed if not on a CI.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)