### PR TITLE
Use Apple Silicon build artifact name required by electron-updater

### DIFF
--- a/electron/packager/config.js
+++ b/electron/packager/config.js
@@ -28,17 +28,17 @@ function artifactName() {
     }
     case 'darwin': {
       if (arch === 'arm64') {
-        return `${name}_${id}_macOS_ARM64.\$\{ext}`;
+        return `${name}_${id}_macOS_arm64.\$\{ext}`;
       }
       return `${name}_${id}_macOS_64bit.\$\{ext}`;
     }
     case 'linux': {
       switch (arch) {
         case 'arm': {
-          return `${name}_${id}_Linux_ARMv7.\$\{ext}`;
+          return `${name}_${id}_Linux_armv7.\$\{ext}`;
         }
         case 'arm64': {
-          return `${name}_${id}_Linux_ARM64.\$\{ext}`;
+          return `${name}_${id}_Linux_arm64.\$\{ext}`;
         }
         case 'x64': {
           return `${name}_${id}_Linux_64bit.\$\{ext}`;


### PR DESCRIPTION
### Motivation

The Arduino IDE update check uses a "channel update info file" on Arduino's download server. This file specifies the latest version of Arduino IDE available from the Arduino download server as well as the download URLs for the release archives.

There is a separate channel file for each host operating system:

- [**Windows**](https://downloads.arduino.cc/arduino-ide/stable.yml)
- [**Linux**](https://downloads.arduino.cc/arduino-ide/stable-linux.yml)
- [**macOS**](https://downloads.arduino.cc/arduino-ide/stable-mac.yml)

Two macOS host architectures are now supported:

- x86 (AKA "Intel")
- ARM64 (AKA "[Apple Silicon](https://en.wikipedia.org/wiki/Apple_silicon)")

These each have their own release archive files. The macOS channel file contains data on both. So the updater must be able to identify the appropriate archive to use for the update based on the host architecture. This is based on the archive filename.

Arduino IDE's auto-update feature is built on [the **electron-updater** package](https://www.npmjs.com/package/electron-updater). The release archive selection is handled by the **electron-updater** codebase and the filename pattern is hardcoded there. It selects the archive file that contains `arm64` in its name (case sensitive), if present, to use for updates on macOS hosts with ARM64 architecture:

https://github.com/electron-userland/electron-builder/blob/electron-updater%404.6.5/packages/electron-updater/src/MacUpdater.ts#L67

```typescript
const isArm64 = (file: ResolvedUpdateFileInfo) => file.url.pathname.includes("arm64") || file.info.url?.includes("arm64")
```

Previously, the build system produced archive files with the name format `arduino-ide_<version>_macOS_ARM64.zip`, consistent with the [established naming](https://github.com/arduino/arduino-cli/releases/latest) in other Arduino tooling projects. Unfortunately this naming would cause either ([depending on the order of the entries in the channel file](https://github.com/electron-userland/electron-builder/blob/electron-updater%404.6.5/packages/electron-updater/src/providers/Provider.ts#L94)) the x86 build to be used to update ARM64 macOS hosts (resulting in lesser performance due to [**Rosetta 2**](https://en.wikipedia.org/wiki/Rosetta_(software)#Rosetta_2) overhead) or the ARM64 build to be used to update x86 hosts (resulting in the IDE failing to start).

### Change description

Change the build artifact name to follow the format dictated by the **electron-updater** package. 

### Other information

Although it is not required (because [**electron-updater** uses separate channel files for the x86 and ARM Linux hosts](https://github.com/electron-userland/electron-builder/blob/electron-updater%404.6.5/packages/electron-updater/src/providers/Provider.ts#L34)), the Linux archive filename format was also changed for the sake of consistency.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)