### PR TITLE
Bump CLI to 0.31.0

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -163,7 +163,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.31.0-rc.1"
+      "version": "0.31.0"
     },
     "fwuploader": {
       "version": "2.2.2"


### PR DESCRIPTION
### Motivation
To ensure we are referencing the most recent arduino-cli release correctly in `arduino-ide-extension > package.json`.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)