### PR TITLE
fix: no unnecessary tree update on mouse over/out

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
+++ b/arduino-ide-extension/src/browser/widgets/sketchbook/sketchbook-tree-widget.tsx
@@ -116,7 +116,6 @@ export class SketchbookTreeWidget extends FileTreeWidget {
   protected hoveredNodeId: string | undefined;
   protected setHoverNodeId(id: string | undefined): void {
     this.hoveredNodeId = id;
-    this.update();
   }
 
   protected override createNodeAttributes(


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Removed unnecessary tree widget update and scroll to node action on mouse over/leave events.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Follow the steps from the [issue description](https://github.com/arduino/arduino-ide/issues/1766); they're excellent. You experience no unnecessary scrolling in the tree. You verify that the inline actions, such `...` for the context menu and pull/push in the cloud tree are rendered and functional when you hover over a node representing a sketch folder.

Closes #1766

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)