### PR TITLE
Bump version metadata post release

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide-extension",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "An extension for Theia building the Arduino IDE",
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "electron-app",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "license": "AGPL-3.0-or-later",
   "main": "src-gen/frontend/electron-main.js",
   "dependencies": {
@@ -21,7 +21,7 @@
     "@theia/process": "1.31.1",
     "@theia/terminal": "1.31.1",
     "@theia/workspace": "1.31.1",
-    "arduino-ide-extension": "2.0.4"
+    "arduino-ide-extension": "2.0.5"
   },
   "devDependencies": {
     "@theia/cli": "1.31.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Arduino IDE",
   "repository": "https://github.com/arduino/arduino-ide.git",
   "author": "Arduino SA",


### PR DESCRIPTION
### Motivation

On every startup, Arduino IDE checks for new versions of the IDE. If a newer version is available, a notification/dialog is shown offering an update.

"Newer" is determined by comparing the version of the user's IDE to the latest available version on the update channel. This comparison is done according to [the Semantic Versioning Specification](https://semver.org/) ("SemVer").
In order to facilitate [beta testing](https://github.com/arduino/arduino-ide/blob/main/docs/contributor-guide/beta-testing.md#beta-testing-guide), builds are generated of the Arduino IDE at the each stage in development. These builds are given an identifying version of the following form:

- `<version>-snapshot-<short hash>` - builds generated for every push and pull request that modifies relevant files
- `<version>-nightly-<YYYYMMDD>` - daily builds of the tip of the default branch

### Change description

In order to cause these builds to be correctly considered "newer" than the release version, the version metadata must be bumped immediately following each release.

This will also serve as the metadata bump for the next release in the event that release is a minor release. In case it is instead a minor or major release, the version metadata will need to be updated once more before the release tag is created.

### Other information

Reference:

https://github.com/arduino/arduino-ide/blob/main/docs/internal/release-procedure.md#4-%EF%B8%8F-bump-version-metadata-of-packages

Related:

- https://github.com/arduino/arduino-ide/issues/1440

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)