### PR TITLE
fix: scroll to the bottom after the state update

### DIFF
--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
@@ -117,6 +117,11 @@ export class MonitorWidget extends ReactWidget {
     (this.focusNode || this.node).focus();
   }
 
+  protected override onAfterShow(msg: Message): void {
+    super.onAfterShow(msg);
+    this.update();
+  }
+
   protected onFocusResolved = (element: HTMLElement | undefined) => {
     if (this.closing || !this.isAttached) {
       return;

--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -17,7 +17,7 @@ export class SerialMonitorOutput extends React.Component<
    * Do not touch it. It is used to be able to "follow" the serial monitor log.
    */
   protected toDisposeBeforeUnmount = new DisposableCollection();
-  private listRef: React.RefObject<any>;
+  private listRef: React.RefObject<List>;
 
   constructor(props: Readonly<SerialMonitorOutput.Props>) {
     super(props);
@@ -34,12 +34,10 @@ export class SerialMonitorOutput extends React.Component<
       <List
         className="serial-monitor-messages"
         height={this.props.height}
-        itemData={
-          {
-            lines: this.state.lines,
-            timestamp: this.state.timestamp,
-          } as any
-        }
+        itemData={{
+          lines: this.state.lines,
+          timestamp: this.state.timestamp,
+        }}
         itemCount={this.state.lines.length}
         itemSize={18}
         width={'100%'}
@@ -93,11 +91,11 @@ export class SerialMonitorOutput extends React.Component<
     this.toDisposeBeforeUnmount.dispose();
   }
 
-  scrollToBottom = ((): void => {
+  private readonly scrollToBottom = () => {
     if (this.listRef.current && this.props.monitorModel.autoscroll) {
       this.listRef.current.scrollToItem(this.state.lines.length, 'end');
     }
-  }).bind(this);
+  };
 }
 
 const _Row = ({

--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -65,11 +65,13 @@ export class SerialMonitorOutput extends React.Component<
           this.state.charCount
         );
         const [lines, charCount] = truncateLines(newLines, totalCharCount);
-        this.setState({
-          lines,
-          charCount,
-        });
-        this.scrollToBottom();
+        this.setState(
+          {
+            lines,
+            charCount,
+          },
+          () => this.scrollToBottom()
+        );
       }),
       this.props.clearConsoleEvent(() =>
         this.setState({ lines: [], charCount: 0 })


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

An alternative version of #1889. This PR also fixes #1724.

Scroll to the bottom fix:


https://user-images.githubusercontent.com/1405703/222668221-46b68d3b-ce4b-48ea-ba67-35f6d22b8667.mp4

Update widget content and scroll position after the widget shows:


https://user-images.githubusercontent.com/1405703/222668321-274bd881-f707-498f-bf3b-7b77af29b7a4.mp4



### Change description
<!-- What does your code do? -->

Scroll to the bottom of the monitor widget after the state update.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1724
Closes #1736

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)