### PR TITLE
fix: jsonc parsing in the IDE2 backend

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -78,6 +78,7 @@
     "google-protobuf": "^3.20.1",
     "hash.js": "^1.1.7",
     "js-yaml": "^3.13.1",
+    "jsonc-parser": "^2.2.0",
     "just-diff": "^5.1.1",
     "jwt-decode": "^3.1.2",
     "keytar": "7.2.0",

--- a/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
+++ b/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
@@ -118,6 +118,7 @@ import {
   LocalDirectoryPluginDeployerResolverWithFallback,
   PluginDeployer_GH_12064,
 } from './theia/plugin-ext/plugin-deployer';
+import { SettingsReader } from './settings-reader';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(BackendApplication).toSelf().inSingletonScope();
@@ -403,6 +404,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     .toSelf()
     .inSingletonScope();
   rebind(PluginDeployer).to(PluginDeployer_GH_12064).inSingletonScope();
+
+  bind(SettingsReader).toSelf().inSingletonScope();
 });
 
 function bindChildLogger(bind: interfaces.Bind, name: string): void {

--- a/arduino-ide-extension/src/node/settings-reader.ts
+++ b/arduino-ide-extension/src/node/settings-reader.ts
@@ -1,0 +1,53 @@
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { FileUri } from '@theia/core/lib/node/file-uri';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { promises as fs } from 'fs';
+import {
+  parse as parseJsonc,
+  ParseError,
+  printParseErrorCode,
+} from 'jsonc-parser';
+import { join } from 'path';
+import { ErrnoException } from './utils/errors';
+
+// Poor man's preferences on the backend. (https://github.com/arduino/arduino-ide/issues/1056#issuecomment-1153975064)
+@injectable()
+export class SettingsReader {
+  @inject(EnvVariablesServer)
+  private readonly envVariableServer: EnvVariablesServer;
+
+  async read(): Promise<Record<string, unknown> | undefined> {
+    const configDirUri = await this.envVariableServer.getConfigDirUri();
+    const configDirPath = FileUri.fsPath(configDirUri);
+    const settingsPath = join(configDirPath, 'settings.json');
+    try {
+      const raw = await fs.readFile(settingsPath, { encoding: 'utf8' });
+      return parse(raw);
+    } catch (err) {
+      if (ErrnoException.isENOENT(err)) {
+        return undefined;
+      }
+    }
+  }
+}
+
+export function parse(raw: string): Record<string, unknown> | undefined {
+  const errors: ParseError[] = [];
+  const settings =
+    parseJsonc(raw, errors, {
+      allowEmptyContent: true,
+      allowTrailingComma: true,
+      disallowComments: false,
+    }) ?? {};
+  if (errors.length) {
+    console.error('Detected JSONC parser errors:');
+    console.error('----- CONTENT START -----');
+    console.error(raw);
+    console.error('----- CONTENT END -----');
+    errors.forEach(({ error, offset }) =>
+      console.error(` - ${printParseErrorCode(error)} at ${offset}`)
+    );
+    return undefined;
+  }
+  return typeof settings === 'object' ? settings : undefined;
+}

--- a/arduino-ide-extension/src/test/node/settings.reader.test.ts
+++ b/arduino-ide-extension/src/test/node/settings.reader.test.ts
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import { parse } from '../../node/settings-reader';
+
+describe('settings-reader', () => {
+  describe('parse', () => {
+    it('should handle comments', () => {
+      const actual = parse(`
+{
+    "alma": "korte",
+    // comment
+    "szilva": false
+}`);
+      expect(actual).to.be.deep.equal({
+        alma: 'korte',
+        szilva: false,
+      });
+    });
+
+    it('should handle trailing comma', () => {
+      const actual = parse(`
+{
+    "alma": "korte",
+    "szilva": 123,
+}`);
+      expect(actual).to.be.deep.equal({
+        alma: 'korte',
+        szilva: 123,
+      });
+    });
+
+    it('should parse empty', () => {
+      const actual = parse('');
+      expect(actual).to.be.deep.equal({});
+    });
+
+    it('should parse to undefined when parse has failed', () => {
+      const actual = parse(`
+{
+    alma:: 'korte'
+    trash
+}`);
+      expect(actual).to.be.undefined;
+    });
+  });
+});

--- a/arduino-ide-extension/src/test/node/test-bindings.ts
+++ b/arduino-ide-extension/src/test/node/test-bindings.ts
@@ -51,6 +51,7 @@ import {
   MonitorServiceFactory,
   MonitorServiceFactoryOptions,
 } from '../../node/monitor-service-factory';
+import { SettingsReader } from '../../node/settings-reader';
 import { SketchesServiceImpl } from '../../node/sketches-service-impl';
 import { EnvVariablesServer } from '../../node/theia/env-variables/env-variables-server';
 
@@ -277,6 +278,7 @@ export function createBaseContainer(
     bind(IsTempSketch).toSelf().inSingletonScope();
     bind(SketchesServiceImpl).toSelf().inSingletonScope();
     bind(SketchesService).toService(SketchesServiceImpl);
+    bind(SettingsReader).toSelf().inSingletonScope();
     if (containerCustomizations) {
       containerCustomizations(bind, rebind);
     }


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
Relaxed the `settings.json` parsing in the IDE2's backend. The problem occurred when the `settings.json` contained comments or a trailing comma.

### Change description
<!-- What does your code do? -->

Use `jsonc-parser` and allow comments, a trailing comma, and empty content.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

Closes #1945

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)