### PR TITLE
feat: omit release details to speed up lib search

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -167,7 +167,7 @@
       "version": {
         "owner": "arduino",
         "repo": "arduino-cli",
-        "commitish": "6992de7"
+        "commitish": "71a8576"
       }
     },
     "fwuploader": {

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.d.ts
@@ -406,6 +406,9 @@ export class LibrarySearchRequest extends jspb.Message {
     getQuery(): string;
     setQuery(value: string): LibrarySearchRequest;
 
+    getOmitReleasesDetails(): boolean;
+    setOmitReleasesDetails(value: boolean): LibrarySearchRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): LibrarySearchRequest.AsObject;
@@ -421,6 +424,7 @@ export namespace LibrarySearchRequest {
     export type AsObject = {
         instance?: cc_arduino_cli_commands_v1_common_pb.Instance.AsObject,
         query: string,
+        omitReleasesDetails: boolean,
     }
 }
 
@@ -465,6 +469,11 @@ export class SearchedLibrary extends jspb.Message {
     getLatest(): LibraryRelease | undefined;
     setLatest(value?: LibraryRelease): SearchedLibrary;
 
+    clearAvailableVersionsList(): void;
+    getAvailableVersionsList(): Array<string>;
+    setAvailableVersionsList(value: Array<string>): SearchedLibrary;
+    addAvailableVersions(value: string, index?: number): string;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): SearchedLibrary.AsObject;
@@ -482,6 +491,7 @@ export namespace SearchedLibrary {
 
         releasesMap: Array<[string, LibraryRelease.AsObject]>,
         latest?: LibraryRelease.AsObject,
+        availableVersionsList: Array<string>,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/lib_pb.js
@@ -374,7 +374,7 @@ if (goog.DEBUG && !COMPILED) {
  * @constructor
  */
 proto.cc.arduino.cli.commands.v1.SearchedLibrary = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.cc.arduino.cli.commands.v1.SearchedLibrary.repeatedFields_, null);
 };
 goog.inherits(proto.cc.arduino.cli.commands.v1.SearchedLibrary, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
@@ -3202,7 +3202,8 @@ proto.cc.arduino.cli.commands.v1.LibrarySearchRequest.prototype.toObject = funct
 proto.cc.arduino.cli.commands.v1.LibrarySearchRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     instance: (f = msg.getInstance()) && cc_arduino_cli_commands_v1_common_pb.Instance.toObject(includeInstance, f),
-    query: jspb.Message.getFieldWithDefault(msg, 2, "")
+    query: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    omitReleasesDetails: jspb.Message.getBooleanFieldWithDefault(msg, 3, false)
   };
 
   if (includeInstance) {
@@ -3248,6 +3249,10 @@ proto.cc.arduino.cli.commands.v1.LibrarySearchRequest.deserializeBinaryFromReade
       var value = /** @type {string} */ (reader.readString());
       msg.setQuery(value);
       break;
+    case 3:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setOmitReleasesDetails(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -3289,6 +3294,13 @@ proto.cc.arduino.cli.commands.v1.LibrarySearchRequest.serializeBinaryToWriter = 
   if (f.length > 0) {
     writer.writeString(
       2,
+      f
+    );
+  }
+  f = message.getOmitReleasesDetails();
+  if (f) {
+    writer.writeBool(
+      3,
       f
     );
   }
@@ -3347,6 +3359,24 @@ proto.cc.arduino.cli.commands.v1.LibrarySearchRequest.prototype.getQuery = funct
  */
 proto.cc.arduino.cli.commands.v1.LibrarySearchRequest.prototype.setQuery = function(value) {
   return jspb.Message.setProto3StringField(this, 2, value);
+};
+
+
+/**
+ * optional bool omit_releases_details = 3;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.LibrarySearchRequest.prototype.getOmitReleasesDetails = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 3, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.LibrarySearchRequest} returns this
+ */
+proto.cc.arduino.cli.commands.v1.LibrarySearchRequest.prototype.setOmitReleasesDetails = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 3, value);
 };
 
 
@@ -3541,6 +3571,13 @@ proto.cc.arduino.cli.commands.v1.LibrarySearchResponse.prototype.setStatus = fun
 
 
 
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.cc.arduino.cli.commands.v1.SearchedLibrary.repeatedFields_ = [4];
+
 
 
 if (jspb.Message.GENERATE_TO_OBJECT) {
@@ -3574,7 +3611,8 @@ proto.cc.arduino.cli.commands.v1.SearchedLibrary.toObject = function(includeInst
   var f, obj = {
     name: jspb.Message.getFieldWithDefault(msg, 1, ""),
     releasesMap: (f = msg.getReleasesMap()) ? f.toObject(includeInstance, proto.cc.arduino.cli.commands.v1.LibraryRelease.toObject) : [],
-    latest: (f = msg.getLatest()) && proto.cc.arduino.cli.commands.v1.LibraryRelease.toObject(includeInstance, f)
+    latest: (f = msg.getLatest()) && proto.cc.arduino.cli.commands.v1.LibraryRelease.toObject(includeInstance, f),
+    availableVersionsList: (f = jspb.Message.getRepeatedField(msg, 4)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -3626,6 +3664,10 @@ proto.cc.arduino.cli.commands.v1.SearchedLibrary.deserializeBinaryFromReader = f
       reader.readMessage(value,proto.cc.arduino.cli.commands.v1.LibraryRelease.deserializeBinaryFromReader);
       msg.setLatest(value);
       break;
+    case 4:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addAvailableVersions(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -3672,6 +3714,13 @@ proto.cc.arduino.cli.commands.v1.SearchedLibrary.serializeBinaryToWriter = funct
       3,
       f,
       proto.cc.arduino.cli.commands.v1.LibraryRelease.serializeBinaryToWriter
+    );
+  }
+  f = message.getAvailableVersionsList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      4,
+      f
     );
   }
 };
@@ -3751,6 +3800,43 @@ proto.cc.arduino.cli.commands.v1.SearchedLibrary.prototype.clearLatest = functio
  */
 proto.cc.arduino.cli.commands.v1.SearchedLibrary.prototype.hasLatest = function() {
   return jspb.Message.getField(this, 3) != null;
+};
+
+
+/**
+ * repeated string available_versions = 4;
+ * @return {!Array<string>}
+ */
+proto.cc.arduino.cli.commands.v1.SearchedLibrary.prototype.getAvailableVersionsList = function() {
+  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 4));
+};
+
+
+/**
+ * @param {!Array<string>} value
+ * @return {!proto.cc.arduino.cli.commands.v1.SearchedLibrary} returns this
+ */
+proto.cc.arduino.cli.commands.v1.SearchedLibrary.prototype.setAvailableVersionsList = function(value) {
+  return jspb.Message.setField(this, 4, value || []);
+};
+
+
+/**
+ * @param {string} value
+ * @param {number=} opt_index
+ * @return {!proto.cc.arduino.cli.commands.v1.SearchedLibrary} returns this
+ */
+proto.cc.arduino.cli.commands.v1.SearchedLibrary.prototype.addAvailableVersions = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 4, value, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.cc.arduino.cli.commands.v1.SearchedLibrary} returns this
+ */
+proto.cc.arduino.cli.commands.v1.SearchedLibrary.prototype.clearAvailableVersionsList = function() {
+  return this.setAvailableVersionsList([]);
 };
 
 

--- a/arduino-ide-extension/src/node/library-service-impl.ts
+++ b/arduino-ide-extension/src/node/library-service-impl.ts
@@ -79,6 +79,7 @@ export class LibraryServiceImpl
     const req = new LibrarySearchRequest();
     req.setQuery(options.query || '');
     req.setInstance(instance);
+    req.setOmitReleasesDetails(true);
     const resp = await new Promise<LibrarySearchResponse>((resolve, reject) =>
       client.librarySearch(req, (err, resp) =>
         !!err ? reject(err) : resolve(resp)
@@ -88,11 +89,8 @@ export class LibraryServiceImpl
       .getLibrariesList()
       .filter((item) => !!item.getLatest())
       .map((item) => {
-        // TODO: This seems to contain only the latest item instead of all of the items.
         const availableVersions = item
-          .getReleasesMap()
-          .getEntryList()
-          .map(([key, _]) => key)
+          .getAvailableVersionsList()
           .sort(Installable.Version.COMPARATOR)
           .reverse();
         let installedVersion: string | undefined;


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To speed up library search in IDE2 by omitting unnecessary information from the CLI via gRPC, such as the library release details.

### Change description
<!-- What does your code do? -->

Use the gRPC equivalent of the new `--omit-releases-details` flag for `lib search`.

### Other information
<!-- Any additional information that could help the review process -->

The library manager works as in 2.0.4.

Ref: arduino/arduino-cli#2102

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)