### PR TITLE
fix: propagate monitor errors to the frontend

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -496,15 +496,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(TabBarToolbarContribution).toService(MonitorViewContribution);
   bind(WidgetFactory).toDynamicValue((context) => ({
     id: MonitorWidget.ID,
-    createWidget: () => {
-      return new MonitorWidget(
-        context.container.get<MonitorModel>(MonitorModel),
-        context.container.get<MonitorManagerProxyClient>(
-          MonitorManagerProxyClient
-        ),
-        context.container.get<BoardsServiceProvider>(BoardsServiceProvider)
-      );
-    },
+    createWidget: () => context.container.get(MonitorWidget),
   }));
 
   bind(MonitorManagerProxyFactory).toFactory(

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-view-contribution.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-view-contribution.tsx
@@ -10,6 +10,7 @@ import {
 import { ArduinoToolbar } from '../../toolbar/arduino-toolbar';
 import { ArduinoMenus } from '../../menu/arduino-menus';
 import { nls } from '@theia/core/lib/common';
+import { Event } from '@theia/core/lib/common/event';
 import { MonitorModel } from '../../monitor-model';
 import { MonitorManagerProxyClient } from '../../../common/protocol';
 
@@ -84,13 +85,13 @@ export class MonitorViewContribution
       id: 'monitor-autoscroll',
       render: () => this.renderAutoScrollButton(),
       isVisible: (widget) => widget instanceof MonitorWidget,
-      onDidChange: this.model.onChange as any, // XXX: it's a hack. See: https://github.com/eclipse-theia/theia/pull/6696/
+      onDidChange: this.model.onChange as Event<unknown> as Event<void>,
     });
     registry.registerItem({
       id: 'monitor-timestamp',
       render: () => this.renderTimestampButton(),
       isVisible: (widget) => widget instanceof MonitorWidget,
-      onDidChange: this.model.onChange as any, // XXX: it's a hack. See: https://github.com/eclipse-theia/theia/pull/6696/
+      onDidChange: this.model.onChange as Event<unknown> as Event<void>,
     });
     registry.registerItem({
       id: SerialMonitor.Commands.CLEAR_OUTPUT.id,
@@ -143,8 +144,7 @@ export class MonitorViewContribution
   protected async reset(): Promise<void> {
     const widget = this.tryGetWidget();
     if (widget) {
-      widget.dispose();
-      await this.openView({ activate: true, reveal: true });
+      widget.reset();
     }
   }
 

--- a/arduino-ide-extension/src/browser/style/index.css
+++ b/arduino-ide-extension/src/browser/style/index.css
@@ -29,9 +29,11 @@
 /* https://github.com/arduino/arduino-ide/pull/1662#issuecomment-1324997134 */
 body {
   --theia-icon-loading: url(../icons/loading-light.svg);
+  --theia-icon-loading-warning: url(../icons/loading-dark.svg);
 }
 body.theia-dark {
   --theia-icon-loading: url(../icons/loading-dark.svg);
+  --theia-icon-loading-warning: url(../icons/loading-light.svg);
 }
 
 .theia-input.warning:focus {
@@ -48,22 +50,32 @@ body.theia-dark {
 }
 
 .theia-input.warning::placeholder {
-  /* Chrome, Firefox, Opera, Safari 10.1+ */
-  color: var(--theia-warningForeground);
-  background-color: var(--theia-warningBackground);
-  opacity: 1; /* Firefox */
-}
-
-.theia-input.warning:-ms-input-placeholder {
-  /* Internet Explorer 10-11 */
   color: var(--theia-warningForeground);
   background-color: var(--theia-warningBackground);
 }
 
-.theia-input.warning::-ms-input-placeholder {
-  /* Microsoft Edge */
-  color: var(--theia-warningForeground);
-  background-color: var(--theia-warningBackground);
+.hc-black.hc-theia.theia-hc .theia-input.warning,
+.hc-black.hc-theia.theia-hc .theia-input.warning::placeholder {
+  color: var(--theia-warningBackground);
+  background-color: var(--theia-warningForeground);
+}
+
+.theia-input.error:focus {
+  outline-width: 1px;
+  outline-style: solid;
+  outline-offset: -1px;
+  opacity: 1 !important;
+  color: var(--theia-errorForeground);
+  background-color: var(--theia-errorBackground);
+}
+
+.theia-input.error {
+  background-color: var(--theia-errorBackground);
+}
+
+.theia-input.error::placeholder {
+  color: var(--theia-errorForeground);
+  background-color: var(--theia-errorBackground);
 }
 
 /* Makes the sidepanel a bit wider when opening the widget */

--- a/arduino-ide-extension/src/browser/style/monitor.css
+++ b/arduino-ide-extension/src/browser/style/monitor.css
@@ -20,22 +20,47 @@
 
 .serial-monitor .head {
     display: flex;
-    padding: 5px;
+    padding: 0px 5px 5px 0px;
     height: 27px;
+    background-color: var(--theia-activityBar-background);
 }
 
 .serial-monitor .head .send {
     display: flex;
     flex: 1;
-    margin-right: 2px;
 }
 
-.serial-monitor .head .send > input {
+.serial-monitor .head .send > label:before {
+    content: "";
+    position: absolute;
+    top: -1px;
+    background: var(--theia-icon-loading-warning) center center no-repeat;
+    animation: theia-spin 1.25s linear infinite;
+    width: 30px;
+    height: 30px;
+}
+
+.serial-monitor .head .send > label {
+    position: relative;
+    width: 100%;
+    display: flex;
+    align-self: baseline;
+}
+
+.serial-monitor .head .send > input,
+.serial-monitor .head .send > label > input {
     line-height: var(--theia-content-line-height);
+    height: 27px;
     width: 100%;
 }
 
-.serial-monitor .head .send > input:focus {
+.serial-monitor .head .send > label > input {
+    padding-left: 30px;
+    box-sizing: border-box;
+}
+
+.serial-monitor .head .send > input:focus,
+.serial-monitor .head .send > label > input:focus {
     border-color: var(--theia-focusBorder);
 }
 

--- a/arduino-ide-extension/src/common/protocol/core-service.ts
+++ b/arduino-ide-extension/src/common/protocol/core-service.ts
@@ -73,12 +73,12 @@ export namespace CoreError {
     UploadUsingProgrammer: 4003,
     BurnBootloader: 4004,
   };
-  export const VerifyFailed = create(Codes.Verify);
-  export const UploadFailed = create(Codes.Upload);
-  export const UploadUsingProgrammerFailed = create(
+  export const VerifyFailed = declareCoreError(Codes.Verify);
+  export const UploadFailed = declareCoreError(Codes.Upload);
+  export const UploadUsingProgrammerFailed = declareCoreError(
     Codes.UploadUsingProgrammer
   );
-  export const BurnBootloaderFailed = create(Codes.BurnBootloader);
+  export const BurnBootloaderFailed = declareCoreError(Codes.BurnBootloader);
   export function is(
     error: unknown
   ): error is ApplicationError<number, ErrorLocation[]> {
@@ -88,7 +88,7 @@ export namespace CoreError {
       Object.values(Codes).includes(error.code)
     );
   }
-  function create(
+  function declareCoreError(
     code: number
   ): ApplicationError.Constructor<number, ErrorLocation[]> {
     return ApplicationError.declare(

--- a/arduino-ide-extension/src/node/core-service-impl.ts
+++ b/arduino-ide-extension/src/node/core-service-impl.ts
@@ -23,7 +23,7 @@ import {
   UploadUsingProgrammerResponse,
 } from './cli-protocol/cc/arduino/cli/commands/v1/upload_pb';
 import { ResponseService } from '../common/protocol/response-service';
-import { OutputMessage, Port, Status } from '../common/protocol';
+import { OutputMessage, Port } from '../common/protocol';
 import { ArduinoCoreServiceClient } from './cli-protocol/cc/arduino/cli/commands/v1/commands_grpc_pb';
 import { Port as RpcPort } from './cli-protocol/cc/arduino/cli/commands/v1/port_pb';
 import { ApplicationError, CommandService, Disposable, nls } from '@theia/core';
@@ -392,7 +392,7 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
   }: {
     fqbn?: string | undefined;
     port?: Port | undefined;
-  }): Promise<Status> {
+  }): Promise<void> {
     this.boardDiscovery.setUploadInProgress(false);
     return this.monitorManager.notifyUploadFinished(fqbn, port);
   }

--- a/arduino-ide-extension/src/node/monitor-settings/monitor-settings-provider.ts
+++ b/arduino-ide-extension/src/node/monitor-settings/monitor-settings-provider.ts
@@ -1,10 +1,9 @@
-import { MonitorModel } from '../../browser/monitor-model';
-import { PluggableMonitorSetting } from '../../common/protocol';
+import { MonitorState, PluggableMonitorSetting } from '../../common/protocol';
 
 export type PluggableMonitorSettings = Record<string, PluggableMonitorSetting>;
 export interface MonitorSettings {
   pluggableMonitorSettings?: PluggableMonitorSettings;
-  monitorUISettings?: Partial<MonitorModel.State>;
+  monitorUISettings?: Partial<MonitorState>;
 }
 
 export const MonitorSettingsProvider = Symbol('MonitorSettingsProvider');

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -328,6 +328,13 @@
       "tools": "Tools"
     },
     "monitor": {
+      "alreadyConnectedError": "Could not connect to {0} {1} port. Already connected.",
+      "baudRate": "{0} baud",
+      "connectionFailedError": "Could not connect to {0} {1} port.",
+      "connectionFailedErrorWithDetails": "{0} Could not connect to {1} {2} port.",
+      "connectionTimeout": "Timeout. The IDE has not received the 'success' message from the monitor after successfully connecting to it",
+      "missingConfigurationError": "Could not connect to {0} {1} port. The monitor configuration is missing.",
+      "notConnectedError": "Not connected to {0} {1} port.",
       "unableToCloseWebSocket": "Unable to close websocket",
       "unableToConnectToWebSocket": "Unable to connect to websocket"
     },
@@ -408,6 +415,7 @@
     "serial": {
       "autoscroll": "Autoscroll",
       "carriageReturn": "Carriage Return",
+      "connecting": "Connecting to '{0}' on '{1}'...",
       "message": "Message (Enter to send message to '{0}' on '{1}')",
       "newLine": "New Line",
       "newLineCarriageReturn": "Both NL & CR",


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

This PR enables clear communication of the problem when starting a monitor process fails.

Shows monitor connection status in the `<input>`
  - not-connected (board or port is missing),
  - connecting (when trying to connect to the monitor port),
  - connected ✅, and
  - error (the connection has failed for whatever reason, and the user should select another board or close + reopen the widget after fixing any port issues outside of IDE2)


https://user-images.githubusercontent.com/1405703/229084603-3b9ebc3d-9e3b-46c8-a896-9c6939333492.mp4



### Change description
<!-- What does your code do? -->
 - Propagate error from backend to frontend via the monitor ws.
 - Open the ws connection before creating the monitor duplex. Otherwise, the status update or error cannot reach the frontend.
 - Fixed monitor widget DI.
 - Fixed monitor service lifecycle inside the widget. `onBeforeAttach` happened multiple times on IDE2 start if the widget was previously opened.
 - Fixed `connect` when creating the ws connection to the monitor. Previously, the promise might have been resolved before the ws `OPEN` event.
 - Moved monitor state to common.
 - Monitor client proxy waits for reconciled boards after the app startup, then starts the monitor.
 - Replaced the `connected: boolean` with a fine-grained `connectionStatus` and kept the code backward compatible with the plotter app.
 - Add translation for `baud` rate.



 - Smoother monitor widget re-render on monitor reset. (arduino/arduino-ide#1985)

https://user-images.githubusercontent.com/1405703/228866203-e6831be0-d6e0-43e1-85e4-92c0b4939d13.mp4
 
 - When there is no monitor connection, the `<input>` is readOnly and keeps the user input. (arduino/arduino-ide#1984)

https://user-images.githubusercontent.com/1405703/228867269-9dc5f9f6-d6b3-47ab-8a47-2649eea2ba0a.mp4

 - The monitor gracefully handles when the board's platform is not installed. (arduino/arduino-ide#1974)

https://user-images.githubusercontent.com/1405703/228868231-0c724990-cf01-4181-af6e-610ce2408d26.mp4

 - Set the monitor widget header color and shifted a few pixels here and there to provide a better monitor UI until a final design is ready as part of #682.

https://user-images.githubusercontent.com/1405703/228869587-ef40cfa1-8512-45f9-a531-f693248af991.mp4

 - Aligned HC warning colors with the error colors:

     2.0.4: 
       <img width="511" alt="Screen Shot 2023-03-30 at 18 55 54" src="https://user-images.githubusercontent.com/1405703/228909973-c6ab35b5-42ee-4a6d-8bcb-1467163f4bd0.png">

     PR:
      <img width="526" alt="Screen Shot 2023-03-30 at 18 56 29" src="https://user-images.githubusercontent.com/1405703/228910039-f9e01caa-e266-4552-b639-e2843f914051.png">

      <img width="526" alt="Screen Shot 2023-03-30 at 18 56 45" src="https://user-images.githubusercontent.com/1405703/228910097-0e004235-1f5d-4361-80d5-a32e75331451.png">


### Other information
<!-- Any additional information that could help the review process -->

Closes arduino/arduino-ide#1508
Closes arduino/arduino-ide#1985
Closes arduino/arduino-ide#1984
Closes arduino/arduino-ide#1974
Ref arduino/arduino-ide#682

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)