### PR TITLE
fix: incorrect editor widget key calculation

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
@@ -45,7 +45,11 @@ export class OpenSketchFiles extends SketchContribution {
         await this.ensureOpened(uri);
       }
       if (focusMainSketchFile) {
-        await this.ensureOpened(mainFileUri, true, { mode: 'activate' });
+        await this.ensureOpened(mainFileUri, true, {
+          mode: 'activate',
+          preview: false,
+          counter: 0,
+        });
       }
       if (mainFileUri.endsWith('.pde')) {
         const message = nls.localize(


### PR DESCRIPTION
### Reviewers, please also see #1970 and #1971 before checking this PR.

### Motivation
<!-- Why this pull request? -->

Avoid duplicate editor tabs when opening a sketch with no previously saved workbench layout.


### Change description
<!-- What does your code do? -->

This PR fixes the incorrect widget key calculation. Two different widget keys have been calculated for the same resource. For example, [this](https://forum.arduino.cc/t/ide-2-0-3-double-tabs/1066585) forum post contains the log files and the widget layout. This is an extract that contains the relevant part:

```json
"mainPanel": {
    "main": {
        "type": "tab-area",
        "widgets": [
            {
                "constructionOptions": {
                    "factoryId": "code-editor-opener",
                    "options": {
                        "counter": 0,
                        "kind": "navigatable",
                        "uri": "file:///c%3A/Users/Wim/Documents/Arduino/MaxMSP/double2float/double2float.0.1/double2float.0.1.ino"
                    }
                },
                "innerWidgetState": "{\"cursorState\":[{\"inSelectionMode\":false,\"selectionStart\":{\"lineNumber\":1,\"column\":1},\"position\":{\"lineNumber\":1,\"column\":1}}],\"viewState\":{\"scrollLeft\":0,\"firstPosition\":{\"lineNumber\":1,\"column\":1},\"firstPositionDeltaTop\":0},\"contributionsState\":{\"editor.contrib.folding\":{\"lineCount\":213,\"provider\":\"indent\",\"foldedImports\":false},\"editor.contrib.wordHighlighter\":false}}"
            },
            {
                "constructionOptions": {
                    "factoryId": "code-editor-opener",
                    "options": {
                        "counter": 1,
                        "kind": "navigatable",
                        "uri": "file:///c%3A/Users/Wim/Documents/Arduino/MaxMSP/double2float/double2float.0.1/double2float.0.1.ino"
                    }
                },
                "innerWidgetState": "{\"cursorState\":[{\"inSelectionMode\":false,\"selectionStart\":{\"lineNumber\":54,\"column\":3},\"position\":{\"lineNumber\":54,\"column\":3}}],\"viewState\":{\"scrollLeft\":0,\"firstPosition\":{\"lineNumber\":41,\"column\":1},\"firstPositionDeltaTop\":-9},\"contributionsState\":{\"editor.contrib.folding\":{\"lineCount\":213,\"provider\":\"indent\",\"foldedImports\":false},\"editor.contrib.wordHighlighter\":true}}"
            }
        ],
        "currentIndex": 1
    }
},
```

Two code editor widget IDs exist for the same resource: `file:///c%3A/Users/Wim/Documents/Arduino/MaxMSP/double2float/double2float.0.1/double2float.0.1.ino`, but the `counter` which is [unused by IDE2](https://github.com/arduino/arduino-ide/blob/9b49712669b06c97bda68a1e5f04eee4664c13f8/arduino-ide-extension/src/browser/theia/editor/editor-manager.ts#L7), are different.

### Other information
<!-- Any additional information that could help the review process -->

Closes #1791

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)