### PR TITLE
no-merge: added a preference to reproduce #1791

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -258,6 +258,12 @@ export const ArduinoConfigSchema: PreferenceSchema = {
       ),
       default: undefined,
     },
+    'arduino.sketch.editorOpenTimeout': {
+      type: 'number',
+      description:
+        'Set the editor timeout in milliseconds to reproduce the duplicate editor tabs. See #1791',
+      default: 5000,
+    },
   },
 };
 
@@ -288,6 +294,7 @@ export interface ArduinoConfiguration {
   'arduino.cli.daemon.debug': boolean;
   'arduino.sketch.inoBlueprint': string;
   'arduino.checkForUpdates': boolean;
+  'arduino.sketch.editorOpenTimeout': number;
 }
 
 export const ArduinoPreferences = Symbol('ArduinoPreferences');

--- a/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
@@ -196,7 +196,7 @@ export class OpenSketchFiles extends SketchContribution {
         }
       });
 
-    const timeout = 5_000; // number of ms IDE2 waits for the editor to show up in the UI
+    const timeout = this.preferences['arduino.sketch.editorOpenTimeout']; // number of ms IDE2 waits for the editor to show up in the UI
     const result: EditorWidget | undefined | 'timeout' = await Promise.race([
       deferred.promise,
       wait(timeout).then(() => {


### PR DESCRIPTION
## NO MERGE

### Motivation
<!-- Why this pull request? -->

This is a PR to help reproduce #1791 and prove that #1969 is correct.

There is a new preference to control the editor timeout when opening the sketch files.

Hardcoded in the `main`:

https://github.com/arduino/arduino-ide/blob/9b49712669b06c97bda68a1e5f04eee4664c13f8/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts#L199

New preference in this branch:
`arduino.sketch.editorOpenTimeout`. The default value is 5000 ms.

How to use:

 - When you create a new sketch, all works fine. The editor timeout is 5000 ms.



https://user-images.githubusercontent.com/1405703/226362575-c1ce99a6-cf0f-4de2-9820-e9e97f08afcc.mp4

 - Open the settings JSON and set `arduino.sketch.editorOpenTimeout` to `1`. Ensure your `settings.json` is saved, and create a new sketch. You see the duplicate tabs.



https://user-images.githubusercontent.com/1405703/226363086-91bb537b-c5b0-4676-bacc-f08348865224.mp4



### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)