### PR TITLE
no-merge: composite PR of #1969 and #1970

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -258,6 +258,12 @@ export const ArduinoConfigSchema: PreferenceSchema = {
       ),
       default: undefined,
     },
+    'arduino.sketch.editorOpenTimeout': {
+      type: 'number',
+      description:
+        'Set the editor timeout in milliseconds to reproduce the duplicate editor tabs. See #1791',
+      default: 5000,
+    },
   },
 };
 
@@ -288,6 +294,7 @@ export interface ArduinoConfiguration {
   'arduino.cli.daemon.debug': boolean;
   'arduino.sketch.inoBlueprint': string;
   'arduino.checkForUpdates': boolean;
+  'arduino.sketch.editorOpenTimeout': number;
 }
 
 export const ArduinoPreferences = Symbol('ArduinoPreferences');

--- a/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
@@ -45,7 +45,11 @@ export class OpenSketchFiles extends SketchContribution {
         await this.ensureOpened(uri);
       }
       if (focusMainSketchFile) {
-        await this.ensureOpened(mainFileUri, true, { mode: 'activate' });
+        await this.ensureOpened(mainFileUri, true, {
+          mode: 'activate',
+          preview: false,
+          counter: 0,
+        });
       }
       if (mainFileUri.endsWith('.pde')) {
         const message = nls.localize(

--- a/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
+++ b/arduino-ide-extension/src/browser/contributions/open-sketch-files.ts
@@ -196,7 +196,7 @@ export class OpenSketchFiles extends SketchContribution {
         }
       });
 
-    const timeout = 5_000; // number of ms IDE2 waits for the editor to show up in the UI
+    const timeout = this.preferences['arduino.sketch.editorOpenTimeout']; // number of ms IDE2 waits for the editor to show up in the UI
     const result: EditorWidget | undefined | 'timeout' = await Promise.race([
       deferred.promise,
       wait(timeout).then(() => {


### PR DESCRIPTION
## NO MERGE

### Motivation
<!-- Why this pull request? -->

This PR is to help verify #1969. This exposes the preferences to tune the editor timeout + also contains the fix. Once you have gone through the steps of #1970, you can try the same with this PR. If you do not see duplicate editor tabs, it proves #1969 fixes the incorrect widget key calculation.


https://user-images.githubusercontent.com/1405703/226365194-5a42e9c5-795c-47b7-9f4a-bbf3a9f77499.mp4



### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)