### PR TITLE
fix: updated to `electron-builder@23.6.0`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,6 +99,7 @@ jobs:
             export CSC_LINK="${{ runner.temp }}/signing_certificate.${{ matrix.config.certificate-extension }}"
             echo "${{ secrets[matrix.config.certificate-secret] }}" | base64 --decode > "$CSC_LINK"
             export CSC_KEY_PASSWORD="${{ secrets[matrix.config.certificate-password-secret] }}"
+            export CSC_FOR_PULL_REQUEST=true
           fi
 
           if [ "${{ runner.OS }}" = "Windows" ]; then

--- a/electron/build/template-package.json
+++ b/electron/build/template-package.json
@@ -3,7 +3,7 @@
   "author": "Arduino SA",
   "resolutions": {
     "**/fs-extra": "^4.0.3",
-    "electron-builder": "23.0.2"
+    "electron-builder": "23.6.0"
   },
   "dependencies": {
     "node-log-rotate": "^0.1.5"
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@theia/cli": "1.31.1",
     "cross-env": "^7.0.2",
-    "electron-builder": "23.3.3",
+    "electron-builder": "23.6.0",
     "electron-notarize": "^1.1.1",
     "is-ci": "^2.0.0",
     "ncp": "^2.0.0",


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To fix the auto-updater defect on Windows caused by a library used by IDE2.

I downloaded the build artifacts and verified them on different OSs:
 - macOS (12.3.6) (dmg),
 - Linux (Ubuntu 22.04) (zip, AppImage),
 - Windows (10 Pro, 21H2) (MSI, interactive installer)

I verified the followings: the app starts, can upload to the board, and the LS works.

### Change description
<!-- What does your code do? -->

 - Use `electron-builder@23.6.0`,
 - Set the `CSC_FOR_PULL_REQUEST` env variable in the workflow to run the signing part for PRs.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)