### PR TITLE
fix: update `themeId` settings after theme change

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
@@ -123,6 +123,17 @@ export class SettingsService {
       this._settings = deepClone(settings);
       this.ready.resolve();
     });
+    this.preferenceService.onPreferenceChanged(async (event) => {
+      await this.ready.promise;
+      const { preferenceName, newValue } = event;
+      if (
+        preferenceName === 'workbench.colorTheme' &&
+        typeof newValue === 'string' &&
+        this._settings.themeId !== newValue
+      ) {
+        this.reset();
+      }
+    });
   }
 
   protected async loadSettings(): Promise<Settings> {


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

In Theia, the current theme ID is not always in sync with the persisted `workbench.colorTheme` preference value. For example, one can preview a theme with the `CtrlCmd+K` + `CtrlCmd+T` key chords. The theme changes on quick pick selection change events, but the change is persisted only on accept (user presses `Enter`).

IDE2 has its way of showing and managing different settings in the UI. When the theme is changed outside the IDE2's UI, the model could get out of sync. This PR ensures that on `workbench.colorTheme` preference change, IDE2's settings model is synchronized with persisted Theia preferences.


The theme does not revert on interface scale change:


https://user-images.githubusercontent.com/1405703/229155731-7b616842-17af-4290-a4a2-fecdf1641178.mp4

The theme `<select>` reflects the current theme when the dialog is open:
 - Clicking _OK_ in the settings dialog does not revert the theme:


https://user-images.githubusercontent.com/1405703/229155930-462a6068-35fc-492b-a6b2-c738b746a1d0.mp4

 - Clicking _Cancel_ in the settings dialog reverts the theme:


https://user-images.githubusercontent.com/1405703/229156225-5677609c-7f36-4c7f-993b-3a77dfc99d99.mp4

 - Previewing a theme but not selecting it does not change the theme `<select>` in the settings dialog:


https://user-images.githubusercontent.com/1405703/229156679-d2b61d7a-f52d-4de3-8536-a6c3045cfb55.mp4



### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Closes #1987

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)