### PR TITLE
fix: try fetch the sketch by path if not in the cache

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketch-cache.ts
+++ b/arduino-ide-extension/src/browser/widgets/cloud-sketchbook/cloud-sketch-cache.ts
@@ -1,12 +1,13 @@
 import { FileStat } from '@theia/filesystem/lib/common/files';
 import { injectable } from '@theia/core/shared/inversify';
-import { toPosixPath } from '../../create/create-paths';
+import { splitSketchPath } from '../../create/create-paths';
 import { Create } from '../../create/typings';
 
 @injectable()
 export class SketchCache {
   sketches: Record<string, Create.Sketch> = {};
   fileStats: Record<string, FileStat> = {};
+  private _createPathPrefix: string | undefined;
 
   init(): void {
     // reset the data
@@ -32,12 +33,19 @@ export class SketchCache {
 
   addSketch(sketch: Create.Sketch): void {
     const { path } = sketch;
-    const posixPath = toPosixPath(path);
+    const [pathPrefix, posixPath] = splitSketchPath(path);
+    if (pathPrefix !== this._createPathPrefix) {
+      this._createPathPrefix = pathPrefix;
+    }
     this.sketches[posixPath] = sketch;
   }
 
   getSketch(path: string): Create.Sketch | null {
     return this.sketches[path] || null;
+  }
+
+  get createPathPrefix(): string | undefined {
+    return this._createPathPrefix;
   }
 
   toString(): string {


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The sketch cache might be empty when trying to generate the secrets included in the main sketch file from the `secrets` property.

Closes #1999

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Please follow the steps from #1999 to reproduce and verify the defect.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)