### PR TITLE
Don't upload "channel update info files" related to manual builds to S3 on release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,6 +245,15 @@ jobs:
           file_glob: true
           body: ${{ needs.changelog.outputs.BODY }}
 
+      # Temporary measure to prevent release update offers before the manually produced builds are uploaded.
+      # The step must be removed once fully automated builds are regained.
+      - name: Remove "channel update info files" related to manual builds
+        run: |
+          # See: https://github.com/arduino/arduino-ide/issues/2018
+          rm "${{ env.JOB_TRANSFER_ARTIFACT }}/stable-linux.yml"
+          # See: https://github.com/arduino/arduino-ide/issues/408
+          rm "${{ env.JOB_TRANSFER_ARTIFACT }}/stable-mac.yml"
+
       - name: Publish Release [S3]
         if: github.repository == 'arduino/arduino-ide'
         uses: docker://plugins/s3


### PR DESCRIPTION
### Motivation

Arduino IDE offers an update to the user when a newer version is available. The availability of an update is determined by comparing the user's IDE version against data file ("channel update info file") stored on Arduino's download server.

These "channel update info files" are automatically generated by the build workflow.

Previously the release process was fully automated, including the upload of the "channel update info files" to the server.

As a temporary workaround for limitations of the GitHub Actions runner machines used to produce the automated builds, some release builds are now produced manually:

- Linux build (because the Ubuntu 18.04 runner was shut down and newer runner versions produce builds incompatible with older Linux versions)
- macOS Apple Silicon build (because GitHub hosted Apple Silicon runners are not available)

The automatic upload of the "channel update info files" produced by the build workflow is problematic because if users receive update offers before the "channel update info files" are updated for the manually produced builds, they can receive an update to a different build than intended:

- Users of older Linux versions would update to a build that won't start on their machine
- macOS Apple Silicon users would update to macOS x86 build that is less performant on their machine

### Change description

For this reason, the build workflow is adjusted to no longer upload the Linux and macOS "channel update info files" to the download server on release. These files will now be manually uploaded after they have been updated to provide the manually produced builds.

This workaround will be reverted once a fully automated release system is regained.

### Other information

I did a test release in my fork using the workflow with the modifications from this PR:

https://github.com/per1234/arduino-ide/actions/runs/4730050364

Since it was a test run, the step that uploads the files to S3 was disabled, but the files that would have been uploaded can be seen in the `s3-files` workflow artifact:

```text
s3-files.zip/
├── arduino-ide_2.1.0_Linux_64bit.AppImage
├── arduino-ide_2.1.0_Linux_64bit.zip
├── arduino-ide_2.1.0_Windows_64bit.exe*
├── arduino-ide_2.1.0_Windows_64bit.msi
├── arduino-ide_2.1.0_Windows_64bit.zip
├── arduino-ide_2.1.0_macOS_64bit.dmg
├── arduino-ide_2.1.0_macOS_64bit.zip
└── stable.yml
```

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)