### PR TITLE
Corrected library.properties assignment w.r.t description and summary

### DIFF
--- a/arduino-ide-extension/src/node/library-service-impl.ts
+++ b/arduino-ide-extension/src/node/library-service-impl.ts
@@ -221,8 +221,8 @@ export class LibraryServiceImpl
           {
             name: library.getName(),
             installedVersion,
-            description: library.getSentence(),
-            summary: library.getParagraph(),
+            description: library.getParagraph(),
+            summary: library.getSentence(),
             moreInfoLink: library.getWebsite(),
             includes: library.getProvidesIncludesList(),
             location: this.mapLocation(library.getLocation()),
@@ -462,9 +462,9 @@ function toLibrary(
     author: lib.getAuthor(),
     availableVersions,
     includes: lib.getProvidesIncludesList(),
-    description: lib.getSentence(),
+    description: lib.getParagraph(),
     moreInfoLink: lib.getWebsite(),
-    summary: lib.getParagraph(),
+    summary: lib.getSentence(),
     category: lib.getCategory(),
     types: lib.getTypesList(),
   };


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To save some part of an excellent work of [@nmzaheer](https://github.com/nmzaheer) from #1611.

> Comparison with Arduino 2.0.2 on the left and Arduino 2.0.1 on the right
> 
> ![gffhfhfhfghf](https://user-images.githubusercontent.com/5036103/199223046-798216a3-9797-4c09-95f2-cc5d196adb8d.png)

Although the _Boards/Library Manager_ UI has been updated in [arduino/arduino-ide#1927](https://github.com/arduino/arduino-ide/pull/1927), the `description` vs. `summary` handling is still a fix IDE2 needs.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Ref: arduino/arduino-ide#1611

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)