### PR TITLE
fix: do not exclude cloud sketch diagnostics

### DIFF
--- a/arduino-ide-extension/src/browser/create/create-features.ts
+++ b/arduino-ide-extension/src/browser/create/create-features.ts
@@ -8,6 +8,10 @@ import { AuthenticationSession } from '../../node/auth/types';
 import { ArduinoPreferences } from '../arduino-preferences';
 import { AuthenticationClientService } from '../auth/authentication-client-service';
 import { LocalCacheFsProvider } from '../local-cache/local-cache-fs-provider';
+import {
+  ARDUINO_CLOUD_FOLDER,
+  REMOTE_SKETCHBOOK_FOLDER,
+} from '../utils/constants';
 import { CreateUri } from './create-uri';
 
 export type CloudSketchState = 'push' | 'pull';
@@ -128,8 +132,8 @@ export class CreateFeatures implements FrontendApplicationContribution {
       return undefined;
     }
     return dataDirUri
-      .resolve('RemoteSketchbook')
-      .resolve('ArduinoCloud')
+      .resolve(REMOTE_SKETCHBOOK_FOLDER)
+      .resolve(ARDUINO_CLOUD_FOLDER)
       .isEqualOrParent(new URI(sketch.uri));
   }
 

--- a/arduino-ide-extension/src/browser/local-cache/local-cache-fs-provider.ts
+++ b/arduino-ide-extension/src/browser/local-cache/local-cache-fs-provider.ts
@@ -16,6 +16,10 @@ import {
 import { AuthenticationClientService } from '../auth/authentication-client-service';
 import { AuthenticationSession } from '../../common/protocol/authentication-service';
 import { ConfigService } from '../../common/protocol';
+import {
+  ARDUINO_CLOUD_FOLDER,
+  REMOTE_SKETCHBOOK_FOLDER,
+} from '../utils/constants';
 
 export namespace LocalCacheUri {
   export const scheme = 'arduino-local-cache';
@@ -107,7 +111,7 @@ export class LocalCacheFsProvider
       return;
     }
     this._localCacheRoot = localCacheUri;
-    for (const segment of ['RemoteSketchbook', 'ArduinoCloud']) {
+    for (const segment of [REMOTE_SKETCHBOOK_FOLDER, ARDUINO_CLOUD_FOLDER]) {
       this._localCacheRoot = this._localCacheRoot.resolve(segment);
       await fileService.createFolder(this._localCacheRoot);
     }


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To enable diagnostics for cloud sketches.

### Change description
<!-- What does your code do? -->

As part of `PROEDITOR-50`, the error markers have been disabled for built-ins (daedae1). Then cloud sketches were added to IDE2, but they're in the same root folder where the built-ins are. This PR relaxes the diagnostics filtering and lets it work for the cloud sketchbook cache folder.

Steps to verify:
 - Error diagnostics work with ordinary sketches,
 - Error diagnostics work with cloud sketches independently from the user's logged-in status,
 - There are still no error diagnostics for built-ins and code from platforms if you navigate into them. (basically, what is in `directory.data` but not in `directory.data/RemoteSketchbook/ArduinoCloud` get filtered)

### Other information
<!-- Any additional information that could help the review process -->

Closes #669

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)