### PR TITLE
fix: copy when punctuation marks in sketch path

### DIFF
--- a/arduino-ide-extension/src/node/sketches-service-impl.ts
+++ b/arduino-ide-extension/src/node/sketches-service-impl.ts
@@ -444,7 +444,7 @@ export class SketchesServiceImpl
    * For example, on Windows, instead of getting an [8.3 filename](https://en.wikipedia.org/wiki/8.3_filename), callers will get a fully resolved path.
    * `C:\\Users\\KITTAA~1\\AppData\\Local\\Temp\\.arduinoIDE-unsaved2022615-21100-iahybb.yyvh\\sketch_jul15a` will be `C:\\Users\\kittaakos\\AppData\\Local\\Temp\\.arduinoIDE-unsaved2022615-21100-iahybb.yyvh\\sketch_jul15a`
    */
-  createTempFolder(): Promise<string> {
+  private createTempFolder(): Promise<string> {
     return new Promise<string>((resolve, reject) => {
       temp.mkdir({ prefix: TempSketchPrefix }, (createError, dirPath) => {
         if (createError) {
@@ -523,13 +523,14 @@ export class SketchesServiceImpl
     } else {
       filter = () => true;
     }
-    await cpy(source, destination, {
+    await cpy(sourceFolderBasename, destination, {
       rename: (basename) =>
         sourceFolderBasename !== destinationFolderBasename &&
         basename === `${sourceFolderBasename}.ino`
           ? `${destinationFolderBasename}.ino`
           : basename,
       filter,
+      cwd: path.dirname(source),
     });
     const copiedSketch = await this.doLoadSketch(destinationUri, false);
     return copiedSketch;


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Changed the `source` and `cwd` args to avoid accidentally creating an
invalid `glob` patterns when doing the brace expansion by `cpy`.

### Change description
<!-- What does your code do? -->

Please follow the steps from #2043. There are new tests to cover that case.

### Other information
<!-- Any additional information that could help the review process -->

Closes arduino/arduino-ide#2043

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)