### PR TITLE
fix: show notification if lib/core install failed

### DIFF
--- a/arduino-ide-extension/src/common/protocol/installable.ts
+++ b/arduino-ide-extension/src/common/protocol/installable.ts
@@ -1,4 +1,5 @@
 import type { MessageService } from '@theia/core/lib/common/message-service';
+import { nls } from '@theia/core/lib/common/nls';
 import {
   coerce as coerceSemver,
   compare as compareSemver,
@@ -8,6 +9,32 @@ import { naturalCompare } from '../utils';
 import type { ArduinoComponent } from './arduino-component';
 import { ExecuteWithProgress } from './progressible';
 import type { ResponseServiceClient } from './response-service';
+
+export function libraryInstallFailed(
+  name: string,
+  version?: string | undefined
+): string {
+  const versionSuffix = version ? `:${version}` : '';
+  return nls.localize(
+    'arduino/installable/libraryInstallFailed',
+    "Failed to install library: '{0}{1}'.",
+    name,
+    versionSuffix
+  );
+}
+
+export function platformInstallFailed(
+  name: string,
+  version?: string | undefined
+): string {
+  const versionSuffix = version ? `:${version}` : '';
+  return nls.localize(
+    'arduino/installable/platformInstallFailed',
+    "Failed to install platform: '{0}{1}'.",
+    name,
+    versionSuffix
+  );
+}
 
 export interface Installable<T extends ArduinoComponent> {
   /**
@@ -62,7 +89,7 @@ export namespace Installable {
     'remove',
     'unknown',
   ] as const;
-  export type Action = typeof ActionLiterals[number];
+  export type Action = (typeof ActionLiterals)[number];
 
   export function action(params: {
     installed?: Version | undefined;

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -18,6 +18,7 @@ import {
   BoardSearch,
   sortComponents,
   SortGroup,
+  platformInstallFailed,
 } from '../common/protocol';
 import {
   PlatformInstallRequest,
@@ -474,7 +475,7 @@ export class BoardsServiceImpl
       });
       resp.on('error', (error) => {
         this.responseService.appendToOutput({
-          chunk: `Failed to install platform: ${item.id}.\n`,
+          chunk: `${platformInstallFailed(item.id, version)}\n`,
         });
         this.responseService.appendToOutput({
           chunk: `${error.toString()}\n`,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -278,6 +278,10 @@
       "updateAvailable": "Update Available",
       "versionDownloaded": "Arduino IDE {0} has been downloaded."
     },
+    "installable": {
+      "libraryInstallFailed": "Failed to install library: '{0}{1}'.",
+      "platformInstallFailed": "Failed to install platform: '{0}{1}'."
+    },
     "library": {
       "addZip": "Add .ZIP Library...",
       "arduinoLibraries": "Arduino libraries",


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

IDE2 should notify the user when installing a library/platform has failed.

### Change description
<!-- What does your code do? -->

 - Catch any Arduino component install errors and toast the error message to the user.

For the verification, please follow #621.

https://github.com/arduino/arduino-ide/assets/1405703/a4df4e38-185b-47de-8bf5-d9c9dd3397c0


This PR should also cover platform install failures. For example, nothing happens when there is no Internet connection and one tries to install a platform with `2.1.0`. This PR should cover it. Providing a less cryptic error message with no Internet connection is separate from this PR: https://github.com/arduino/arduino-ide/issues/1429.

`2.1.0`:


https://github.com/arduino/arduino-ide/assets/1405703/19e9571d-a316-4e9e-aaa7-ae0ee932fce8



Build from this PR:


https://github.com/arduino/arduino-ide/assets/1405703/9eca7c67-9181-4d52-8cc1-f771d7a0a3fa




### Other information
<!-- Any additional information that could help the review process -->

Closes #621

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)