### PR TITLE
fix: show no errors if users cancel lib install

### DIFF
--- a/arduino-ide-extension/src/browser/widgets/component-list/filterable-list-container.tsx
+++ b/arduino-ide-extension/src/browser/widgets/component-list/filterable-list-container.tsx
@@ -13,7 +13,7 @@ import {
 } from '../../../common/protocol/installable';
 import { ArduinoComponent } from '../../../common/protocol/arduino-component';
 import { SearchBar } from './search-bar';
-import { ListWidget } from './list-widget';
+import { ListWidget, UserAbortError } from './list-widget';
 import { ComponentList } from './component-list';
 import { ListItemRenderer } from './list-item-renderer';
 import {
@@ -148,6 +148,11 @@ export class FilterableListContainer<
         try {
           await install({ item, progressId, version });
         } catch (err) {
+          if (err instanceof UserAbortError) {
+            // Do not toast an error message on user abort.
+            // https://github.com/arduino/arduino-ide/issues/2063
+            return;
+          }
           const message = LibraryPackage.is(item) // TODO: this dispatch does not belong here
             ? libraryInstallFailed(name, version)
             : platformInstallFailed(name, version);


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

With #2061, IDE2 shows an error notification if an error was caught during the platform/library installation. This is all good, but IDE2 throws `UserAbortError` when the user interrupts the installation process. In such a case, no error notification is needed.

### Change description
<!-- What does your code do? -->

Catch and swallow `UserAbortError` during the installation.

How to verify:
 - Please follow the steps from #2063; you will see no error notifications.
 - Try to install the `Forced-BME280` library; the installation fails, and the cause of the error is shown to the user as an error notification.

https://github.com/arduino/arduino-ide/assets/1405703/5cf285bf-a9fa-4085-b260-1cbceeab2f60

### Other information
<!-- Any additional information that could help the review process -->

Closes #2063

Apologies for the double review, Per.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)