### PR TITLE
add linux-arm64 to download-ls

### DIFF
--- a/arduino-ide-extension/scripts/download-ls.js
+++ b/arduino-ide-extension/scripts/download-ls.js
@@ -88,6 +88,12 @@
       lsSuffix = 'Linux_64bit.tar.gz';
       clangdSuffix = 'Linux_64bit';
       break;
+    case 'linux-arm64':
+      clangdExecutablePath = path.join(build, 'clangd');
+      clangFormatExecutablePath = path.join(build, 'clang-format');
+      lsSuffix = 'Linux_ARM64.tar.gz';
+      clangdSuffix = 'Linux_ARM64';
+      break;
     case 'win32-x64':
       clangdExecutablePath = path.join(build, 'clangd.exe');
       clangFormatExecutablePath = path.join(build, 'clang-format.exe');


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
I want to locally build arduino ide on a linux arm64 machine.

### Change description
<!-- What does your code do? -->
Updates one of the build scripts, so that the ide can build succesfully on linux arm64. 

Tested on Orange Pi 5, Armbian distro.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)