### PR TITLE
fix: relaxed `saveAll` if no Internet connection

### DIFF
--- a/arduino-ide-extension/src/browser/theia/core/application-shell.ts
+++ b/arduino-ide-extension/src/browser/theia/core/application-shell.ts
@@ -8,13 +8,10 @@ import {
   TabBar,
   Widget,
 } from '@theia/core/lib/browser';
-import {
-  ConnectionStatus,
-  ConnectionStatusService,
-} from '@theia/core/lib/browser/connection-status-service';
 import { nls } from '@theia/core/lib/common/nls';
 import { MessageService } from '@theia/core/lib/common/message-service';
 import { inject, injectable } from '@theia/core/shared/inversify';
+import { ApplicationConnectionStatusContribution } from './connection-status-service';
 import { ToolbarAwareTabBar } from './tab-bars';
 
 @injectable()
@@ -22,8 +19,8 @@ export class ApplicationShell extends TheiaApplicationShell {
   @inject(MessageService)
   private readonly messageService: MessageService;
 
-  @inject(ConnectionStatusService)
-  private readonly connectionStatusService: ConnectionStatusService;
+  @inject(ApplicationConnectionStatusContribution)
+  private readonly connectionStatusService: ApplicationConnectionStatusContribution;
 
   override async addWidget(
     widget: Widget,
@@ -64,9 +61,8 @@ export class ApplicationShell extends TheiaApplicationShell {
   }
 
   override async saveAll(options?: SaveOptions): Promise<void> {
-    if (
-      this.connectionStatusService.currentStatus === ConnectionStatus.OFFLINE
-    ) {
+    // When there is no connection between the IDE2 frontend and backend.
+    if (this.connectionStatusService.offlineStatus === 'backend') {
       this.messageService.error(
         nls.localize(
           'theia/core/couldNotSave',


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Saving any (local and cloud) sketches without an Internet connection must be possible. (Pulling/pushing cloud sketch changes are expected to not work without the Internet.)

### Change description
<!-- What does your code do? -->

The previous logic has incorrectly bailed the save when there is no Internet connection. The corrected logic disallows saving files if there is no connection between the front and backend.

### Other information
<!-- Any additional information that could help the review process -->

How to verify the fix:
 - open IDE2, create a new sketch, turn auto-save off, disconnect from the Internet (you will see the yellow `Offline` status bar),
 - modify the sketch and save it. It works. Restart IDE2, and you will see the updated sketch content.

### Reviewer checklist

This PR **does not fix** https://github.com/arduino/arduino-ide/issues/2081.
Ref: cff2c956845e04d320231e8a924d1a47ad016af7
Closes #2079

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)