### PR TITLE
fix: warn user when IDE cannot save the sketch

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/contribution.ts
+++ b/arduino-ide-extension/src/browser/contributions/contribution.ts
@@ -68,6 +68,7 @@ import { MainMenuManager } from '../../common/main-menu-manager';
 import { ConfigServiceClient } from '../config/config-service-client';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
 import { DialogService } from '../dialog-service';
+import { ApplicationConnectionStatusContribution } from '../theia/core/connection-status-service';
 
 export {
   Command,
@@ -171,6 +172,9 @@ export abstract class SketchContribution extends Contribution {
 
   @inject(EnvVariablesServer)
   protected readonly envVariableServer: EnvVariablesServer;
+
+  @inject(ApplicationConnectionStatusContribution)
+  protected readonly connectionStatusService: ApplicationConnectionStatusContribution;
 
   protected async sourceOverride(): Promise<Record<string, string>> {
     const override: Record<string, string> = {};

--- a/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
@@ -24,6 +24,7 @@ import {
   RenameCloudSketch,
   RenameCloudSketchParams,
 } from './rename-cloud-sketch';
+import { assertConnectedToBackend } from './save-sketch';
 
 @injectable()
 export class SaveAsSketch extends CloudSketchContribution {
@@ -64,6 +65,10 @@ export class SaveAsSketch extends CloudSketchContribution {
       markAsRecentlyOpened,
     }: SaveAsSketch.Options = SaveAsSketch.Options.DEFAULT
   ): Promise<boolean> {
+    assertConnectedToBackend({
+      connectionStatusService: this.connectionStatusService,
+      messageService: this.messageService,
+    });
     const sketch = await this.sketchServiceClient.currentSketch();
     if (!CurrentSketch.isValid(sketch)) {
       return false;

--- a/arduino-ide-extension/src/browser/contributions/save-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/save-sketch.ts
@@ -1,16 +1,18 @@
-import { injectable } from '@theia/core/shared/inversify';
 import { CommonCommands } from '@theia/core/lib/browser/common-frontend-contribution';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { nls } from '@theia/core/lib/common/nls';
+import { injectable } from '@theia/core/shared/inversify';
 import { ArduinoMenus } from '../menu/arduino-menus';
-import { SaveAsSketch } from './save-as-sketch';
+import { CurrentSketch } from '../sketches-service-client-impl';
+import { ApplicationConnectionStatusContribution } from '../theia/core/connection-status-service';
 import {
-  SketchContribution,
   Command,
   CommandRegistry,
-  MenuModelRegistry,
   KeybindingRegistry,
+  MenuModelRegistry,
+  SketchContribution,
 } from './contribution';
-import { nls } from '@theia/core/lib/common';
-import { CurrentSketch } from '../sketches-service-client-impl';
+import { SaveAsSketch } from './save-as-sketch';
 
 @injectable()
 export class SaveSketch extends SketchContribution {
@@ -36,6 +38,10 @@ export class SaveSketch extends SketchContribution {
   }
 
   async saveSketch(): Promise<void> {
+    assertConnectedToBackend({
+      connectionStatusService: this.connectionStatusService,
+      messageService: this.messageService,
+    });
     const sketch = await this.sketchServiceClient.currentSketch();
     if (!CurrentSketch.isValid(sketch)) {
       return;
@@ -61,5 +67,20 @@ export namespace SaveSketch {
     export const SAVE_SKETCH: Command = {
       id: 'arduino-save-sketch',
     };
+  }
+}
+
+// https://github.com/arduino/arduino-ide/issues/2081
+export function assertConnectedToBackend(param: {
+  connectionStatusService: ApplicationConnectionStatusContribution;
+  messageService: MessageService;
+}): void {
+  if (param.connectionStatusService.offlineStatus === 'backend') {
+    const message = nls.localize(
+      'theia/core/couldNotSave',
+      'Could not save the sketch. Please copy your unsaved work into your favorite text editor, and restart the IDE.'
+    );
+    param.messageService.error(message);
+    throw new Error(message);
   }
 }

--- a/arduino-ide-extension/src/test/browser/connection-status-service.test.ts
+++ b/arduino-ide-extension/src/test/browser/connection-status-service.test.ts
@@ -20,25 +20,41 @@ disableJSDOM();
 describe('connection-status-service', () => {
   describe('offlineMessage', () => {
     it('should warn about the offline backend if connected to both CLI daemon and Internet but offline', () => {
-      const actual = offlineMessage({ port: '50051', online: true });
+      const actual = offlineMessage({
+        port: '50051',
+        online: true,
+        backendConnected: false,
+      });
       expect(actual.text).to.be.equal(backendOfflineText);
       expect(actual.tooltip).to.be.equal(backendOfflineTooltip);
     });
 
     it('should warn about the offline CLI daemon if the CLI daemon port is missing but has Internet connection', () => {
-      const actual = offlineMessage({ port: undefined, online: true });
+      const actual = offlineMessage({
+        port: undefined,
+        online: true,
+        backendConnected: true,
+      });
       expect(actual.text.endsWith(daemonOfflineText)).to.be.true;
       expect(actual.tooltip).to.be.equal(daemonOfflineTooltip);
     });
 
     it('should warn about the offline CLI daemon if the CLI daemon port is missing and has no Internet connection', () => {
-      const actual = offlineMessage({ port: undefined, online: false });
+      const actual = offlineMessage({
+        port: undefined,
+        online: false,
+        backendConnected: true,
+      });
       expect(actual.text.endsWith(daemonOfflineText)).to.be.true;
       expect(actual.tooltip).to.be.equal(daemonOfflineTooltip);
     });
 
     it('should warn about no Internet connection if CLI daemon port is available but the Internet connection is offline', () => {
-      const actual = offlineMessage({ port: '50051', online: false });
+      const actual = offlineMessage({
+        port: '50051',
+        online: false,
+        backendConnected: true,
+      });
       expect(actual.text.endsWith(offlineText)).to.be.true;
       expect(actual.tooltip).to.be.equal(offlineTooltip);
     });


### PR DESCRIPTION
~## Depends on #2080~ ✅ 

----

### Motivation
<!-- Why this pull request? -->

IDE2 must warn the users to manually save the sketch content when IDE cannot do it due to a crashed backend process.

### Change description
<!-- What does your code do? -->

Check the `socket.connected` status when calculating the nature of the connectivity problem in the frontend.

Steps to verify: Please see https://github.com/arduino/arduino-ide/issues/2081

### Other information
<!-- Any additional information that could help the review process -->

Closes #2081

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)