### PR TITLE
fix: omit port from upload request when not set

### DIFF
--- a/arduino-ide-extension/src/node/core-service-impl.ts
+++ b/arduino-ide-extension/src/node/core-service-impl.ts
@@ -411,17 +411,21 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
     }
   }
 
-  private createPort(port: Port | undefined): RpcPort {
+  private createPort(port: Port | undefined): RpcPort | undefined {
+    if (!port) {
+      return undefined;
+    }
     const rpcPort = new RpcPort();
-    if (port) {
-      rpcPort.setAddress(port.address);
-      rpcPort.setLabel(port.addressLabel);
-      rpcPort.setProtocol(port.protocol);
-      rpcPort.setProtocolLabel(port.protocolLabel);
-      if (port.properties) {
-        for (const [key, value] of Object.entries(port.properties)) {
-          rpcPort.getPropertiesMap().set(key, value);
-        }
+    rpcPort.setAddress(port.address);
+    rpcPort.setLabel(port.addressLabel);
+    rpcPort.setProtocol(port.protocol);
+    rpcPort.setProtocolLabel(port.protocolLabel);
+    if (port.hardwareId !== undefined) {
+      rpcPort.setHardwareId(port.hardwareId);
+    }
+    if (port.properties) {
+      for (const [key, value] of Object.entries(port.properties)) {
+        rpcPort.getPropertiesMap().set(key, value);
       }
     }
     return rpcPort;

--- a/arduino-ide-extension/src/test/node/core-service-impl.test.ts
+++ b/arduino-ide-extension/src/test/node/core-service-impl.test.ts
@@ -1,0 +1,41 @@
+import { expect } from 'chai';
+import { Port } from '../../node/cli-protocol/cc/arduino/cli/commands/v1/port_pb';
+import { CoreServiceImpl } from '../../node/core-service-impl';
+
+describe('core-service-impl', () => {
+  describe('createPort', () => {
+    it("should map the 'undefined' port object to an 'undefined' gRPC port value", () => {
+      const actual = new CoreServiceImpl()['createPort'](undefined);
+      expect(actual).to.be.undefined;
+    });
+
+    it('should map a port object to the appropriate gRPC port object', () => {
+      const properties = {
+        alma: 'false',
+        korte: '36',
+      };
+      const port = {
+        address: 'address',
+        addressLabel: 'address label',
+        hardwareId: '1730323',
+        protocol: 'serial',
+        protocolLabel: 'serial port',
+        properties,
+      } as const;
+      const actual = new CoreServiceImpl()['createPort'](port);
+      expect(actual).to.be.not.undefined;
+      const expected = new Port()
+        .setAddress(port.address)
+        .setHardwareId(port.hardwareId)
+        .setLabel(port.addressLabel)
+        .setProtocol(port.protocol)
+        .setProtocolLabel(port.protocolLabel);
+      Object.entries(properties).forEach(([key, value]) =>
+        expected.getPropertiesMap().set(key, value)
+      );
+      expect((<Port>actual).toObject(false)).to.be.deep.equal(
+        expected.toObject(false)
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Omit the port object from the compile request so the CLI can correctly fall back to the `default` upload port. This does not work when the `port` object is empty. Only `null` is a valid port value in such a scenario.

### Change description
<!-- What does your code do? -->

Previously, if the `port` was not set in IDE2, the compile request object was created with an empty port object (`{}`). IDE2 will create a compile request with the default `null` `port` value if the port is not specified.

This PR sets the `hardwareId` on the port object. `Port#hardwareId ` has not been used in IDE2 since its introduction.

### Other information
<!-- Any additional information that could help the review process -->

I went through the steps from #2089, but I am not 100% sure I could follow them. I did the followings:
 - Opened 2.1.0, and uploaded the "Soft brick" sketch to my Micro, then CLI/IDE2 couldn't detect my Micro board after. Every upload attempt failed with the `Failed uploading: no upload port provided` message.
 - Opened IDE2 from this PR, selected the Micro board but not the port, started the upload, and saw the followings in the _Output_, and could upload:
    ```
    Skipping 1200-bps touch reset: no serial port selected!
    Waiting for upload port...
    No upload port found, using  as fallback
    ```

`2.1.0`:

https://github.com/arduino/arduino-ide/assets/1405703/2bff1aa4-3d97-44d3-8c34-d5c59063074a

Build from this PR:

https://github.com/arduino/arduino-ide/assets/1405703/5c9d6653-5709-47f3-bdb7-299cc91fe597


Closes #2089

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)