### PR TITLE
fix: include all log `args` in the log message 

### DIFF
--- a/arduino-ide-extension/src/node/arduino-daemon-impl.ts
+++ b/arduino-ide-extension/src/node/arduino-daemon-impl.ts
@@ -9,6 +9,7 @@ import {
   DisposableCollection,
 } from '@theia/core/lib/common/disposable';
 import { Event, Emitter } from '@theia/core/lib/common/event';
+import { deepClone } from '@theia/core/lib/common/objects';
 import { environment } from '@theia/application-package/lib/environment';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
@@ -171,7 +172,10 @@ export class ArduinoDaemonImpl
     const args = await this.getSpawnArgs();
     const cliPath = this.getExecPath();
     const ready = new Deferred<{ daemon: ChildProcess; port: string }>();
-    const options = { shell: true };
+    const options = {
+      shell: true,
+      env: { ...deepClone(process.env), NO_COLOR: String(true) },
+    };
     const daemon = spawn(`"${cliPath}"`, args, options);
 
     // If the process exists right after the daemon gRPC server has started (due to an invalid port, unknown address, TCP port in use, etc.)
@@ -258,7 +262,7 @@ export class ArduinoDaemonImpl
   }
 
   protected onData(message: string): void {
-    this.logger.info(message);
+    this.logger.info(message.trim());
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/electron/build/patch/backend/main.js
+++ b/electron/build/patch/backend/main.js
@@ -6,6 +6,7 @@
 // From the specs: https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
 // "If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used."
 const os = require('os');
+const util = require('util');
 if (os.platform() === 'linux' && !process.env['XDG_CONFIG_HOME']) {
     const { join } = require('path');
     const home = process.env['HOME'];
@@ -18,12 +19,14 @@ setup({
     appName: 'Arduino IDE',
     maxSize: 10 * 1024 * 1024
 });
-for (const name of ['log', 'trace', 'info', 'warn', 'error']) {
+for (const name of ['log', 'trace', 'debug', 'info', 'warn', 'error']) {
     const original = console[name];
-    console[name] = (data => {
-        original(data);
-        log(data);
-    }).bind(console);
+    console[name] = function () {
+        const messages = Object.values(arguments);
+        const message = util.format(...messages)
+        original(message)
+        log(message);
+    }
 }
 
 const { BackendApplicationConfigProvider } = require('@theia/core/lib/node/backend-application-config-provider');


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

`debug` messages logged by the Theia logger were not forwarded to the file logger. This PR fixes it.

### Change description
<!-- What does your code do? -->

 - In the bundled application, the customized logger that writes the log
files bogusly includes only the first message fragment in the log
message. This PR ensures all message fragments are included in the final
message before it is printed to the console/terminal and persisted to
the rotating log files.
 - Includes messages with `debug` severity in the log.
 - Disables the ANSI coloring in the CLI daemon log by adding the
`NO_COLOR=true` environment variable to the spawned CLI daemon process.
 - Trims trailing line ending of the daemon log.

### Other information
<!-- Any additional information that could help the review process -->

Steps to verify:
 - Start IDE2 with `debug` log level from a terminal. On macOS, it is similar to `/Applications/Arduino\ IDE\ 2.1.0.app/Contents/MacOS/Arduino\ IDE --log-level debug`.
 - Attach then detach a board. Verify that you see `root DEBUG Board config changed:` messages in the terminal.
 - Make sure messages consisting of multiple fragments are logged correctly. A good example is `DEBUG Starting the deployer with the list of resolvers`. You see the list of resolvers as a JSON string.
 - Quit IDE2 and open up the most recent log file. It is under `/Library/Logs/Arduino IDE` on macOS. Verify that the `root DEBUG Board config changed:` messages are inside the file. This does not work with `2.1.0`.
 - Verify the followings:
    - no ANSI control codes in the log, and
    - no unnecessary empty lines.

----

Before:
```
INFO[0000] Required tool                                 tool="rp2040:pqt-gcc@1.5.0-b-c7bab52"
```

After:
```
2023-06-23T11:47:18.237Z daemon INFO time="2023-06-23T13:47:18+02:00" level=info msg="Required tool" tool="rp2040:pqt-elf2uf2@1.5.0-b-c7bab52"
time="2023-06-23T13:47:18+02:00" level=info msg="Required tool" tool="rp2040:pqt-gcc@1.5.0-b-c7bab52"
```

----

Before:
```
2023-06-23T11:35:13.406Z daemon INFO DEBU[0002] Querying installed cores for board identification... 

2023-06-23T11:35:13.406Z daemon INFO DEBU[0002] Querying installed cores for board identification... 

```

After:
```
time="2023-06-23T13:47:09+02:00" level=debug msg="Querying installed cores for board identification..."
time="2023-06-23T13:47:09+02:00" level=debug msg="Querying installed cores for board identification..."
```

----

Ref: https://github.com/arduino/arduino-ide/issues/2100#issuecomment-1594818955

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)