### PR TITLE
fix: flawed config handling in the FQBN

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/ino-language.ts
+++ b/arduino-ide-extension/src/browser/contributions/ino-language.ts
@@ -92,8 +92,10 @@ export class InoLanguage extends SketchContribution {
               `Failed to sanitize the FQBN of the running language server. FQBN with the board settings was: ${this.languageServerFqbn}`
             );
           }
+          // The incoming FQBNs might contain custom boards configs, sanitize them before the comparison.
+          // https://github.com/arduino/arduino-ide/pull/2113#pullrequestreview-1499998328
           const matchingFqbn = dataChangePerFqbn.find(
-            (fqbn) => sanitizedFqbn === fqbn
+            (fqbn) => sanitizedFqbn === sanitizeFqbn(fqbn)
           );
           const { boardsConfig } = this.boardsServiceProvider;
           if (

--- a/arduino-ide-extension/src/browser/contributions/ino-language.ts
+++ b/arduino-ide-extension/src/browser/contributions/ino-language.ts
@@ -6,7 +6,6 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { Mutex } from 'async-mutex';
 import {
   ArduinoDaemon,
-  assertSanitizedFqbn,
   BoardsService,
   ExecutableService,
   sanitizeFqbn,
@@ -151,7 +150,6 @@ export class InoLanguage extends SketchContribution {
         }
         return;
       }
-      assertSanitizedFqbn(fqbn);
       const fqbnWithConfig = await this.boardDataStore.appendConfigToFqbn(fqbn);
       if (!fqbnWithConfig) {
         throw new Error(

--- a/arduino-ide-extension/src/common/protocol/boards-service.ts
+++ b/arduino-ide-extension/src/common/protocol/boards-service.ts
@@ -574,7 +574,8 @@ export namespace ConfigOption {
     const configSuffix = Object.entries(mergedOptions)
       .map(([option, value]) => `${option}=${value}`)
       .join(',');
-    return `${vendor}:${arch}:${id}:${configSuffix}`;
+
+    return `${vendor}:${arch}:${id}${configSuffix ? `:${configSuffix}` : ''}`;
   }
 
   export class ConfigOptionError extends Error {

--- a/arduino-ide-extension/src/test/common/boards-service.test.ts
+++ b/arduino-ide-extension/src/test/common/boards-service.test.ts
@@ -104,6 +104,12 @@ describe('boards-service', () => {
         })
     );
 
+    it('should not append the trailing boards config part to FQBN if configs is empty', () => {
+      const fqbn = 'a:b:c';
+      const actual = ConfigOption.decorate(fqbn, []);
+      expect(actual).to.be.equal(fqbn);
+    });
+
     it('should be noop when config options is empty', () => {
       const fqbn = 'a:b:c:menu1=value1';
       const actual = ConfigOption.decorate(fqbn, []);


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Fixes the incorrect config options handling in the FQBN.

### Change description
<!-- What does your code do? -->

This PR also relaxes the LS assertions at the start. As it turned out, the CLI can detect FQBNs with already appended board config values.

### Other information
<!-- Any additional information that could help the review process -->

To set up:
 - Open the 3rd party URLs config.
 - If you have `https://www.pjrc.com/teensy/package_teensy_index.json` added, remove it.
 - Add `https://www.pjrc.com/teensy/package_issue1588_index.json`.
 - If you have the Teensy core installed, remove it.
 - Install Teensy@1.57

To verify:
 - Please see the steps from https://github.com/arduino/arduino-ide/issues/1588.
 - Please make sure the language features work. They must!

If you had Teensy installed before the verification, you probably know how to revert to the original setup 😊 but in case you don't
 - Remove Teensy @1.57.
 - Replace `https://www.pjrc.com/teensy/package_issue1588_index.json` with `https://www.pjrc.com/teensy/package_teensy_index.json` in the 3rd party URLs dialog.
 - Install the latest Teensy version.


Closes #1588

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)