### PR TITLE
chore(cli): Bumped the CLI version to `0.33.1`

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -170,7 +170,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.33.0"
+      "version": "0.33.1"
     },
     "fwuploader": {
       "version": "2.2.2"

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -170,7 +170,7 @@
   ],
   "arduino": {
     "cli": {
-      "version": "0.32.3"
+      "version": "0.33.0"
     },
     "fwuploader": {
       "version": "2.2.2"

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/board_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/board_pb.d.ts
@@ -18,6 +18,9 @@ export class BoardDetailsRequest extends jspb.Message {
     getFqbn(): string;
     setFqbn(value: string): BoardDetailsRequest;
 
+    getDoNotExpandBuildProperties(): boolean;
+    setDoNotExpandBuildProperties(value: boolean): BoardDetailsRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): BoardDetailsRequest.AsObject;
@@ -33,6 +36,7 @@ export namespace BoardDetailsRequest {
     export type AsObject = {
         instance?: cc_arduino_cli_commands_v1_common_pb.Instance.AsObject,
         fqbn: string,
+        doNotExpandBuildProperties: boolean,
     }
 }
 
@@ -93,6 +97,11 @@ export class BoardDetailsResponse extends jspb.Message {
     setIdentificationPropertiesList(value: Array<BoardIdentificationProperties>): BoardDetailsResponse;
     addIdentificationProperties(value?: BoardIdentificationProperties, index?: number): BoardIdentificationProperties;
 
+    clearBuildPropertiesList(): void;
+    getBuildPropertiesList(): Array<string>;
+    setBuildPropertiesList(value: Array<string>): BoardDetailsResponse;
+    addBuildProperties(value: string, index?: number): string;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): BoardDetailsResponse.AsObject;
@@ -120,6 +129,7 @@ export namespace BoardDetailsResponse {
         programmersList: Array<cc_arduino_cli_commands_v1_common_pb.Programmer.AsObject>,
         debuggingSupported: boolean,
         identificationPropertiesList: Array<BoardIdentificationProperties.AsObject>,
+        buildPropertiesList: Array<string>,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/board_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/board_pb.js
@@ -498,7 +498,8 @@ proto.cc.arduino.cli.commands.v1.BoardDetailsRequest.prototype.toObject = functi
 proto.cc.arduino.cli.commands.v1.BoardDetailsRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     instance: (f = msg.getInstance()) && cc_arduino_cli_commands_v1_common_pb.Instance.toObject(includeInstance, f),
-    fqbn: jspb.Message.getFieldWithDefault(msg, 2, "")
+    fqbn: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    doNotExpandBuildProperties: jspb.Message.getBooleanFieldWithDefault(msg, 3, false)
   };
 
   if (includeInstance) {
@@ -544,6 +545,10 @@ proto.cc.arduino.cli.commands.v1.BoardDetailsRequest.deserializeBinaryFromReader
       var value = /** @type {string} */ (reader.readString());
       msg.setFqbn(value);
       break;
+    case 3:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setDoNotExpandBuildProperties(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -585,6 +590,13 @@ proto.cc.arduino.cli.commands.v1.BoardDetailsRequest.serializeBinaryToWriter = f
   if (f.length > 0) {
     writer.writeString(
       2,
+      f
+    );
+  }
+  f = message.getDoNotExpandBuildProperties();
+  if (f) {
+    writer.writeBool(
+      3,
       f
     );
   }
@@ -646,13 +658,31 @@ proto.cc.arduino.cli.commands.v1.BoardDetailsRequest.prototype.setFqbn = functio
 };
 
 
+/**
+ * optional bool do_not_expand_build_properties = 3;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.BoardDetailsRequest.prototype.getDoNotExpandBuildProperties = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 3, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.BoardDetailsRequest} returns this
+ */
+proto.cc.arduino.cli.commands.v1.BoardDetailsRequest.prototype.setDoNotExpandBuildProperties = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 3, value);
+};
+
+
 
 /**
  * List of repeated fields within this message type.
  * @private {!Array<number>}
  * @const
  */
-proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.repeatedFields_ = [10,11,13,15];
+proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.repeatedFields_ = [10,11,13,15,16];
 
 
 
@@ -702,7 +732,8 @@ proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.toObject = function(includ
     cc_arduino_cli_commands_v1_common_pb.Programmer.toObject, includeInstance),
     debuggingSupported: jspb.Message.getBooleanFieldWithDefault(msg, 14, false),
     identificationPropertiesList: jspb.Message.toObjectList(msg.getIdentificationPropertiesList(),
-    proto.cc.arduino.cli.commands.v1.BoardIdentificationProperties.toObject, includeInstance)
+    proto.cc.arduino.cli.commands.v1.BoardIdentificationProperties.toObject, includeInstance),
+    buildPropertiesList: (f = jspb.Message.getRepeatedField(msg, 16)) == null ? undefined : f
   };
 
   if (includeInstance) {
@@ -800,6 +831,10 @@ proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.deserializeBinaryFromReade
       var value = new proto.cc.arduino.cli.commands.v1.BoardIdentificationProperties;
       reader.readMessage(value,proto.cc.arduino.cli.commands.v1.BoardIdentificationProperties.deserializeBinaryFromReader);
       msg.addIdentificationProperties(value);
+      break;
+    case 16:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addBuildProperties(value);
       break;
     default:
       reader.skipField();
@@ -932,6 +967,13 @@ proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.serializeBinaryToWriter = 
       15,
       f,
       proto.cc.arduino.cli.commands.v1.BoardIdentificationProperties.serializeBinaryToWriter
+    );
+  }
+  f = message.getBuildPropertiesList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      16,
+      f
     );
   }
 };
@@ -1304,6 +1346,43 @@ proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.prototype.addIdentificatio
  */
 proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.prototype.clearIdentificationPropertiesList = function() {
   return this.setIdentificationPropertiesList([]);
+};
+
+
+/**
+ * repeated string build_properties = 16;
+ * @return {!Array<string>}
+ */
+proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.prototype.getBuildPropertiesList = function() {
+  return /** @type {!Array<string>} */ (jspb.Message.getRepeatedField(this, 16));
+};
+
+
+/**
+ * @param {!Array<string>} value
+ * @return {!proto.cc.arduino.cli.commands.v1.BoardDetailsResponse} returns this
+ */
+proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.prototype.setBuildPropertiesList = function(value) {
+  return jspb.Message.setField(this, 16, value || []);
+};
+
+
+/**
+ * @param {string} value
+ * @param {number=} opt_index
+ * @return {!proto.cc.arduino.cli.commands.v1.BoardDetailsResponse} returns this
+ */
+proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.prototype.addBuildProperties = function(value, opt_index) {
+  return jspb.Message.addToRepeatedField(this, 16, value, opt_index);
+};
+
+
+/**
+ * Clears the list making it empty but non-null.
+ * @return {!proto.cc.arduino.cli.commands.v1.BoardDetailsResponse} returns this
+ */
+proto.cc.arduino.cli.commands.v1.BoardDetailsResponse.prototype.clearBuildPropertiesList = function() {
+  return this.setBuildPropertiesList([]);
 };
 
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/common_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/common_pb.d.ts
@@ -260,6 +260,12 @@ export class Platform extends jspb.Message {
     getHelp(): HelpResources | undefined;
     setHelp(value?: HelpResources): Platform;
 
+    getIndexed(): boolean;
+    setIndexed(value: boolean): Platform;
+
+    getMissingMetadata(): boolean;
+    setMissingMetadata(value: boolean): Platform;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): Platform.AsObject;
@@ -285,6 +291,8 @@ export namespace Platform {
         deprecated: boolean,
         typeList: Array<string>,
         help?: HelpResources.AsObject,
+        indexed: boolean,
+        missingMetadata: boolean,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/common_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/common_pb.js
@@ -1637,7 +1637,9 @@ proto.cc.arduino.cli.commands.v1.Platform.toObject = function(includeInstance, m
     manuallyInstalled: jspb.Message.getBooleanFieldWithDefault(msg, 9, false),
     deprecated: jspb.Message.getBooleanFieldWithDefault(msg, 10, false),
     typeList: (f = jspb.Message.getRepeatedField(msg, 11)) == null ? undefined : f,
-    help: (f = msg.getHelp()) && proto.cc.arduino.cli.commands.v1.HelpResources.toObject(includeInstance, f)
+    help: (f = msg.getHelp()) && proto.cc.arduino.cli.commands.v1.HelpResources.toObject(includeInstance, f),
+    indexed: jspb.Message.getBooleanFieldWithDefault(msg, 13, false),
+    missingMetadata: jspb.Message.getBooleanFieldWithDefault(msg, 14, false)
   };
 
   if (includeInstance) {
@@ -1723,6 +1725,14 @@ proto.cc.arduino.cli.commands.v1.Platform.deserializeBinaryFromReader = function
       var value = new proto.cc.arduino.cli.commands.v1.HelpResources;
       reader.readMessage(value,proto.cc.arduino.cli.commands.v1.HelpResources.deserializeBinaryFromReader);
       msg.setHelp(value);
+      break;
+    case 13:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setIndexed(value);
+      break;
+    case 14:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setMissingMetadata(value);
       break;
     default:
       reader.skipField();
@@ -1837,6 +1847,20 @@ proto.cc.arduino.cli.commands.v1.Platform.serializeBinaryToWriter = function(mes
       12,
       f,
       proto.cc.arduino.cli.commands.v1.HelpResources.serializeBinaryToWriter
+    );
+  }
+  f = message.getIndexed();
+  if (f) {
+    writer.writeBool(
+      13,
+      f
+    );
+  }
+  f = message.getMissingMetadata();
+  if (f) {
+    writer.writeBool(
+      14,
+      f
     );
   }
 };
@@ -2113,6 +2137,42 @@ proto.cc.arduino.cli.commands.v1.Platform.prototype.clearHelp = function() {
  */
 proto.cc.arduino.cli.commands.v1.Platform.prototype.hasHelp = function() {
   return jspb.Message.getField(this, 12) != null;
+};
+
+
+/**
+ * optional bool indexed = 13;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.Platform.prototype.getIndexed = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 13, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.Platform} returns this
+ */
+proto.cc.arduino.cli.commands.v1.Platform.prototype.setIndexed = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 13, value);
+};
+
+
+/**
+ * optional bool missing_metadata = 14;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.Platform.prototype.getMissingMetadata = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 14, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.Platform} returns this
+ */
+proto.cc.arduino.cli.commands.v1.Platform.prototype.setMissingMetadata = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 14, value);
 };
 
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.d.ts
@@ -95,6 +95,9 @@ export class CompileRequest extends jspb.Message {
     getSkipLibrariesDiscovery(): boolean;
     setSkipLibrariesDiscovery(value: boolean): CompileRequest;
 
+    getDoNotExpandBuildProperties(): boolean;
+    setDoNotExpandBuildProperties(value: boolean): CompileRequest;
+
 
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): CompileRequest.AsObject;
@@ -133,6 +136,7 @@ export namespace CompileRequest {
         signKey: string,
         encryptKey: string,
         skipLibrariesDiscovery: boolean,
+        doNotExpandBuildProperties: boolean,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/compile_pb.js
@@ -155,7 +155,8 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.toObject = function(includeInsta
     keysKeychain: jspb.Message.getFieldWithDefault(msg, 25, ""),
     signKey: jspb.Message.getFieldWithDefault(msg, 26, ""),
     encryptKey: jspb.Message.getFieldWithDefault(msg, 27, ""),
-    skipLibrariesDiscovery: jspb.Message.getBooleanFieldWithDefault(msg, 28, false)
+    skipLibrariesDiscovery: jspb.Message.getBooleanFieldWithDefault(msg, 28, false),
+    doNotExpandBuildProperties: jspb.Message.getBooleanFieldWithDefault(msg, 29, false)
   };
 
   if (includeInstance) {
@@ -291,6 +292,10 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.deserializeBinaryFromReader = fu
     case 28:
       var value = /** @type {boolean} */ (reader.readBool());
       msg.setSkipLibrariesDiscovery(value);
+      break;
+    case 29:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setDoNotExpandBuildProperties(value);
       break;
     default:
       reader.skipField();
@@ -485,6 +490,13 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.serializeBinaryToWriter = functi
   if (f) {
     writer.writeBool(
       28,
+      f
+    );
+  }
+  f = message.getDoNotExpandBuildProperties();
+  if (f) {
+    writer.writeBool(
+      29,
       f
     );
   }
@@ -1019,6 +1031,24 @@ proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.getSkipLibrariesDiscov
  */
 proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.setSkipLibrariesDiscovery = function(value) {
   return jspb.Message.setProto3BooleanField(this, 28, value);
+};
+
+
+/**
+ * optional bool do_not_expand_build_properties = 29;
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.getDoNotExpandBuildProperties = function() {
+  return /** @type {boolean} */ (jspb.Message.getBooleanFieldWithDefault(this, 29, false));
+};
+
+
+/**
+ * @param {boolean} value
+ * @return {!proto.cc.arduino.cli.commands.v1.CompileRequest} returns this
+ */
+proto.cc.arduino.cli.commands.v1.CompileRequest.prototype.setDoNotExpandBuildProperties = function(value) {
+  return jspb.Message.setProto3BooleanField(this, 29, value);
 };
 
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.d.ts
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.d.ts
@@ -282,6 +282,12 @@ export class PlatformUpgradeResponse extends jspb.Message {
     setTaskProgress(value?: cc_arduino_cli_commands_v1_common_pb.TaskProgress): PlatformUpgradeResponse;
 
 
+    hasPlatform(): boolean;
+    clearPlatform(): void;
+    getPlatform(): cc_arduino_cli_commands_v1_common_pb.Platform | undefined;
+    setPlatform(value?: cc_arduino_cli_commands_v1_common_pb.Platform): PlatformUpgradeResponse;
+
+
     serializeBinary(): Uint8Array;
     toObject(includeInstance?: boolean): PlatformUpgradeResponse.AsObject;
     static toObject(includeInstance: boolean, msg: PlatformUpgradeResponse): PlatformUpgradeResponse.AsObject;
@@ -296,6 +302,7 @@ export namespace PlatformUpgradeResponse {
     export type AsObject = {
         progress?: cc_arduino_cli_commands_v1_common_pb.DownloadProgress.AsObject,
         taskProgress?: cc_arduino_cli_commands_v1_common_pb.TaskProgress.AsObject,
+        platform?: cc_arduino_cli_commands_v1_common_pb.Platform.AsObject,
     }
 }
 

--- a/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.js
+++ b/arduino-ide-extension/src/node/cli-protocol/cc/arduino/cli/commands/v1/core_pb.js
@@ -2064,7 +2064,8 @@ proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse.prototype.toObject = fu
 proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     progress: (f = msg.getProgress()) && cc_arduino_cli_commands_v1_common_pb.DownloadProgress.toObject(includeInstance, f),
-    taskProgress: (f = msg.getTaskProgress()) && cc_arduino_cli_commands_v1_common_pb.TaskProgress.toObject(includeInstance, f)
+    taskProgress: (f = msg.getTaskProgress()) && cc_arduino_cli_commands_v1_common_pb.TaskProgress.toObject(includeInstance, f),
+    platform: (f = msg.getPlatform()) && cc_arduino_cli_commands_v1_common_pb.Platform.toObject(includeInstance, f)
   };
 
   if (includeInstance) {
@@ -2111,6 +2112,11 @@ proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse.deserializeBinaryFromRe
       reader.readMessage(value,cc_arduino_cli_commands_v1_common_pb.TaskProgress.deserializeBinaryFromReader);
       msg.setTaskProgress(value);
       break;
+    case 3:
+      var value = new cc_arduino_cli_commands_v1_common_pb.Platform;
+      reader.readMessage(value,cc_arduino_cli_commands_v1_common_pb.Platform.deserializeBinaryFromReader);
+      msg.setPlatform(value);
+      break;
     default:
       reader.skipField();
       break;
@@ -2154,6 +2160,14 @@ proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse.serializeBinaryToWriter
       2,
       f,
       cc_arduino_cli_commands_v1_common_pb.TaskProgress.serializeBinaryToWriter
+    );
+  }
+  f = message.getPlatform();
+  if (f != null) {
+    writer.writeMessage(
+      3,
+      f,
+      cc_arduino_cli_commands_v1_common_pb.Platform.serializeBinaryToWriter
     );
   }
 };
@@ -2230,6 +2244,43 @@ proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse.prototype.clearTaskProg
  */
 proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse.prototype.hasTaskProgress = function() {
   return jspb.Message.getField(this, 2) != null;
+};
+
+
+/**
+ * optional Platform platform = 3;
+ * @return {?proto.cc.arduino.cli.commands.v1.Platform}
+ */
+proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse.prototype.getPlatform = function() {
+  return /** @type{?proto.cc.arduino.cli.commands.v1.Platform} */ (
+    jspb.Message.getWrapperField(this, cc_arduino_cli_commands_v1_common_pb.Platform, 3));
+};
+
+
+/**
+ * @param {?proto.cc.arduino.cli.commands.v1.Platform|undefined} value
+ * @return {!proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse} returns this
+*/
+proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse.prototype.setPlatform = function(value) {
+  return jspb.Message.setWrapperField(this, 3, value);
+};
+
+
+/**
+ * Clears the message field making it undefined.
+ * @return {!proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse} returns this
+ */
+proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse.prototype.clearPlatform = function() {
+  return this.setPlatform(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {boolean}
+ */
+proto.cc.arduino.cli.commands.v1.PlatformUpgradeResponse.prototype.hasPlatform = function() {
+  return jspb.Message.getField(this, 3) != null;
 };
 
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Get the latest CLI release into IDE2 nightly.

### Change description
<!-- What does your code do? -->

 - Reverts https://github.com/arduino/arduino-ide/commit/d0bce15f8baaa17b0272a5b8c0ba45e5577ed3a9, and
 - Set the CLI dependency to `0.33.1`.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

Related: https://github.com/arduino/arduino-ide/pull/2119

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)