### PR TITLE
Clean localization data files before pulling from Transifex

### DIFF
--- a/scripts/i18n/transifex-pull.js
+++ b/scripts/i18n/transifex-pull.js
@@ -1,6 +1,8 @@
 // @ts-check
 
 const transifex = require('./transifex');
+const path = require('path');
+const fs = require('node:fs/promises');
 const util = require('util');
 const shell = require('shelljs');
 const fetch = require('node-fetch');
@@ -105,6 +107,15 @@ const getTranslationDownloadStatus = async (language, downloadRequestId) => {
 
     const languages = await getLanguages(organization, project);
     shell.echo('translations found:', languages.join(', '));
+
+    // Remove data managed on Transifex to avoid accumulation of vestigial files
+    const translationFilenames = await fs.readdir(translationsDirectory);
+    for (const filename of translationFilenames) {
+        if (filename === 'en.json' || !filename.endsWith('.json')) {
+            continue;
+        }
+        await fs.unlink(path.join(translationsDirectory, filename));
+    }
 
     let downloadIds = [];
     for (const language of languages) {


### PR DESCRIPTION
### Motivation

The localization of the UI strings specific to the Arduino IDE application is done via the Transifex localization platform. A scheduled workflow pulls the data from Transifex weekly and submits a pull request for the updates.

Previously, the script used to pull the data did not clean the data files before pulling. This meant that a vestigial file would accumulate in the repository whenever a language was removed from the Transifex project.

### Change description

The accumulation is avoided by deleting the data files for the locales managed on Transifex (all locales other than the source English locale) before downloading the data from Transifex.

### Other information

Fixes https://github.com/arduino/arduino-ide/issues/2152

---

The workflow is configured to only trigger on a schedule and the requirement of the Transifex credentials makes it inconvenient to run the script locally. So I did a demonstration run of the workflow. I changed the workflow to print a diff in the logs of the effect of running the script instead of submitting a PR as it usually does:

https://github.com/arduino/arduino-ide/actions/runs/5664882697/job/15348851968#step:8:1

Note that 14 files are deleted, all of which are for languages no longer in the Transifex project (likely removed due to https://github.com/arduino/arduino-ide/issues/1447):

https://explore.transifex.com/arduino-1/ide2/

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)