### PR TITLE
fix: handle `UNKNOWN` code on `syscall: 'stat'`

### DIFF
--- a/arduino-ide-extension/src/node/sketches-service-impl.ts
+++ b/arduino-ide-extension/src/node/sketches-service-impl.ts
@@ -677,6 +677,7 @@ async function isInvalidSketchNameError(
  *
  * The sketch folder name and sketch file name can be different. This method is not sketch folder name compliant.
  * The `path` must be an absolute, resolved path. This method does not handle EACCES (Permission denied) errors.
+ * This method handles `UNKNOWN` errors ([nodejs/node#19965](https://github.com/nodejs/node/issues/19965#issuecomment-380750573)).
  *
  * When `fallbackToInvalidFolderPath` is `true`, and the `path` is an accessible folder without any sketch files,
  * this method returns with the `path` argument instead of `undefined`.
@@ -689,7 +690,7 @@ export async function isAccessibleSketchPath(
   try {
     stats = await fs.stat(path);
   } catch (err) {
-    if (ErrnoException.isENOENT(err)) {
+    if (ErrnoException.isENOENT(err) || ErrnoException.isUNKNOWN(err)) {
       return undefined;
     }
     throw err;

--- a/arduino-ide-extension/src/node/utils/errors.ts
+++ b/arduino-ide-extension/src/node/utils/errors.ts
@@ -15,7 +15,16 @@ export namespace ErrnoException {
   }
 
   /**
-   *  (No such file or directory): Commonly raised by `fs` operations to indicate that a component of the specified pathname does not exist — no entity (file or directory) could be found by the given path.
+   * _(Permission denied):_ An attempt was made to access a file in a way forbidden by its file access permissions.
+   */
+  export function isEACCES(
+    arg: unknown
+  ): arg is ErrnoException & { code: 'EACCES' } {
+    return is(arg) && arg.code === 'EACCES';
+  }
+
+  /**
+   * _(No such file or directory):_ Commonly raised by `fs` operations to indicate that a component of the specified pathname does not exist — no entity (file or directory) could be found by the given path.
    */
   export function isENOENT(
     arg: unknown
@@ -24,11 +33,22 @@ export namespace ErrnoException {
   }
 
   /**
-   * (Not a directory): A component of the given pathname existed, but was not a directory as expected. Commonly raised by `fs.readdir`.
+   * _(Not a directory):_ A component of the given pathname existed, but was not a directory as expected. Commonly raised by `fs.readdir`.
    */
   export function isENOTDIR(
     arg: unknown
   ): arg is ErrnoException & { code: 'ENOTDIR' } {
     return is(arg) && arg.code === 'ENOTDIR';
+  }
+
+  /**
+   * _"That 4094 error code is a generic network-or-configuration error, Node.js just passes it on from the operating system."_
+   *
+   * See [nodejs/node#19965](https://github.com/nodejs/node/issues/19965#issuecomment-380750573) for more details.
+   */
+  export function isUNKNOWN(
+    arg: unknown
+  ): arg is ErrnoException & { code: 'UNKNOWN' } {
+    return is(arg) && arg.code === 'UNKNOWN';
   }
 }


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

IDE2 must gracefully handle when it cannot restore a sketch from a network drive at startup.

### Change description
<!-- What does your code do? -->

This PR relaxes the logic of how IDE2 checks whether a sketch is accessible. From now on, `UNKNOWN` errors are caught, and the missing sketch is not restored.

### Other information
<!-- Any additional information that could help the review process -->

Closes #2166

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)