### PR TITLE
Do full run of "Arduino IDE" workflow on tag push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,12 +46,10 @@ jobs:
         id: determination
         run: |
           RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
-          TAG_REGEX="refs/tags/.*"
           # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
           if [[
-            ("${{ github.event_name }}" != "create" ||
-            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX) &&
-            ! "${{ github.ref }}" =~ $TAG_REGEX
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
           ]]; then
             # Run the other jobs.
             RESULT="true"


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

The project was recently switched to using a "trunk-based" development strategy (https://github.com/arduino/arduino-ide/pull/2120). This necessitated some adjustments to the [configuration](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions) of the GitHub Actions workflows in order to ensure the CI system could be used to effectively validate the project at the state staged for release in the release branch.

A `run-determination` job was added to the workflow. This job determines whether the conditions under which the workflow was triggered indicate that the rest of the jobs in the workflow should be run.

A validation workflow should run fully under any of the following conditions:

- The [trigger event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows) was something other than a branch creation
- The trigger event was a release [branch creation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#create)

Since the project is fully validated prior to a release, running the workflow when triggered by a [release tag](https://github.com/arduino/arduino-ide/blob/main/docs/internal/release-procedure.md#6--create-the-release-on-github) is pointless (and even [harmful](https://github.com/arduino/tooling-project-assets/pull/295) in some specific standardized workflows not currently used in this repository), so (even if for no other reason than efficiency) verification workflows are configured to not run under these conditions.

The [standardized Arduino tooling project workflows](https://github.com/arduino/tooling-project-assets/tree/main/workflow-templates#github-actions-workflow-templates) follow a modular design where each workflow has a narrow scope of purpose. That path was not taken by those who set up the infrastructure for this repository. They instead created a single massive monolithic "Arduino IDE" workflow that performs many unrelated operations under various conditions. This workflow generates releases in addition to doing validation. Even though it is pointless to run the workflow's validation operations when the workflow is triggered by a release tag, it is essential to run it for the release generation.

Previously, the code used in the "Arduino IDE" workflow's `run-determination` job was configured as appropriate for a verification workflow. This meant that a release would not be generated on push of a release tag as intended. 


### Change description

The bug is fixed by adjusting the code to do a full run of the workflow when triggered by a release tag.

### Other information

Release made in my fork to demonstrate the functionality of the workflow with the proposed changes:

- https://github.com/per1234/arduino-ide/actions/runs/5910547217
- https://github.com/per1234/arduino-ide/releases/tag/0.0.0-rc.18

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)