### PR TITLE
fix: expand boards if available on detected port 

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -172,11 +172,7 @@
   ],
   "arduino": {
     "arduino-cli": {
-      "version": {
-        "owner": "arduino",
-        "repo": "arduino-cli",
-        "commitish": "38479dc"
-      }
+      "version": "0.34.0-rc.1"
     },
     "arduino-fwuploader": {
       "version": "2.3.0"

--- a/arduino-ide-extension/src/browser/dialogs/certificate-uploader/certificate-uploader-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/certificate-uploader/certificate-uploader-component.tsx
@@ -1,10 +1,7 @@
 import { nls } from '@theia/core/lib/common/nls';
 import React from '@theia/core/shared/react';
 import Tippy from '@tippyjs/react';
-import {
-  BoardList,
-  isInferredBoardListItem,
-} from '../../../common/protocol/board-list';
+import type { BoardList } from '../../../common/protocol/board-list';
 import {
   boardIdentifierEquals,
   portIdentifierEquals,
@@ -50,9 +47,7 @@ export const CertificateUploaderComponent = ({
     if (!selectedItem) {
       return;
     }
-    const board = isInferredBoardListItem(selectedItem)
-      ? selectedItem.inferredBoard
-      : selectedItem.board;
+    const board = selectedItem.board;
     if (!board.fqbn) {
       return;
     }
@@ -76,13 +71,9 @@ export const CertificateUploaderComponent = ({
       if (!item) {
         return;
       }
-      const board = isInferredBoardListItem(item)
-        ? item.inferredBoard
-        : item.board;
-      const selectedBoard = isInferredBoardListItem(selectedItem)
-        ? selectedItem.inferredBoard
-        : selectedItem?.board;
+      const board = item.board;
       const port = item.port;
+      const selectedBoard = selectedItem?.board;
       const selectedPort = selectedItem?.port;
 
       if (

--- a/arduino-ide-extension/src/browser/dialogs/certificate-uploader/select-board-components.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/certificate-uploader/select-board-components.tsx
@@ -1,14 +1,12 @@
 import { nls } from '@theia/core/lib/common';
 import React from '@theia/core/shared/react';
-import {
+import type {
   BoardList,
   BoardListItemWithBoard,
-  InferredBoardListItem,
-  isInferredBoardListItem,
 } from '../../../common/protocol/board-list';
 import { ArduinoSelect } from '../../widgets/arduino-select';
 
-export type BoardOptionValue = BoardListItemWithBoard | InferredBoardListItem;
+export type BoardOptionValue = BoardListItemWithBoard;
 type BoardOption = { value: BoardOptionValue | undefined; label: string };
 
 export const SelectBoardComponent = ({
@@ -46,9 +44,7 @@ export const SelectBoardComponent = ({
       'Select a board...'
     );
     const updatableBoards = boardList.boards.filter((item) => {
-      const fqbn = (
-        isInferredBoardListItem(item) ? item.inferredBoard : item.board
-      ).fqbn;
+      const fqbn = item.board.fqbn;
       return fqbn && updatableFqbns.includes(fqbn);
     });
     let selBoard = -1;
@@ -57,15 +53,12 @@ export const SelectBoardComponent = ({
       if (selectedItem === item) {
         selBoard = i;
       }
-      const board = isInferredBoardListItem(item)
-        ? item.inferredBoard
-        : item.board;
       return {
         label: nls.localize(
           'arduino/certificate/boardAtPort',
           '{0} at {1}',
-          board.name,
-          item.port?.address ?? ''
+          item.board.name,
+          item.port.address ?? ''
         ),
         value: item,
       };
@@ -100,10 +93,7 @@ export const SelectBoardComponent = ({
           label: nls.localize(
             'arduino/certificate/boardAtPort',
             '{0} at {1}',
-            (isInferredBoardListItem(selectedItem)
-              ? selectedItem.inferredBoard
-              : selectedItem.board
-            ).name,
+            selectedItem.board.name,
             selectedItem.port.address ?? ''
           ),
         }) ||

--- a/arduino-ide-extension/src/browser/dialogs/firmware-uploader/firmware-uploader-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/firmware-uploader/firmware-uploader-component.tsx
@@ -9,10 +9,9 @@ import {
   ArduinoFirmwareUploader,
   FirmwareInfo,
 } from '../../../common/protocol/arduino-firmware-uploader';
-import {
+import type {
   BoardList,
   BoardListItemWithBoard,
-  isInferredBoardListItem,
 } from '../../../common/protocol/board-list';
 import { ArduinoSelect } from '../../widgets/arduino-select';
 import { SelectBoardComponent } from '../certificate-uploader/select-board-components';
@@ -63,9 +62,7 @@ export const FirmwareUploaderComponent = ({
     }
 
     // fetch the firmwares for the selected board
-    const board = isInferredBoardListItem(selectedItem)
-      ? selectedItem.inferredBoard
-      : selectedItem.board;
+    const board = selectedItem.board;
     const firmwaresForFqbn = await firmwareUploader.availableFirmwares(
       board.fqbn || ''
     );
@@ -89,11 +86,14 @@ export const FirmwareUploaderComponent = ({
       (firmware) => firmware.firmware_version === selectedFirmware?.value
     );
 
+    const selectedBoard = selectedItem?.board;
+    const selectedPort = selectedItem?.port;
     try {
       const installStatus =
-        !!firmwareToFlash &&
-        !!selectedItem?.board &&
-        (await flashFirmware(firmwareToFlash, selectedItem?.port));
+        firmwareToFlash &&
+        selectedBoard &&
+        selectedPort &&
+        (await flashFirmware(firmwareToFlash, selectedPort));
 
       setInstallFeedback((installStatus && 'ok') || 'fail');
     } catch {
@@ -106,13 +106,9 @@ export const FirmwareUploaderComponent = ({
       if (!item) {
         return;
       }
-      const board = isInferredBoardListItem(item)
-        ? item.inferredBoard
-        : item.board;
-      const selectedBoard = isInferredBoardListItem(selectedItem)
-        ? selectedItem.inferredBoard
-        : selectedItem?.board;
+      const board = item.board;
       const port = item.port;
+      const selectedBoard = selectedItem?.board;
       const selectedPort = selectedItem?.port;
 
       if (

--- a/arduino-ide-extension/src/test/common/board-list.test.ts
+++ b/arduino-ide-extension/src/test/common/board-list.test.ts
@@ -328,6 +328,130 @@ describe('board-list', () => {
       expect(items[0].labels.boardLabel).to.be.equal(Unknown);
     });
 
+    describe('boards', () => {
+      it('should include discovered boards on detected ports', () => {
+        const { boards } = createBoardList({
+          ...detectedPort(unoSerialPort, uno),
+          ...detectedPort(mkr1000SerialPort, mkr1000),
+          ...detectedPort(undiscoveredSerialPort),
+        });
+        expect(boards).to.deep.equal([
+          {
+            port: mkr1000SerialPort,
+            board: mkr1000,
+          },
+          {
+            port: unoSerialPort,
+            board: uno,
+          },
+        ]);
+      });
+
+      it('should include manually selected boards on detected ports', () => {
+        const { boards } = createBoardList({
+          ...detectedPort(unoSerialPort, uno),
+          ...detectedPort(undiscoveredSerialPort, uno),
+          ...detectedPort(undiscoveredUsbToUARTSerialPort),
+        });
+        expect(boards).to.deep.equal([
+          {
+            port: unoSerialPort,
+            board: uno,
+          },
+          {
+            port: undiscoveredSerialPort,
+            board: uno,
+          },
+        ]);
+      });
+
+      it('should include manually overridden boards on detected ports', () => {
+        const { boards } = createBoardList(
+          {
+            ...detectedPort(unoSerialPort, uno),
+            ...detectedPort(mkr1000SerialPort, mkr1000),
+          },
+          emptyBoardsConfig(),
+          {
+            ...history(unoSerialPort, mkr1000),
+          }
+        );
+        expect(boards).to.deep.equal([
+          {
+            port: mkr1000SerialPort,
+            board: mkr1000,
+          },
+          {
+            port: unoSerialPort,
+            board: mkr1000,
+          },
+        ]);
+      });
+
+      it('should include all boards discovered on a port', () => {
+        const { boards } = createBoardList({
+          ...detectedPort(
+            nanoEsp32SerialPort,
+            arduinoNanoEsp32,
+            esp32NanoEsp32
+          ),
+          ...detectedPort(
+            nanoEsp32DetectsMultipleEsp32BoardsSerialPort,
+            esp32S3DevModule,
+            esp32S3Box
+          ),
+        });
+        expect(boards).to.deep.equal([
+          {
+            port: nanoEsp32SerialPort,
+            board: arduinoNanoEsp32,
+          },
+          {
+            port: nanoEsp32SerialPort,
+            board: esp32NanoEsp32,
+          },
+          {
+            port: nanoEsp32DetectsMultipleEsp32BoardsSerialPort,
+            board: esp32S3Box,
+          },
+          {
+            port: nanoEsp32DetectsMultipleEsp32BoardsSerialPort,
+            board: esp32S3DevModule,
+          },
+        ]);
+      });
+
+      it('should include all boards discovered on a port (handle manual select)', () => {
+        const { boards } = createBoardList(
+          {
+            ...detectedPort(
+              nanoEsp32SerialPort,
+              arduinoNanoEsp32,
+              esp32NanoEsp32
+            ),
+          },
+          emptyBoardsConfig(),
+          {
+            ...history(nanoEsp32SerialPort, esp32S3DevModule),
+          }
+        );
+        expect(boards).to.deep.equal([
+          {
+            port: nanoEsp32SerialPort,
+            board: arduinoNanoEsp32,
+          },
+          {
+            port: nanoEsp32SerialPort,
+            board: esp32NanoEsp32,
+          },
+          {
+            port: nanoEsp32SerialPort,
+            board: esp32S3DevModule,
+          },
+        ]);
+      });
+    });
+
     describe('defaultAction', () => {
       it("'select' should be the default action for identifier boards", () => {
         const { items } = createBoardList({


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

When multiple boards are discovered on a detected port, the board selector component is broken in the firmware uploader dialog. This PR moves the board inference logic from the UI to the model and allows selecting a board+port pair even before confirming the board in the board list.

This PR pins the CLI version to `0.34.0-rc.1` to overcome the flaky tests mentioned at https://github.com/arduino/arduino-ide/pull/2176#issuecomment-1684790036.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

I could reproduce the bug following the steps in #2175. I could fix the bug, but the firmware update fails at the CLI.

I connect my Arduino Nano RP2040 board and start the firmware update, and get all these board list watch logs and the stderr of the executable:

<details><summary>click to see the `board list watch` events and the error log from the firmware uploader CLI</summary>
<p>

```
2023-08-19T11:00:06.494Z daemon INFO time="2023-08-19T13:00:06+02:00" level=info msg="from discovery builtin:serial-discovery received message type: remove, port: /dev/cu.usbmodem14301"
2023-08-19T11:00:06.495Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"/dev/cu.usbmodem14301","label":"","protocol":"serial","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:00:09.447Z daemon INFO time="2023-08-19T13:00:09+02:00" level=info msg="from discovery rp2040 received message type: add, port: UF2_Board"
2023-08-19T11:00:09.448Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"UF2 Board","protocol":"uf2conv","protocolLabel":"UF2 Devices","propertiesMap":[["mac","ffffffffffff"],["pid","0x2e8a"],["vid","0x000a"]],"hardwareId":""}},"error":""}
2023-08-19T11:00:19.617Z daemon INFO time="2023-08-19T13:00:19+02:00" level=info msg="from discovery builtin:serial-discovery received message type: add, port: /dev/cu.usbmodem14301"
2023-08-19T11:00:19.620Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[{"name":"Arduino Nano RP2040 Connect","fqbn":"arduino:mbed_nano:nanorp2040connect","isHidden":false},{"name":"Arduino Nano RP2040 Connect (dummy)","fqbn":"fwuploader-board-dummies:foo:nanorp2040connect","isHidden":false}],"port":{"address":"/dev/cu.usbmodem14301","label":"/dev/cu.usbmodem14301","protocol":"serial","protocolLabel":"Serial Port (USB)","propertiesMap":[["pid","0x005E"],["serialNumber","FFFFFFFFFFFFFFFF"],["vid","0x2341"]],"hardwareId":"FFFFFFFFFFFFFFFF"}},"error":""}
2023-08-19T11:00:19.780Z daemon INFO time="2023-08-19T13:00:19+02:00" level=info msg="from discovery rp2040 received message type: remove, port: UF2_Board"
2023-08-19T11:00:19.780Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"","protocol":"uf2conv","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:00:27.686Z daemon INFO time="2023-08-19T13:00:27+02:00" level=info msg="from discovery builtin:serial-discovery received message type: remove, port: /dev/cu.usbmodem14301"
2023-08-19T11:00:27.687Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"/dev/cu.usbmodem14301","label":"","protocol":"serial","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:00:30.072Z daemon INFO time="2023-08-19T13:00:30+02:00" level=info msg="from discovery rp2040 received message type: add, port: UF2_Board"
2023-08-19T11:00:30.074Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"UF2 Board","protocol":"uf2conv","protocolLabel":"UF2 Devices","propertiesMap":[["mac","ffffffffffff"],["pid","0x2e8a"],["vid","0x000a"]],"hardwareId":""}},"error":""}
2023-08-19T11:00:40.351Z daemon INFO time="2023-08-19T13:00:40+02:00" level=info msg="from discovery rp2040 received message type: remove, port: UF2_Board"
2023-08-19T11:00:40.352Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"","protocol":"uf2conv","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:00:40.527Z daemon INFO time="2023-08-19T13:00:40+02:00" level=info msg="from discovery builtin:serial-discovery received message type: add, port: /dev/cu.usbmodem14301"
2023-08-19T11:00:40.528Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[{"name":"Arduino Nano RP2040 Connect","fqbn":"arduino:mbed_nano:nanorp2040connect","isHidden":false},{"name":"Arduino Nano RP2040 Connect (dummy)","fqbn":"fwuploader-board-dummies:foo:nanorp2040connect","isHidden":false}],"port":{"address":"/dev/cu.usbmodem14301","label":"/dev/cu.usbmodem14301","protocol":"serial","protocolLabel":"Serial Port (USB)","propertiesMap":[["pid","0x005E"],["serialNumber","FFFFFFFFFFFFFFFF"],["vid","0x2341"]],"hardwareId":"FFFFFFFFFFFFFFFF"}},"error":""}
2023-08-19T11:00:48.596Z daemon INFO time="2023-08-19T13:00:48+02:00" level=info msg="from discovery builtin:serial-discovery received message type: remove, port: /dev/cu.usbmodem14301"
2023-08-19T11:00:48.597Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"/dev/cu.usbmodem14301","label":"","protocol":"serial","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:00:50.622Z daemon INFO time="2023-08-19T13:00:50+02:00" level=info msg="from discovery rp2040 received message type: add, port: UF2_Board"
2023-08-19T11:00:50.624Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"UF2 Board","protocol":"uf2conv","protocolLabel":"UF2 Devices","propertiesMap":[["mac","ffffffffffff"],["pid","0x2e8a"],["vid","0x000a"]],"hardwareId":""}},"error":""}
2023-08-19T11:01:00.878Z daemon INFO time="2023-08-19T13:01:00+02:00" level=info msg="from discovery rp2040 received message type: remove, port: UF2_Board"
2023-08-19T11:01:00.879Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"","protocol":"uf2conv","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:01:01.449Z daemon INFO time="2023-08-19T13:01:01+02:00" level=info msg="from discovery builtin:serial-discovery received message type: add, port: /dev/cu.usbmodem14301"
2023-08-19T11:01:01.450Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[{"name":"Arduino Nano RP2040 Connect","fqbn":"arduino:mbed_nano:nanorp2040connect","isHidden":false},{"name":"Arduino Nano RP2040 Connect (dummy)","fqbn":"fwuploader-board-dummies:foo:nanorp2040connect","isHidden":false}],"port":{"address":"/dev/cu.usbmodem14301","label":"/dev/cu.usbmodem14301","protocol":"serial","protocolLabel":"Serial Port (USB)","propertiesMap":[["pid","0x005E"],["serialNumber","FFFFFFFFFFFFFFFF"],["vid","0x2341"]],"hardwareId":"FFFFFFFFFFFFFFFF"}},"error":""}
2023-08-19T11:01:09.530Z daemon INFO time="2023-08-19T13:01:09+02:00" level=info msg="from discovery builtin:serial-discovery received message type: remove, port: /dev/cu.usbmodem14301"
2023-08-19T11:01:09.531Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"/dev/cu.usbmodem14301","label":"","protocol":"serial","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:01:11.134Z daemon INFO time="2023-08-19T13:01:11+02:00" level=info msg="from discovery rp2040 received message type: add, port: UF2_Board"
2023-08-19T11:01:11.135Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"UF2 Board","protocol":"uf2conv","protocolLabel":"UF2 Devices","propertiesMap":[["mac","ffffffffffff"],["pid","0x2e8a"],["vid","0x000a"]],"hardwareId":""}},"error":""}
2023-08-19T11:01:22.414Z daemon INFO time="2023-08-19T13:01:22+02:00" level=info msg="from discovery builtin:serial-discovery received message type: add, port: /dev/cu.usbmodem14301"
2023-08-19T11:01:22.415Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[{"name":"Arduino Nano RP2040 Connect","fqbn":"arduino:mbed_nano:nanorp2040connect","isHidden":false},{"name":"Arduino Nano RP2040 Connect (dummy)","fqbn":"fwuploader-board-dummies:foo:nanorp2040connect","isHidden":false}],"port":{"address":"/dev/cu.usbmodem14301","label":"/dev/cu.usbmodem14301","protocol":"serial","protocolLabel":"Serial Port (USB)","propertiesMap":[["pid","0x005E"],["serialNumber","FFFFFFFFFFFFFFFF"],["vid","0x2341"]],"hardwareId":"FFFFFFFFFFFFFFFF"}},"error":""}
2023-08-19T11:01:23.403Z daemon INFO time="2023-08-19T13:01:23+02:00" level=info msg="from discovery rp2040 received message type: remove, port: UF2_Board"
2023-08-19T11:01:23.403Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"","protocol":"uf2conv","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:01:30.490Z daemon INFO time="2023-08-19T13:01:30+02:00" level=info msg="from discovery builtin:serial-discovery received message type: remove, port: /dev/cu.usbmodem14301"
2023-08-19T11:01:30.491Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"/dev/cu.usbmodem14301","label":"","protocol":"serial","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:01:33.695Z daemon INFO time="2023-08-19T13:01:33+02:00" level=info msg="from discovery rp2040 received message type: add, port: UF2_Board"
2023-08-19T11:01:33.696Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"UF2 Board","protocol":"uf2conv","protocolLabel":"UF2 Devices","propertiesMap":[["mac","ffffffffffff"],["pid","0x2e8a"],["vid","0x000a"]],"hardwareId":""}},"error":""}
2023-08-19T11:01:43.307Z daemon INFO time="2023-08-19T13:01:43+02:00" level=info msg="from discovery builtin:serial-discovery received message type: add, port: /dev/cu.usbmodem14301"
2023-08-19T11:01:43.308Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[{"name":"Arduino Nano RP2040 Connect","fqbn":"arduino:mbed_nano:nanorp2040connect","isHidden":false},{"name":"Arduino Nano RP2040 Connect (dummy)","fqbn":"fwuploader-board-dummies:foo:nanorp2040connect","isHidden":false}],"port":{"address":"/dev/cu.usbmodem14301","label":"/dev/cu.usbmodem14301","protocol":"serial","protocolLabel":"Serial Port (USB)","propertiesMap":[["pid","0x005E"],["serialNumber","FFFFFFFFFFFFFFFF"],["vid","0x2341"]],"hardwareId":"FFFFFFFFFFFFFFFF"}},"error":""}
2023-08-19T11:01:43.991Z daemon INFO time="2023-08-19T13:01:43+02:00" level=info msg="from discovery rp2040 received message type: remove, port: UF2_Board"
2023-08-19T11:01:43.992Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"","protocol":"uf2conv","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:01:51.393Z daemon INFO time="2023-08-19T13:01:51+02:00" level=info msg="from discovery builtin:serial-discovery received message type: remove, port: /dev/cu.usbmodem14301"
2023-08-19T11:01:51.394Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"/dev/cu.usbmodem14301","label":"","protocol":"serial","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:01:54.256Z daemon INFO time="2023-08-19T13:01:54+02:00" level=info msg="from discovery rp2040 received message type: add, port: UF2_Board"
2023-08-19T11:01:54.257Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"UF2 Board","protocol":"uf2conv","protocolLabel":"UF2 Devices","propertiesMap":[["mac","ffffffffffff"],["pid","0x2e8a"],["vid","0x000a"]],"hardwareId":""}},"error":""}
2023-08-19T11:02:04.251Z daemon INFO time="2023-08-19T13:02:04+02:00" level=info msg="from discovery builtin:serial-discovery received message type: add, port: /dev/cu.usbmodem14301"
2023-08-19T11:02:04.252Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[{"name":"Arduino Nano RP2040 Connect","fqbn":"arduino:mbed_nano:nanorp2040connect","isHidden":false},{"name":"Arduino Nano RP2040 Connect (dummy)","fqbn":"fwuploader-board-dummies:foo:nanorp2040connect","isHidden":false}],"port":{"address":"/dev/cu.usbmodem14301","label":"/dev/cu.usbmodem14301","protocol":"serial","protocolLabel":"Serial Port (USB)","propertiesMap":[["pid","0x005E"],["serialNumber","FFFFFFFFFFFFFFFF"],["vid","0x2341"]],"hardwareId":"FFFFFFFFFFFFFFFF"}},"error":""}
2023-08-19T11:02:04.545Z daemon INFO time="2023-08-19T13:02:04+02:00" level=info msg="from discovery rp2040 received message type: remove, port: UF2_Board"
2023-08-19T11:02:04.546Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"","protocol":"uf2conv","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:02:12.344Z daemon INFO time="2023-08-19T13:02:12+02:00" level=info msg="from discovery builtin:serial-discovery received message type: remove, port: /dev/cu.usbmodem14301"
2023-08-19T11:02:12.345Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"/dev/cu.usbmodem14301","label":"","protocol":"serial","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:02:14.816Z daemon INFO time="2023-08-19T13:02:14+02:00" level=info msg="from discovery rp2040 received message type: add, port: UF2_Board"
2023-08-19T11:02:14.817Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"UF2 Board","protocol":"uf2conv","protocolLabel":"UF2 Devices","propertiesMap":[["mac","ffffffffffff"],["pid","0x2e8a"],["vid","0x000a"]],"hardwareId":""}},"error":""}
2023-08-19T11:02:25.122Z daemon INFO time="2023-08-19T13:02:25+02:00" level=info msg="from discovery rp2040 received message type: remove, port: UF2_Board"
2023-08-19T11:02:25.123Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"","protocol":"uf2conv","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:02:25.214Z daemon INFO time="2023-08-19T13:02:25+02:00" level=info msg="from discovery builtin:serial-discovery received message type: add, port: /dev/cu.usbmodem14301"
2023-08-19T11:02:25.217Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[{"name":"Arduino Nano RP2040 Connect","fqbn":"arduino:mbed_nano:nanorp2040connect","isHidden":false},{"name":"Arduino Nano RP2040 Connect (dummy)","fqbn":"fwuploader-board-dummies:foo:nanorp2040connect","isHidden":false}],"port":{"address":"/dev/cu.usbmodem14301","label":"/dev/cu.usbmodem14301","protocol":"serial","protocolLabel":"Serial Port (USB)","propertiesMap":[["pid","0x005E"],["serialNumber","FFFFFFFFFFFFFFFF"],["vid","0x2341"]],"hardwareId":"FFFFFFFFFFFFFFFF"}},"error":""}
2023-08-19T11:02:33.339Z daemon INFO time="2023-08-19T13:02:33+02:00" level=info msg="from discovery builtin:serial-discovery received message type: remove, port: /dev/cu.usbmodem14301"
2023-08-19T11:02:33.340Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"/dev/cu.usbmodem14301","label":"","protocol":"serial","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:02:35.398Z daemon INFO time="2023-08-19T13:02:35+02:00" level=info msg="from discovery rp2040 received message type: add, port: UF2_Board"
2023-08-19T11:02:35.399Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"UF2 Board","protocol":"uf2conv","protocolLabel":"UF2 Devices","propertiesMap":[["mac","ffffffffffff"],["pid","0x2e8a"],["vid","0x000a"]],"hardwareId":""}},"error":""}
2023-08-19T11:02:45.713Z daemon INFO time="2023-08-19T13:02:45+02:00" level=info msg="from discovery rp2040 received message type: remove, port: UF2_Board"
2023-08-19T11:02:45.714Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"","protocol":"uf2conv","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:02:46.175Z daemon INFO time="2023-08-19T13:02:46+02:00" level=info msg="from discovery builtin:serial-discovery received message type: add, port: /dev/cu.usbmodem14301"
2023-08-19T11:02:46.176Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[{"name":"Arduino Nano RP2040 Connect","fqbn":"arduino:mbed_nano:nanorp2040connect","isHidden":false},{"name":"Arduino Nano RP2040 Connect (dummy)","fqbn":"fwuploader-board-dummies:foo:nanorp2040connect","isHidden":false}],"port":{"address":"/dev/cu.usbmodem14301","label":"/dev/cu.usbmodem14301","protocol":"serial","protocolLabel":"Serial Port (USB)","propertiesMap":[["pid","0x005E"],["serialNumber","FFFFFFFFFFFFFFFF"],["vid","0x2341"]],"hardwareId":"FFFFFFFFFFFFFFFF"}},"error":""}
2023-08-19T11:02:54.264Z daemon INFO time="2023-08-19T13:02:54+02:00" level=info msg="from discovery builtin:serial-discovery received message type: remove, port: /dev/cu.usbmodem14301"
2023-08-19T11:02:54.265Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"/dev/cu.usbmodem14301","label":"","protocol":"serial","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:02:56.201Z daemon INFO time="2023-08-19T13:02:56+02:00" level=info msg="from discovery rp2040 received message type: add, port: UF2_Board"
2023-08-19T11:02:56.202Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"UF2 Board","protocol":"uf2conv","protocolLabel":"UF2 Devices","propertiesMap":[["mac","ffffffffffff"],["pid","0x2e8a"],["vid","0x000a"]],"hardwareId":""}},"error":""}
2023-08-19T11:03:06.535Z daemon INFO time="2023-08-19T13:03:06+02:00" level=info msg="from discovery rp2040 received message type: remove, port: UF2_Board"
2023-08-19T11:03:06.536Z discovery-log INFO {"eventType":"remove","port":{"matchingBoardsList":[],"port":{"address":"UF2_Board","label":"","protocol":"uf2conv","protocolLabel":"","propertiesMap":[],"hardwareId":""}},"error":""}
2023-08-19T11:03:07.117Z daemon INFO time="2023-08-19T13:03:07+02:00" level=info msg="from discovery builtin:serial-discovery received message type: add, port: /dev/cu.usbmodem14301"
2023-08-19T11:03:07.118Z discovery-log INFO {"eventType":"add","port":{"matchingBoardsList":[{"name":"Arduino Nano RP2040 Connect","fqbn":"arduino:mbed_nano:nanorp2040connect","isHidden":false},{"name":"Arduino Nano RP2040 Connect (dummy)","fqbn":"fwuploader-board-dummies:foo:nanorp2040connect","isHidden":false}],"port":{"address":"/dev/cu.usbmodem14301","label":"/dev/cu.usbmodem14301","protocol":"serial","protocolLabel":"Serial Port (USB)","propertiesMap":[["pid","0x005E"],["serialNumber","FFFFFFFFFFFFFFFF"],["vid","0x2341"]],"hardwareId":"FFFFFFFFFFFFFFFF"}},"error":""}
2023-08-19T11:03:13.705Z fwuploader ERROR Error: Error executing /Users/a.kitta/dev/git/arduino-ide/arduino-ide-extension/lib/node/resources/arduino-fwuploader firmware flash --fqbn arduino:mbed_nano:nanorp2040connect --address /dev/cu.usbmodem14301 --module NINA@1.5.0: Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
    at ChildProcess.<anonymous> (/Users/a.kitta/dev/git/arduino-ide/arduino-ide-extension/lib/node/exec-util.js:24:31)
    at ChildProcess.emit (node:events:513:28)
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
    at Process.callbackTrampoline (node:internal/async_hooks:130:17)
2023-08-19T11:03:13.706Z root ERROR Request flash failed with error: Error executing /Users/a.kitta/dev/git/arduino-ide/arduino-ide-extension/lib/node/resources/arduino-fwuploader firmware flash --fqbn arduino:mbed_nano:nanorp2040connect --address /dev/cu.usbmodem14301 --module NINA@1.5.0: Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab Error: Error executing /Users/a.kitta/dev/git/arduino-ide/arduino-ide-extension/lib/node/resources/arduino-fwuploader firmware flash --fqbn arduino:mbed_nano:nanorp2040connect --address /dev/cu.usbmodem14301 --module NINA@1.5.0: Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
Error: missing ack on erase: ab
    at ChildProcess.<anonymous> (/Users/a.kitta/dev/git/arduino-ide/arduino-ide-extension/lib/node/exec-util.js:24:31)
    at ChildProcess.emit (node:events:513:28)
    at ChildProcess._handle.onexit (node:internal/child_process:291:12)
    at Process.callbackTrampoline (node:internal/async_hooks:130:17)

```

</p>
</details>

Closes arduino/arduino-ide#2175

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)