### PR TITLE
fix: incorrect certificate flashing command string

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/upload-certificate.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-certificate.ts
@@ -16,14 +16,11 @@ import {
   arduinoCert,
   certificateList,
 } from '../dialogs/certificate-uploader/utils';
-import { ArduinoFirmwareUploader } from '../../common/protocol/arduino-firmware-uploader';
+import {
+  ArduinoFirmwareUploader,
+  UploadCertificateParams,
+} from '../../common/protocol/arduino-firmware-uploader';
 import { nls } from '@theia/core/lib/common';
-
-interface UploadCertificateParams {
-  readonly fqbn: string;
-  readonly address: string;
-  readonly urls: readonly string[];
-}
 
 @injectable()
 export class UploadCertificate extends Contribution {
@@ -81,16 +78,7 @@ export class UploadCertificate extends Contribution {
 
     registry.registerCommand(UploadCertificate.Commands.UPLOAD_CERT, {
       execute: async (params: UploadCertificateParams) => {
-        const { fqbn, address, urls } = params;
-        return this.arduinoFirmwareUploader.uploadCertificates({
-          flags: [
-            '-b',
-            fqbn,
-            '-a',
-            address,
-            ...urls.flatMap((url) => ['-u', url]),
-          ],
-        });
+        return this.arduinoFirmwareUploader.uploadCertificates(params);
       },
     });
 

--- a/arduino-ide-extension/src/browser/contributions/upload-certificate.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-certificate.ts
@@ -19,6 +19,12 @@ import {
 import { ArduinoFirmwareUploader } from '../../common/protocol/arduino-firmware-uploader';
 import { nls } from '@theia/core/lib/common';
 
+interface UploadCertificateParams {
+  readonly fqbn: string;
+  readonly address: string;
+  readonly urls: readonly string[];
+}
+
 @injectable()
 export class UploadCertificate extends Contribution {
   @inject(UploadCertificateDialog)
@@ -74,12 +80,17 @@ export class UploadCertificate extends Contribution {
     });
 
     registry.registerCommand(UploadCertificate.Commands.UPLOAD_CERT, {
-      execute: async ({ fqbn, address, urls }) => {
-        return this.arduinoFirmwareUploader.uploadCertificates(
-          `-b ${fqbn} -a ${address} ${urls
-            .map((url: string) => `-u ${url}`)
-            .join(' ')}`
-        );
+      execute: async (params: UploadCertificateParams) => {
+        const { fqbn, address, urls } = params;
+        return this.arduinoFirmwareUploader.uploadCertificates({
+          flags: [
+            '-b',
+            fqbn,
+            '-a',
+            address,
+            ...urls.flatMap((url) => ['-u', url]),
+          ],
+        });
       },
     });
 

--- a/arduino-ide-extension/src/common/protocol/arduino-firmware-uploader.ts
+++ b/arduino-ide-extension/src/common/protocol/arduino-firmware-uploader.ts
@@ -1,4 +1,4 @@
-import { Port } from "./boards-service";
+import type { Port } from './boards-service';
 
 export const ArduinoFirmwareUploaderPath =
   '/services/arduino-firmware-uploader';
@@ -13,7 +13,7 @@ export type FirmwareInfo = {
 export interface ArduinoFirmwareUploader {
   list(fqbn?: string): Promise<FirmwareInfo[]>;
   flash(firmware: FirmwareInfo, port: Port): Promise<string>;
-  uploadCertificates(command: string): Promise<any>;
+  uploadCertificates(params: { flags: string[] }): Promise<any>;
   updatableBoards(): Promise<string[]>;
   availableFirmwares(fqbn: string): Promise<FirmwareInfo[]>;
 }

--- a/arduino-ide-extension/src/common/protocol/arduino-firmware-uploader.ts
+++ b/arduino-ide-extension/src/common/protocol/arduino-firmware-uploader.ts
@@ -3,17 +3,22 @@ import type { Port } from './boards-service';
 export const ArduinoFirmwareUploaderPath =
   '/services/arduino-firmware-uploader';
 export const ArduinoFirmwareUploader = Symbol('ArduinoFirmwareUploader');
-export type FirmwareInfo = {
+export interface FirmwareInfo {
   board_name: string;
   board_fqbn: string;
   module: string;
   firmware_version: string;
   Latest: boolean;
-};
+}
+export interface UploadCertificateParams {
+  readonly fqbn: string;
+  readonly address: string;
+  readonly urls: readonly string[];
+}
 export interface ArduinoFirmwareUploader {
   list(fqbn?: string): Promise<FirmwareInfo[]>;
   flash(firmware: FirmwareInfo, port: Port): Promise<string>;
-  uploadCertificates(params: { flags: string[] }): Promise<any>;
+  uploadCertificates(params: UploadCertificateParams): Promise<unknown>;
   updatableBoards(): Promise<string[]>;
   availableFirmwares(fqbn: string): Promise<FirmwareInfo[]>;
 }

--- a/arduino-ide-extension/src/node/arduino-firmware-uploader-impl.ts
+++ b/arduino-ide-extension/src/node/arduino-firmware-uploader-impl.ts
@@ -17,8 +17,8 @@ export class ArduinoFirmwareUploaderImpl implements ArduinoFirmwareUploader {
   @inject(MonitorManager)
   private readonly monitorManager: MonitorManager;
 
-  async uploadCertificates(command: string): Promise<string> {
-    return await this.runCommand(['certificates', 'flash', command]);
+  async uploadCertificates(params: { flags: string[] }): Promise<string> {
+    return await this.runCommand(['certificates', 'flash', ...params.flags]);
   }
 
   async list(fqbn?: string): Promise<FirmwareInfo[]> {

--- a/arduino-ide-extension/src/node/arduino-firmware-uploader-impl.ts
+++ b/arduino-ide-extension/src/node/arduino-firmware-uploader-impl.ts
@@ -4,6 +4,7 @@ import type { Port } from '../common/protocol';
 import {
   ArduinoFirmwareUploader,
   FirmwareInfo,
+  UploadCertificateParams,
 } from '../common/protocol/arduino-firmware-uploader';
 import { spawnCommand } from './exec-util';
 import { MonitorManager } from './monitor-manager';
@@ -17,8 +18,17 @@ export class ArduinoFirmwareUploaderImpl implements ArduinoFirmwareUploader {
   @inject(MonitorManager)
   private readonly monitorManager: MonitorManager;
 
-  async uploadCertificates(params: { flags: string[] }): Promise<string> {
-    return await this.runCommand(['certificates', 'flash', ...params.flags]);
+  async uploadCertificates(params: UploadCertificateParams): Promise<string> {
+    const { fqbn, address, urls } = params;
+    return await this.runCommand([
+      'certificates',
+      'flash',
+      '-b',
+      fqbn,
+      '-a',
+      address,
+      ...urls.flatMap((url) => ['-u', url]),
+    ]);
   }
 
   async list(fqbn?: string): Promise<FirmwareInfo[]> {


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Fix the certificate flashing.

### Change description
<!-- What does your code do? -->

Use a `string` array of command flags instead of the concatenated final `string` command.

### Other information
<!-- Any additional information that could help the review process -->

Ref: arduino/arduino-ide#2067

Closes #2179

I could reproduce and fix the defect, but the certificate flashing failed with the `Error: missing ack on erase: ab` [familiar error](https://github.com/arduino/arduino-ide/pull/2178#issue-1857676149):
```
Error executing /Users/a.kitta/dev/git/arduino-ide/arduino-ide-extension/lib/node/resources/arduino-fwuploader certificates flash -b arduino:mbed_nano:nanorp2040connect -a /dev/cu.usbmodem14301 -u arduino.cc:443: Error: missing ack on erase: ab Error: Error executing /Users/a.kitta/dev/git/arduino-ide/arduino-ide-extension/lib/node/resources/arduino-fwuploader certificates flash -b arduino:mbed_nano:nanorp2040connect -a /dev/cu.usbmodem14301 -u arduino.cc:443: Error: missing ack on erase: ab
``` 

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)