### PR TITLE
fix: falsy context menu `handlerId`

### DIFF
--- a/arduino-ide-extension/src/electron-main/arduino-electron-main-module.ts
+++ b/arduino-ide-extension/src/electron-main/arduino-electron-main-module.ts
@@ -1,6 +1,7 @@
 import { JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging/proxy-factory';
 import { ElectronMainWindowService } from '@theia/core/lib/electron-common/electron-main-window-service';
 import { ElectronConnectionHandler } from '@theia/core/lib/electron-common/messaging/electron-connection-handler';
+import { TheiaMainApi } from '@theia/core/lib/electron-main/electron-api-main';
 import {
   ElectronMainApplication as TheiaElectronMainApplication,
   ElectronMainApplicationContribution,
@@ -17,6 +18,7 @@ import { ElectronArduino } from './electron-arduino';
 import { IDEUpdaterImpl } from './ide-updater/ide-updater-impl';
 import { ElectronMainApplication } from './theia/electron-main-application';
 import { ElectronMainWindowServiceImpl } from './theia/electron-main-window-service';
+import { TheiaMainApiFixFalsyHandlerId } from './theia/theia-api-main';
 import { TheiaElectronWindow } from './theia/theia-electron-window';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
@@ -52,4 +54,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
   bind(ElectronArduino).toSelf().inSingletonScope();
   bind(ElectronMainApplicationContribution).toService(ElectronArduino);
+
+  // eclipse-theia/theia#12500
+  bind(TheiaMainApiFixFalsyHandlerId).toSelf().inSingletonScope();
+  rebind(TheiaMainApi).toService(TheiaMainApiFixFalsyHandlerId);
 });

--- a/arduino-ide-extension/src/electron-main/theia/theia-api-main.ts
+++ b/arduino-ide-extension/src/electron-main/theia/theia-api-main.ts
@@ -1,0 +1,40 @@
+import {
+  CHANNEL_INVOKE_MENU,
+  InternalMenuDto,
+} from '@theia/core/lib/electron-common/electron-api';
+import { TheiaMainApi } from '@theia/core/lib/electron-main/electron-api-main';
+import { injectable } from '@theia/core/shared/inversify';
+import { MenuItemConstructorOptions } from '@theia/electron/shared/electron';
+
+@injectable()
+export class TheiaMainApiFixFalsyHandlerId extends TheiaMainApi {
+  override fromMenuDto(
+    sender: Electron.WebContents,
+    menuId: number,
+    menuDto: InternalMenuDto[]
+  ): Electron.MenuItemConstructorOptions[] {
+    return menuDto.map((dto) => {
+      const result: MenuItemConstructorOptions = {
+        id: dto.id,
+        label: dto.label,
+        type: dto.type,
+        checked: dto.checked,
+        enabled: dto.enabled,
+        visible: dto.visible,
+        role: dto.role,
+        accelerator: dto.accelerator,
+      };
+      if (dto.submenu) {
+        result.submenu = this.fromMenuDto(sender, menuId, dto.submenu);
+      }
+      // Fix for handlerId === 0
+      // https://github.com/eclipse-theia/theia/pull/12500#issuecomment-1686074836
+      if (typeof dto.handlerId === 'number') {
+        result.click = () => {
+          sender.send(CHANNEL_INVOKE_MENU, menuId, dto.handlerId);
+        };
+      }
+      return result;
+    });
+  }
+}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To fix the non-functional `New Tab` content menu item from `•••`. The first context menu item with ID `0` has no click handler.

### Change description
<!-- What does your code do? -->

Customized the default Theia menu item building to attach the click handler to the menu node with ID `0`

Steps to reproduce:
 - Open IDE2,
 - Create a new sketch (`File` > `New Sketch`, or `Ctrl/Cmd+N`),
 - Open the context menu in the editor's toolbar by clicking on `•••`,
 - Click `New Tab` the new file dialog opens.

### Other information
<!-- Any additional information that could help the review process -->

Originally reported here: https://forum.arduino.cc/t/new-tab-command-first-invocation-does-nothing/1160085
Ref: https://github.com/eclipse-theia/theia/pull/12500#issuecomment-1686074836

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)