### PR TITLE
fix: missing app icon for AppImage on Linux

### DIFF
--- a/arduino-ide-extension/src/electron-main/arduino-electron-main-module.ts
+++ b/arduino-ide-extension/src/electron-main/arduino-electron-main-module.ts
@@ -15,6 +15,7 @@ import {
 } from '../common/protocol/ide-updater';
 import { IsTempSketch } from '../node/is-temp-sketch';
 import { ElectronArduino } from './electron-arduino';
+import { FixAppImageIcon } from './fix-app-image-icon';
 import { IDEUpdaterImpl } from './ide-updater/ide-updater-impl';
 import { ElectronMainApplication } from './theia/electron-main-application';
 import { ElectronMainWindowServiceImpl } from './theia/electron-main-window-service';
@@ -58,4 +59,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   // eclipse-theia/theia#12500
   bind(TheiaMainApiFixFalsyHandlerId).toSelf().inSingletonScope();
   rebind(TheiaMainApi).toService(TheiaMainApiFixFalsyHandlerId);
+
+  // https://github.com/arduino/arduino-ide/issues/131
+  bind(FixAppImageIcon).toSelf().inSingletonScope();
+  bind(ElectronMainApplicationContribution).toService(FixAppImageIcon);
 });

--- a/arduino-ide-extension/src/electron-main/fix-app-image-icon.ts
+++ b/arduino-ide-extension/src/electron-main/fix-app-image-icon.ts
@@ -1,0 +1,31 @@
+import { environment } from '@theia/application-package/lib/environment';
+import { isOSX, isWindows } from '@theia/core/lib/common/os';
+import {
+  ElectronMainApplication,
+  ElectronMainApplicationContribution,
+} from '@theia/core/lib/electron-main/electron-main-application';
+import { injectable } from '@theia/core/shared/inversify';
+import { join } from 'node:path';
+
+// Fixes no application icon for the AppImage on Linux (https://github.com/arduino/arduino-ide/issues/131)
+// The fix was based on https://github.com/eclipse-theia/theia-blueprint/pull/180.
+// Upstream: https://github.com/electron-userland/electron-builder/issues/4617
+@injectable()
+export class FixAppImageIcon implements ElectronMainApplicationContribution {
+  onStart(application: ElectronMainApplication): void {
+    if (isOSX || isWindows || environment.electron.isDevMode()) {
+      return;
+    }
+    const windowOptions = application.config.electron.windowOptions;
+    if (windowOptions && windowOptions.icon === undefined) {
+      windowOptions.icon = join(
+        __dirname,
+        '..',
+        '..',
+        'resources',
+        'icons',
+        '512-512.png'
+      );
+    }
+  }
+}

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -119,6 +119,7 @@
       "arduino-ide-electron-main.js",
       "src-gen",
       "lib",
+      "resources/icons/512x512.png",
       "!**node_modules/**"
     ],
     "extraResources": [


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Manually set the application icon for the AppImage on Linux.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

Closes #131

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)