### PR TITLE
fix: name of translation (`UA`) module

### DIFF
--- a/arduino-ide-extension/src/node/i18n/arduino-localization-contribution.ts
+++ b/arduino-ide-extension/src/node/i18n/arduino-localization-contribution.ts
@@ -17,7 +17,7 @@ import plJson from '../resources/i18n/pl.json';
 import ptJson from '../resources/i18n/pt.json';
 import ruJson from '../resources/i18n/ru.json';
 import trJson from '../resources/i18n/tr.json';
-import uk_UAJson from '../resources/i18n/uk_UA.json';
+import ukJson from '../resources/i18n/uk.json';
 import zhJson from '../resources/i18n/zh.json';
 import zh_HantJson from '../resources/i18n/zh-Hant.json';
 
@@ -45,7 +45,7 @@ export class ArduinoLocalizationContribution
     'pt-br': ptJson,
     ru: [ruJson],
     tr: [trJson],
-    uk: uk_UAJson,
+    uk: ukJson,
     'zh-cn': zhJson,
     'zh-tw': zh_HantJson,
   };


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Some of the translation module names have changed in https://github.com/arduino/arduino-ide/pull/2153. We did not know this before merging: https://github.com/arduino/arduino-ide/pull/2031. This PR fixes the `UA` module name.

### Change description
<!-- What does your code do? -->

FIx `UA` translation module name.

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)