### PR TITLE
fix: defer board+port state update for extensions

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/update-arduino-state.ts
+++ b/arduino-ide-extension/src/browser/contributions/update-arduino-state.ts
@@ -76,7 +76,9 @@ export class UpdateArduinoState extends SketchContribution {
   }
 
   override onReady(): void {
-    this.updateBoardsConfig(this.boardsServiceProvider.boardsConfig); // TODO: verify!
+    this.boardsServiceProvider.ready.then(() => {
+      this.updateBoardsConfig(this.boardsServiceProvider.boardsConfig);
+    });
     this.updateSketchPath(this.sketchServiceClient.tryGetCurrentSketch());
     this.updateUserDirPath(this.configService.tryGetSketchDirUri());
     this.updateDataDirPath(this.configService.tryGetDataDirUri());


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

To fix a race condition when setting the Arduin state for extensions at app startup. If the board+port state is set before it's read from the `localStorage`, clients will get an `undefined` `fqbn`.

### Change description
<!-- What does your code do? -->

Defer updating the board+port state for extensions when it's ready.

### Other information
<!-- Any additional information that could help the review process -->

Ref: arduino/arduino-ide#2165
Ref: dankeboy36/esp-exception-decoder#10


Steps to reproduce:
 - you have an ESP32 board, the ESP32 platform and the [debugger extension](https://github.com/dankeboy36/esp-exception-decoder#installation) are installed.
 - create a new sketch,
 - attach the board, select the board and port, and save the sketch,
 - upload the sketch,
 - open the decoder terminal with the `ESP Exception Decoder: Show Decoder Terminal` command,
 - you see the FQBN and the sketch printed to the console,
 - quit IDE2,
 - start IDE2 and open the decoder terminal. You see the FQBN instead of the `No board selected` error message.

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)