### PR TITLE
fix: forward backend logging to electron

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,8 +4,11 @@
     {
       "label": "Rebuild App",
       "type": "shell",
-      "command": "yarn rebuild:browser && yarn rebuild:electron",
+      "command": "yarn rebuild",
       "group": "build",
+      "options": {
+        "cwd": "${workspaceFolder}/electron-app"
+      },
       "presentation": {
         "reveal": "always",
         "panel": "new",

--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -844,5 +844,7 @@ function updateAppInfo(
 }
 
 function isAddressInfo(arg: unknown): arg is Pick<AddressInfo, 'port'> {
-  return isObject<AddressInfo>(arg) && typeof arg.port === 'number'; // `family` might be
+  // Cannot do the type-guard on all properties, but the port is sufficient as the address is always `localhost`.
+  // For example, the `family` might be absent if the address is IPv6.
+  return isObject<AddressInfo>(arg) && typeof arg.port === 'number';
 }

--- a/electron-app/arduino-ide-backend-main.js
+++ b/electron-app/arduino-ide-backend-main.js
@@ -1,42 +1,17 @@
 // @ts-check
 'use strict';
 
-// Patch for on Linux when `XDG_CONFIG_HOME` is not available, `node-log-rotate` creates the folder with `undefined` name.
-// See https://github.com/lemon-sour/node-log-rotate/issues/23 and https://github.com/arduino/arduino-ide/issues/394.
-// If the IDE2 is running on Linux, and the `XDG_CONFIG_HOME` variable is not available, set it to avoid the `undefined` folder.
-// From the specs: https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html
-// "If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used."
-function enableFileLogger() {
-  const os = require('os');
+// `true` if the this (backend main) process has been forked.
+if (process.send) {
   const util = require('util');
-  if (os.platform() === 'linux' && !process.env['XDG_CONFIG_HOME']) {
-    const { join } = require('path');
-    const home = process.env['HOME'];
-    const xdgConfigHome = home
-      ? join(home, '.config')
-      : join(os.homedir(), '.config');
-    process.env['XDG_CONFIG_HOME'] = xdgConfigHome;
-  }
-  const { setup, log } = require('node-log-rotate');
-
-  setup({
-    appName: 'Arduino IDE',
-    maxSize: 10 * 1024 * 1024,
-  });
   for (const name of ['log', 'trace', 'debug', 'info', 'warn', 'error']) {
-    const original = console[name];
     console[name] = function () {
       // eslint-disable-next-line prefer-rest-params
-      const messages = Object.values(arguments);
-      const message = util.format(...messages);
-      original(message);
-      log(message);
+      const args = Object.values(arguments);
+      const message = util.format(...args);
+      process.send?.({ severity: name, message }); // send the log message to the parent process (electron main)
     };
   }
-}
-
-if (process.env.IDE2_FILE_LOGGER === 'true') {
-  enableFileLogger();
 }
 
 require('./src-gen/backend/main');

--- a/electron-app/arduino-ide-electron-main.js
+++ b/electron-app/arduino-ide-electron-main.js
@@ -18,8 +18,6 @@ if (config.buildDate) {
   ]
     .filter(Boolean)
     .join(',');
-  // Enables the file logger in the backend process.
-  process.env.IDE2_FILE_LOGGER = 'true';
 }
 
 require('./lib/backend/electron-main');

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -53,7 +53,7 @@
     "prepackage": "rimraf dist",
     "package": "node ./scripts/package.js",
     "postpackage": "node ./scripts/post-package.js",
-    "rebuild": "theia rebuild:browser && theia rebuild:electron"
+    "rebuild": "theia rebuild:browser --cacheRoot ../.. && theia rebuild:electron --cacheRoot ../.."
   },
   "theia": {
     "target": "electron",


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->

Problem: When IDE2 runs in production mode (the app is bundled up), it logs into a file. When IDE2 starts, multiple processes start under the hood. The process hierarchy is like this _electron main_ > _backend main_ >> _plugins_fsWatcher_and_other_subProcesses_. IDE2 logs only in the _backend main_ process and its child processes. The _electron main_ process logging is missing from the generated single log file.

Since the _electron main_ logging is missing, it very often happens that IDE2 does not even start on users' env (due to file permission, IPv6 vs. IPv4 issue, etc.), and the cause (error) is missing from the logs.

 - Without introducing a sophisticated logging server and/or message queues, it's impossible to write the same log file stream from different processes.
 - I would like to avoid introducing different log files (backend, electron) to simplify the info-gathering procedure.

This PR enables logging in the _electorn main_ module, and the _backend main_ with all its children will forward the log to the _electron main_ via IPC. So it's in a centralized place and can be written into a file in production mode.

Steps to verify:
 - rename or delete the default log file location on your env. (on macOS, it's under `~/Library/Logs/Arduino IDE`),
 - start IDE2 from a terminal,
 - normally quit the app,
 - open the generated log file and compare it with the terminal output.

You must see such entries in the generated log files:

```
[...]
2023-09-22 16:24:38 Arduino IDE 2.2.2-snapshot-0c567f78
2023-09-22 16:24:38 Checking for frontend application configuration customizations. Module path: /Users/a.kitta/dev/git/arduino-ide/electron-app/dist/mac/Arduino IDE.app/Contents/Resources/app/lib/backend/electron-main.js, destination 'package.json': /Users/a.kitta/dev/git/arduino-ide/electron-app/dist/mac/Arduino IDE.app/Contents/Resources/app/package.json
2023-09-22 16:24:38 Setting 'theia.frontend.config.appVersion' application configuration value to: "2.2.2-snapshot-0c567f78" (type of string)
2023-09-22 16:24:38 Setting 'theia.frontend.config.cliVersion' application configuration value to: "0.34.0" (type of string)
2023-09-22 16:24:38 Setting 'theia.frontend.config.buildDate' application configuration value to: "2023-09-22T14:22:41.170Z" (type of string)
[...]
2023-09-22 16:24:59 Storing the sketch as a workspace root: </Users/a.kitta/Documents/Arduino/WiFi101_OTA>.
2023-09-22 16:24:59 Skipped storing sketch as workspace root. Already visited: </Users/a.kitta/Documents/Arduino/WiFi101_OTA>.
2023-09-22 16:24:59 Stored workspaces roots: /Users/a.kitta/Documents/Arduino/WiFi101_OTA
2023-09-22 16:24:59 No sketches were scheduled for deletion.
[...]
```

The order of the log entries in the generated file and from the terminal is the same.

### Change description
<!-- What does your code do? -->

### Other information
<!-- Any additional information that could help the review process -->

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)