### PR TITLE
fix: use board+port at startup if it's restored

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/debug.ts
+++ b/arduino-ide-extension/src/browser/contributions/debug.ts
@@ -19,7 +19,7 @@ import {
   SketchContribution,
   TabBarToolbarRegistry,
 } from './contribution';
-import { MaybePromise, MenuModelRegistry, nls } from '@theia/core/lib/common';
+import { MenuModelRegistry, nls } from '@theia/core/lib/common';
 import { CurrentSketch } from '../sketches-service-client-impl';
 import { ArduinoMenus } from '../menu/arduino-menus';
 
@@ -99,8 +99,8 @@ export class Debug extends SketchContribution {
     this.notificationCenter.onPlatformDidUninstall(() => this.refreshState());
   }
 
-  override onReady(): MaybePromise<void> {
-    this.refreshState();
+  override onReady(): void {
+    this.boardsServiceProvider.ready.then(() => this.refreshState());
   }
 
   override registerCommands(registry: CommandRegistry): void {

--- a/arduino-ide-extension/src/browser/contributions/examples.ts
+++ b/arduino-ide-extension/src/browser/contributions/examples.ts
@@ -300,8 +300,8 @@ export class LibraryExamples extends Examples {
     this.notificationCenter.onLibraryDidUninstall(() => this.update());
   }
 
-  override async onReady(): Promise<void> {
-    this.update(); // no `await`
+  override onReady(): void {
+    this.boardsServiceProvider.ready.then(() => this.update());
   }
 
   protected override handleBoardChanged(board: Board | undefined): void {

--- a/arduino-ide-extension/src/browser/contributions/include-library.ts
+++ b/arduino-ide-extension/src/browser/contributions/include-library.ts
@@ -2,7 +2,6 @@ import PQueue from 'p-queue';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
-import { EditorManager } from '@theia/editor/lib/browser';
 import { MenuModelRegistry, MenuPath } from '@theia/core/lib/common/menu';
 import {
   Disposable,
@@ -22,28 +21,25 @@ import { CurrentSketch } from '../sketches-service-client-impl';
 @injectable()
 export class IncludeLibrary extends SketchContribution {
   @inject(CommandRegistry)
-  protected readonly commandRegistry: CommandRegistry;
+  private readonly commandRegistry: CommandRegistry;
 
   @inject(MenuModelRegistry)
-  protected readonly menuRegistry: MenuModelRegistry;
+  private readonly menuRegistry: MenuModelRegistry;
 
   @inject(MainMenuManager)
-  protected readonly mainMenuManager: MainMenuManager;
-
-  @inject(EditorManager)
-  protected override readonly editorManager: EditorManager;
+  private readonly mainMenuManager: MainMenuManager;
 
   @inject(NotificationCenter)
-  protected readonly notificationCenter: NotificationCenter;
+  private readonly notificationCenter: NotificationCenter;
 
   @inject(BoardsServiceProvider)
-  protected readonly boardsServiceProvider: BoardsServiceProvider;
+  private readonly boardsServiceProvider: BoardsServiceProvider;
 
   @inject(LibraryService)
-  protected readonly libraryService: LibraryService;
+  private readonly libraryService: LibraryService;
 
-  protected readonly queue = new PQueue({ autoStart: true, concurrency: 1 });
-  protected readonly toDispose = new DisposableCollection();
+  private readonly queue = new PQueue({ autoStart: true, concurrency: 1 });
+  private readonly toDispose = new DisposableCollection();
 
   override onStart(): void {
     this.boardsServiceProvider.onBoardsConfigDidChange(() =>
@@ -56,8 +52,8 @@ export class IncludeLibrary extends SketchContribution {
     this.notificationCenter.onDidReinitialize(() => this.updateMenuActions());
   }
 
-  override async onReady(): Promise<void> {
-    this.updateMenuActions();
+  override onReady(): void {
+    this.boardsServiceProvider.ready.then(() => this.updateMenuActions());
   }
 
   override registerMenus(registry: MenuModelRegistry): void {
@@ -93,7 +89,7 @@ export class IncludeLibrary extends SketchContribution {
     });
   }
 
-  protected async updateMenuActions(): Promise<void> {
+  private async updateMenuActions(): Promise<void> {
     return this.queue.add(async () => {
       this.toDispose.dispose();
       this.mainMenuManager.update();
@@ -139,7 +135,7 @@ export class IncludeLibrary extends SketchContribution {
     });
   }
 
-  protected registerLibrary(
+  private registerLibrary(
     libraryOrPlaceholder: LibraryPackage | string,
     menuPath: MenuPath
   ): Disposable {
@@ -172,7 +168,7 @@ export class IncludeLibrary extends SketchContribution {
     );
   }
 
-  protected async includeLibrary(library: LibraryPackage): Promise<void> {
+  private async includeLibrary(library: LibraryPackage): Promise<void> {
     const sketch = await this.sketchServiceClient.currentSketch();
     if (!CurrentSketch.isValid(sketch)) {
       return;

--- a/arduino-ide-extension/src/browser/contributions/selected-board.ts
+++ b/arduino-ide-extension/src/browser/contributions/selected-board.ts
@@ -19,16 +19,18 @@ export class SelectedBoard extends Contribution {
   private readonly boardsServiceProvider: BoardsServiceProvider;
 
   override onStart(): void {
-    this.boardsServiceProvider.onBoardListDidChange(() =>
-      this.update(this.boardsServiceProvider.boardList)
+    this.boardsServiceProvider.onBoardListDidChange((boardList) =>
+      this.update(boardList)
     );
   }
 
   override onReady(): void {
-    this.update(this.boardsServiceProvider.boardList);
+    this.boardsServiceProvider.ready.then(() => this.update());
   }
 
-  private update(boardList: BoardList): void {
+  private update(
+    boardList: BoardList = this.boardsServiceProvider.boardList
+  ): void {
     const { selectedBoard, selectedPort } = boardList.boardsConfig;
     this.statusBar.setElement('arduino-selected-board', {
       alignment: StatusBarAlignment.RIGHT,


### PR DESCRIPTION
### Motivation

There are a few regressions in IDE2 after the board+port simplification (#2165). This PR fixes them.

<!-- Why this pull request? -->

### Change description

Refresh the following at app startup when the board+port selection has been restored:
 - the board+port in the status bar. (this is not a functional bug, but with https://github.com/arduino/arduino-ide/commit/db83ed095bed5cc0151cac4f006581ec2f660a08, an unnecessary refresh has been removed),
 - `File` > `Examples` menu (https://github.com/arduino/arduino-ide/commit/20a192afe6d14818ad2be18ac8c53e9fb2c4d671),
 - `Sketch` > `Include Library` menu (https://github.com/arduino/arduino-ide/commit/20a192afe6d14818ad2be18ac8c53e9fb2c4d671),
 - Debug toolbar item (https://github.com/arduino/arduino-ide/commit/4d04aac56d5af1e502f6a596a641e4bccd43a882)

Steps to verify:
 1. Open IDE2,
 2. Create a new sketch and save it,
 3. Select your Arduino Nano ESP32 board (you can select any other board that supports debugging),
 4. Verify
    - the debug toolbar is enabled,
    - `File` > `Examples` > `Examples for Arduino Nano ESP32` menu group is visible,
    - `Sketch` > `Include Library` > `Arduino libraries` menu group is visible.
 5. Quit IDE2,
 6. Start IDE2,
 7. Repeat step `(4)`; all works.

<img width="541" alt="Screenshot 2023-10-02 at 09 25 50" src="https://github.com/arduino/arduino-ide/assets/1405703/dc74b4a9-b2e4-452b-858d-95e86426c9bd">

<img width="644" alt="Screenshot 2023-10-02 at 09 26 01" src="https://github.com/arduino/arduino-ide/assets/1405703/08231130-0c5c-4938-a452-9e0d25689e98">

<img width="629" alt="Screenshot 2023-10-02 at 09 26 09" src="https://github.com/arduino/arduino-ide/assets/1405703/258db2e9-8ae0-4869-90ee-a7ded202967f">



<!-- What does your code do? -->

### Other information

<!-- Any additional information that could help the review process -->

Closes arduino/arduino-ide#2237
Closes arduino/arduino-ide#2239

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
