### PR TITLE
Correct conditional logic for publishing steps of build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -304,7 +304,7 @@ jobs:
         if: fromJSON(matrix.config.container).image == null
         uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11.x'
 
       - name: Install Go
         uses: actions/setup-go@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -452,24 +452,6 @@ jobs:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
           path: ${{ env.CHANNEL_FILES_PATH }}
 
-  # This job serves only as a container for the logic necessary to allow dependent jobs to run if the
-  # merge-channel-files job was skipped.
-  merge-channel-files-complete:
-    needs:
-      - merge-channel-files
-    if: >
-      always() &&
-      (
-        needs.merge-channel-files.result == 'skipped' ||
-        needs.merge-channel-files.result == 'success'
-      )
-    runs-on: ubuntu-latest
-    permissions: {}
-    steps:
-      # GitHub Actions requires every job to have >=1 step.
-      - name: Dummy step
-        run: ''
-
   artifacts:
     name: ${{ matrix.artifact.name }} artifact
     needs:
@@ -546,9 +528,16 @@ jobs:
   publish:
     needs:
       - build-type-determination
-      - merge-channel-files-complete
+      - merge-channel-files
       - changelog
     if: >
+      always() &&
+      needs.build-type-determination.result == 'success' &&
+      (
+        needs.merge-channel-files.result == 'skipped' ||
+        needs.merge-channel-files.result == 'success'
+      ) &&
+      needs.changelog.result == 'success' &&
       needs.build-type-determination.outputs.publish-to-s3 == 'true' &&
       needs.build-type-determination.outputs.is-nightly == 'true'
     runs-on: ubuntu-latest
@@ -572,9 +561,17 @@ jobs:
   release:
     needs:
       - build-type-determination
-      - merge-channel-files-complete
+      - merge-channel-files
       - changelog
-    if: needs.build-type-determination.outputs.is-release == 'true'
+    if: >
+      always() &&
+      needs.build-type-determination.result == 'success' &&
+      (
+        needs.merge-channel-files.result == 'skipped' ||
+        needs.merge-channel-files.result == 'success'
+      ) &&
+      needs.changelog.result == 'success' &&
+      needs.build-type-determination.outputs.is-release == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Download [GitHub Actions]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -595,13 +595,6 @@ jobs:
           file_glob: true
           body: ${{ needs.changelog.outputs.BODY }}
 
-      # Temporary measure to prevent release update offers before the manually produced builds are uploaded.
-      # The step must be removed once fully automated builds are regained.
-      - name: Remove "channel update info files" related to manual builds
-        run: |
-          # See: https://github.com/arduino/arduino-ide/issues/2018
-          rm "${{ env.JOB_TRANSFER_ARTIFACT }}/stable-linux.yml"
-
       - name: Publish Release [S3]
         if: needs.build-type-determination.outputs.publish-to-s3 == 'true'
         uses: docker://plugins/s3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -284,16 +284,16 @@ jobs:
 
     steps:
       - name: Checkout
-        if: fromJSON(matrix.config.container).image == null
+        if: fromJSON(matrix.config.container) == null
         uses: actions/checkout@v4
 
       - name: Checkout
         # actions/checkout@v4 has dependency on a higher version of glibc than available in the Linux container.
-        if: fromJSON(matrix.config.container).image != null
+        if: fromJSON(matrix.config.container) != null
         uses: actions/checkout@v3
 
       - name: Install Node.js
-        if: fromJSON(matrix.config.container).image == null
+        if: fromJSON(matrix.config.container) == null
         uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -301,7 +301,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install Python 3.x
-        if: fromJSON(matrix.config.container).image == null
+        if: fromJSON(matrix.config.container) == null
         uses: actions/setup-python@v4
         with:
           python-version: '3.11.x'


### PR DESCRIPTION
## Background

The "Arduino IDE" GitHub Actions workflow is used to generate several distinct types of builds:

- Tester builds of commits
- Nightly builds
- Release builds

Different operations must be performed depending on which type of build is being produced. The workflow uses dedicated [jobs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobs) for publishing the nightly builds and for publishing the release builds. Those jobs are [configured to run only when certain criteria are met](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif).

One such criteria is that the `merge-channel-files` job ran as expected. There are [four possible result types of a job](https://docs.github.com/en/actions/learn-github-actions/contexts#needs-context:~:text=needs.%3Cjob_id%3E.result), which should be handled as follows:

| Result   | Run dependent job? |
| -------- | ------------------ |
| success  | Yes                |
| failure  | No                 |
| canceled | No                 |
| skipped  | Yes                |

GitHub Actions automatically takes the desired action regarding whether the dependent job should run for the first three result types, but that is not the case for the "skipped" result. The `merge-channel-files` job dependency is skipped when a channel file merge is not needed and so this is not cause to cancel the build publishing.

The only way to make a dependent job run when the dependency was skipped is to add the [`always()` expression](https://docs.github.com/en/actions/learn-github-actions/expressions#always) to the [job conditional](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif). This goes too far in the other direction by causing the job to run even when the dependency failed or was canceled. So it is necessary to also add logic for each of the dependency job result types to the conditional, which makes it quite complex when combined with the logic for the other criteria of the job.

## Problem

In order to reduce the amount of complexity of the conditionals of the dependent jobs, a job (`merge-channel-files-complete`) was interposed in the dependency chain, which was intended to act simply as a container for the logic about the `merge-channel-files` job result. Unfortunately it turns out that even if the direct dependency job's result was success, if any ancestor in the dependency chain was skipped, [GitHub Actions still skips all dependent jobs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds:~:text=If%20a%20run%20contains%20a%20series%20of%20jobs%20that%20need%20each%20other%2C%20a%20failure%20or%20skip%20applies%20to%20all%20jobs%20in%20the%20dependency%20chain%20from%20the%20point%20of%20failure%20or%20skip%20onwards.) without an [`always()` expression](https://docs.github.com/en/actions/learn-github-actions/expressions#always) in their [conditional](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif), meaning the intermediate job was pointless. This caused the build publishing jobs to be skipped under the conditions where they should have ran.

## Solution

The pointless intermediate job is hereby removed, an `always()` expression added to the conditionals of the dependent jobs, and the full logic for how to handle each dependent job result type added there as well.

## Additional Changes

### Pin Python to 3.11.x minor version

https://github.com/arduino/arduino-ide/pull/2261/commits/97b0bc014c641be66e5153a1b232ef800fe940b4

I found that the node-gyp installation was broken by the update to Python 3.12 in the GitHub Actions runner: https://github.com/nodejs/node-gyp/issues/2869

This caused a failure of the workflow runs unrelated to the changes made by this PR:

https://github.com/per1234/arduino-ide/actions/runs/6566684071/job/17837889420#step:8:247

```text
Traceback (most recent call last):
  File "D:\a\arduino-ide\arduino-ide\node_modules\node-gyp\gyp\gyp_main.py", line 42, in <module>
    import gyp  # noqa: E402
    ^^^^^^^^^^
  File "D:\a\arduino-ide\arduino-ide\node_modules\node-gyp\gyp\pylib\gyp\__init__.py", line 9, in <module>
    import gyp.input
  File "D:\a\arduino-ide\arduino-ide\node_modules\node-gyp\gyp\pylib\gyp\input.py", line 19, in <module>
    from distutils.version import StrictVersion
ModuleNotFoundError: No module named 'distutils'
```

The workaround is to pin the version of Python used for the build job in the runner environment to 3.11.

I believe the node-gyp maintainers are already working on a fix, which will be in the next release so we can likely revert this pin at some point in the future if it is preferred to only pin the major version of Python.

### Restore Linux channel file uploading

https://github.com/arduino/arduino-ide/pull/2261/commits/dd79c637bc742831402a18d6e28cda7ea97a6901

The Linux channel file upload was disabled due to the fact that we were manually producing that build (https://github.com/arduino/arduino-ide/pull/2020). The problem causing the need for a manually produced Linux build was fixed (https://github.com/arduino/arduino-ide/pull/2253), but I forgot to restore the channel file upload at that time.

### Minor workflow refactoring

https://github.com/arduino/arduino-ide/pull/2261/commits/883426dd8f78753aad240bebb041b32567c82b2e

I made a small change to the conditionals for the container/runner environment-specific steps of the build job. This is unrelated to the other work and has no functional effect, but I think it makes the workflow a little easier to understand by matching the comparison in the conditional to the matrix data.

## Information for reviewers

I did some demonstration runs of the workflow (in addition to the tester build run that will be associated with the PR):

---

Triggered by `workflow_dispatch` event:

https://github.com/arduino/arduino-ide/actions/runs/6568764692

---

Triggered by `schedule` event (which causes a "nightly" build publishing):

https://github.com/per1234/arduino-ide/actions/runs/6567577721

This was performed in my fork, where I don't have the AWS credentials, so the failure of the S3 upload step in the "publish" job is expected, but you can see the rest of the workflow was successful

---

Production release:

https://github.com/per1234/arduino-ide/actions/runs/6567497724

This was performed in my fork, where I don't have the AWS credentials, so the failure of the S3 upload step in the "release" job is expected, but you can see the rest of the workflow was successful, including the creation of the GitHub Release: https://github.com/per1234/arduino-ide/releases/tag/0.0.0-rc.32

---

## Additional context

Originally reported by @KurtE:

https://forum.arduino.cc/t/where-are-wifis3-examples-hiding/1178596/12