### PR TITLE
fix: board `<select>` update on board detach

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/certificate-uploader/certificate-uploader-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/certificate-uploader/certificate-uploader-component.tsx
@@ -69,6 +69,7 @@ export const CertificateUploaderComponent = ({
   const onItemSelect = React.useCallback(
     (item: BoardOptionValue | null) => {
       if (!item) {
+        setSelectedItem(null);
         return;
       }
       const board = item.board;

--- a/arduino-ide-extension/src/browser/dialogs/certificate-uploader/select-board-components.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/certificate-uploader/select-board-components.tsx
@@ -1,8 +1,9 @@
 import { nls } from '@theia/core/lib/common';
 import React from '@theia/core/shared/react';
-import type {
-  BoardList,
-  BoardListItemWithBoard,
+import {
+  boardListItemEquals,
+  type BoardList,
+  type BoardListItemWithBoard,
 } from '../../../common/protocol/board-list';
 import { ArduinoSelect } from '../../widgets/arduino-select';
 
@@ -75,7 +76,9 @@ export const SelectBoardComponent = ({
     setSelectOptions(boardOptions);
 
     if (selectedItem) {
-      selBoard = updatableBoards.indexOf(selectedItem);
+      selBoard = updatableBoards.findIndex((board) =>
+        boardListItemEquals(board, selectedItem)
+      );
     }
 
     selectOption(boardOptions[selBoard] || null);

--- a/arduino-ide-extension/src/browser/dialogs/firmware-uploader/firmware-uploader-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/firmware-uploader/firmware-uploader-component.tsx
@@ -104,6 +104,7 @@ export const FirmwareUploaderComponent = ({
   const onItemSelect = React.useCallback(
     (item: BoardListItemWithBoard | null) => {
       if (!item) {
+        setSelectedItem(null);
         return;
       }
       const board = item.board;


### PR DESCRIPTION
### Motivation

<!-- Why this pull request? -->

When the previously selected board is not detected, unset the `<select>` option.

Closes #2222

### Change description

<!-- What does your code do? -->

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
