### PR TITLE
Remove version pin of Git dependency in Linux build container Dockerfile

### DIFF
--- a/.github/workflows/assets/linux.Dockerfile
+++ b/.github/workflows/assets/linux.Dockerfile
@@ -32,7 +32,7 @@ RUN \
   apt-get \
     --yes \
     install \
-      "git=1:2.42.0-0ppa1~ubuntu18.04.1" && \
+      "git" && \
   \
   apt-get \
     --yes \


### PR DESCRIPTION
### Motivation

A Docker container is used to produce the Linux build of Arduino IDE.

The dependencies of the build are pinned to a specific version in the Dockerfile in order to ensure a stable environment in the images.

One such dependency is Git. The [version of Git available from the package repository of the Ubuntu 18.04 distro](https://launchpad.net/ubuntu/bionic/+source/git) used for the image is too outdated to be used for this purpose. For this reason, [a PPA](https://git-scm.com/download/linux#:~:text=For%20Ubuntu%2C%20this%20PPA%20provides%20the%20latest%20stable%20upstream%20Git%20version) is used as the source for the Git package.

On the last test build of the image, the installation of the `git=1:2.42.0-0ppa1~ubuntu18.04.1` package failed:

https://github.com/arduino/arduino-ide/actions/runs/7001663864/job/19045182781#step:4:726

```text
5.515 E: Version '1:2.42.0-0ppa1~ubuntu18.04.1' for 'git' was not found
```

It turns out that the maintainers of the PPA remove the previous package every time they add a package for a newer version of Git. They removed the `1:2.42.0-0ppa1~ubuntu18.04.1` package when they released `1:2.43.0-0ppa1~ubuntu18.04.1` and thus broke the installation of the Git package pinned to the removed package version in the Dockerfile.

### Change description

The maintenance practices of the PPA make it impossible to version pin the Git package in the Dockerfile, so it is unpinned by this PR. This will cause whichever version is available from the PPA to be installed each time the image is built. 

Although not ideal for this application, that shouldn't cause any problems in practice since Git has quite a stable and carefully maintained interface.

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
