### PR TITLE
Bump built-in example sketches version to 1.10.1

### DIFF
--- a/arduino-ide-extension/scripts/download-examples.js
+++ b/arduino-ide-extension/scripts/download-examples.js
@@ -1,7 +1,7 @@
 // @ts-check
 
 // The version to use.
-const version = '1.10.0';
+const version = '1.10.1';
 
 (async () => {
   const os = require('node:os');


### PR DESCRIPTION
### Motivation

The Arduino IDE installation includes a collection of example sketches demonstrating fundamental concepts.

These examples are hosted in a dedicated repository, which is a dependency of this project. A new release has been made in that `arduino/arduino-examples` repository:

https://github.com/arduino/arduino-examples/releases/tag/1.10.1

### Change description

Bump the version of the `arduino/arduino-examples` dependency in the download script so that the latest version of the examples will be bundled with the Arduino IDE installation.

### Other information

Related:

- https://github.com/arduino/arduino-ide/pull/1519
- https://github.com/arduino/arduino-ide/pull/383

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)