### PR TITLE
chore: pinned Arduino CLI `0.35.1`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,6 @@
   },
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -169,7 +169,7 @@
   ],
   "arduino": {
     "arduino-cli": {
-      "version": "0.35.0-rc.7"
+      "version": "0.35.1"
     },
     "arduino-fwuploader": {
       "version": "2.4.1"


### PR DESCRIPTION
### Motivation

<!-- Why this pull request? -->

 - IDE2 should use the `0.35.1` of the Arduino CLI.
 - Use the latest (`>=1.85`) preferred value of the `source.fixAll.eslint` VS Code settings.

### Change description

<!-- What does your code do? -->

 - Pinned the CLI version,
 - Update the shared `settings.json` file

### Other information

<!-- Any additional information that could help the review process -->

Closes arduino/arduino-ide#2318

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
