### PR TITLE
Bundle native Arduino Firmware Uploader with Apple Silicon build

### DIFF
--- a/arduino-ide-extension/scripts/download-fwuploader.js
+++ b/arduino-ide-extension/scripts/download-fwuploader.js
@@ -50,7 +50,14 @@
     const suffix = (() => {
       switch (platform) {
         case 'darwin':
-          return 'macOS_64bit.tar.gz';
+          switch (arch) {
+            case 'arm64':
+              return 'macOS_ARM64.tar.gz';
+            case 'x64':
+              return 'macOS_64bit.tar.gz';
+            default:
+              return undefined;
+          }
         case 'win32':
           return 'Windows_64bit.zip';
         case 'linux': {


### PR DESCRIPTION
### Motivation

A separate build of Arduino IDE is produced for each of the macOS host architectures:

* Apple Silicon (ARM)
* Intel (x86)

The Arduino IDE distribution includes several bundled helper tools. The build of those tools should also be selected according to the target host architecture.

At the time the infrastructure was set up for bundling the "Arduino Firmware Uploader" tool with the Arduino IDE distribution, that tool was only produced in a macOS x86 variant. So this was used even in the Apple Silicon Arduino IDE distribution, relying on Rosetta 2 to provide compatibility when used on Apple Silicon machines. Since that time, the Arduino Firmware Uploader build infrastructure has been updated to produce an Apple Silicon build of the tool (https://github.com/arduino/arduino-fwuploader/pull/144) and such a build is available for the IDE's current version dependency of Arduino Firmware Updater:

https://github.com/arduino/arduino-ide/blob/b8dd39c729d9fb4b886f3552d382f930b5aec605/arduino-ide-extension/package.json#L174-L176

https://github.com/arduino/arduino-fwuploader/releases/tag/2.4.1

### Change description

This PR updates the "Arduino Firmware Uploader" tool bundling script ito use the most appropriate variant of the dependency for the target host architecture. This provides the following benefits

* Compatibility with systems that don't have Rosetta 2 installed
* Improved performance

### Other information

I ran a demonstration build that includes the Apple Silicon variant in my fork:

https://github.com/per1234/arduino-ide/actions/runs/7602618426

---

Resolves https://github.com/arduino/arduino-ide/issues/2337 by completing all related tasks in this codebase (work in other codebases should be tracked in those issue trackers).

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
