### PR TITLE
feat: preference to limit thread count of the LS

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -169,13 +169,13 @@
   ],
   "arduino": {
     "arduino-cli": {
-      "version": "0.35.1"
+      "version": "0.35.2"
     },
     "arduino-fwuploader": {
       "version": "2.4.1"
     },
     "arduino-language-server": {
-      "version": "0.7.5"
+      "version": "0.7.6"
     },
     "clangd": {
       "version": "14.0.0"

--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -54,6 +54,10 @@ export function isMonitorWidgetDockPanel(
   return arg === 'bottom' || arg === 'right';
 }
 
+export const defaultAsyncWorkers = 0 as const;
+export const minAsyncWorkers = defaultAsyncWorkers;
+export const maxAsyncWorkers = 8 as const;
+
 type StrictPreferenceSchemaProperties<T extends object> = {
   [p in keyof T]: PreferenceSchemaProperty;
 };
@@ -78,6 +82,16 @@ const properties: ArduinoPreferenceSchemaProperties = {
       "If true, the language server provides real-time diagnostics when typing in the editor. It's false by default."
     ),
     default: false,
+  },
+  'arduino.language.asyncWorkers': {
+    type: 'number',
+    description: nls.localize(
+      'arduino/preferences/language.asyncWorkers',
+      'Number of async workers used by the Arduino Language Server (clangd). Background index also uses this many workers. The minimum value is 0, and the maximum is 8. When it is 0, the language server uses all available cores. The default value is 0.'
+    ),
+    minimum: minAsyncWorkers,
+    maximum: maxAsyncWorkers,
+    default: defaultAsyncWorkers,
   },
   'arduino.compile.verbose': {
     type: 'boolean',
@@ -298,6 +312,7 @@ export const ArduinoConfigSchema: PreferenceSchema = {
 export interface ArduinoConfiguration {
   'arduino.language.log': boolean;
   'arduino.language.realTimeDiagnostics': boolean;
+  'arduino.language.asyncWorkers': number;
   'arduino.compile.verbose': boolean;
   'arduino.compile.experimental': boolean;
   'arduino.compile.revealRange': ErrorRevealStrategy;

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -196,7 +196,7 @@
   "theiaPlugins": {
     "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.52.1/file/vscode.cpp-1.52.1.vsix",
     "vscode-arduino-api": "https://github.com/dankeboy36/vscode-arduino-api/releases/download/0.1.2/vscode-arduino-api-0.1.2.vsix",
-    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.1.1.vsix",
+    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.1.2.vsix",
     "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.46.1/file/vscode.json-1.46.1.vsix",
     "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "cortex-debug": "https://downloads.arduino.cc/marus25.cortex-debug/marus25.cortex-debug-1.5.1.vsix",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -385,6 +385,7 @@
       "invalid.editorFontSize": "Invalid editor font size. It must be a positive integer.",
       "invalid.sketchbook.location": "Invalid sketchbook location: {0}",
       "invalid.theme": "Invalid theme.",
+      "language.asyncWorkers": "Number of async workers used by the Arduino Language Server (clangd). Background index also uses this many workers. The minimum value is 0, and the maximum is 8. When it is 0, the language server uses all available cores. The default value is 0.",
       "language.log": "True if the Arduino Language Server should generate log files into the sketch folder. Otherwise, false. It's false by default.",
       "language.realTimeDiagnostics": "If true, the language server provides real-time diagnostics when typing in the editor. It's false by default.",
       "manualProxy": "Manual proxy configuration",


### PR DESCRIPTION
#### ~Depends on https://github.com/arduino/vscode-arduino-tools/pull/46~ Done ✅ 

### Motivation

Added a new preference (`arduino.language.asyncWorkers`) to control the number of async workers used by `clangd`.
Users can use fine tune the `clangd` thread count to overcome excessive CPU usage.

<!-- Why this pull request? -->

### Change description
 - use `0.1.2` Arduino Tools VSIX,
 - use `0.35.2` CLI,
 - use `0.7.6` Arduino LS,
 - new preference to control the `clangd` thread count per sketch

<!-- What does your code do? -->

### Other information

Ref: arduino/arduino-language-server#177
Ref: arduino/vscode-arduino-tools#46

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
