### PR TITLE
chore: use version `2.3.0` for the next release

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide-extension",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "An extension for Theia building the Arduino IDE",
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "electron-app",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "license": "AGPL-3.0-or-later",
   "main": "./src-gen/backend/electron-main.js",
   "dependencies": {
@@ -19,7 +19,7 @@
     "@theia/preferences": "1.41.0",
     "@theia/terminal": "1.41.0",
     "@theia/workspace": "1.41.0",
-    "arduino-ide-extension": "2.2.2"
+    "arduino-ide-extension": "2.3.0"
   },
   "devDependencies": {
     "@theia/cli": "1.41.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "description": "Arduino IDE",
   "repository": "https://github.com/arduino/arduino-ide.git",
   "author": "Arduino SA",


### PR DESCRIPTION
#### ~Depends on https://github.com/arduino/arduino-ide/pull/2350~ Done ✅ 

### Motivation

<!-- Why this pull request? -->

The version number must be increased before the next release. See the [docs](https://github.com/arduino/arduino-ide/blob/main/docs/internal/release-procedure.md#3--check-version-of-packages).

### Change description

Bump version from `2.2.2` to `2.3.0`

<!-- What does your code do? -->

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
