### PR TITLE
fix: no required `programmer` for `debug --info`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
-  GO_VERSION: '1.19'
+  GO_VERSION: '1.21'
   # See: https://github.com/actions/setup-node/#readme
   NODE_VERSION: '18.17'
   JOB_TRANSFER_ARTIFACT: build-artifacts

--- a/.github/workflows/check-i18n-task.yml
+++ b/.github/workflows/check-i18n-task.yml
@@ -2,7 +2,7 @@ name: Check Internationalization
 
 env:
   # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
-  GO_VERSION: '1.19'
+  GO_VERSION: '1.21'
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/i18n-nightly-push.yml
+++ b/.github/workflows/i18n-nightly-push.yml
@@ -2,7 +2,7 @@ name: i18n-nightly-push
 
 env:
   # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
-  GO_VERSION: '1.19'
+  GO_VERSION: '1.21'
 
 on:
   schedule:

--- a/.github/workflows/i18n-weekly-pull.yml
+++ b/.github/workflows/i18n-weekly-pull.yml
@@ -2,7 +2,7 @@ name: i18n-weekly-pull
 
 env:
   # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
-  GO_VERSION: '1.19'
+  GO_VERSION: '1.21'
 
 on:
   schedule:

--- a/.github/workflows/themes-weekly-pull.yml
+++ b/.github/workflows/themes-weekly-pull.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
-  GO_VERSION: '1.19'
+  GO_VERSION: '1.21'
   NODE_VERSION: '18.17'
 
 jobs:

--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -169,7 +169,7 @@
   ],
   "arduino": {
     "arduino-cli": {
-      "version": "0.35.2"
+      "version": "0.35.3"
     },
     "arduino-fwuploader": {
       "version": "2.4.1"

--- a/arduino-ide-extension/src/browser/contributions/debug.ts
+++ b/arduino-ide-extension/src/browser/contributions/debug.ts
@@ -398,12 +398,9 @@ export async function isDebugEnabled(
       `Failed to append boards config to the FQBN. Original FQBN was: ${fqbn}`
     );
   }
-  if (!data.selectedProgrammer) {
-    throw new Error(noProgrammerSelectedFor(board.name));
-  }
   const params = {
     fqbn: fqbnWithConfig,
-    programmer: data.selectedProgrammer.id,
+    programmer: data.selectedProgrammer?.id,
   };
   try {
     const debugFqbn = await checkDebugEnabled(params);
@@ -440,16 +437,6 @@ export function debuggingNotSupported(boardName: string): string {
   return nls.localize(
     'arduino/debug/debuggingNotSupported',
     "Debugging is not supported by '{0}'",
-    boardName
-  );
-}
-/**
- * (non-API)
- */
-export function noProgrammerSelectedFor(boardName: string): string {
-  return nls.localize(
-    'arduino/debug/noProgrammerSelectedFor',
-    "No programmer selected for '{0}'",
     boardName
   );
 }

--- a/arduino-ide-extension/src/common/protocol/boards-service.ts
+++ b/arduino-ide-extension/src/common/protocol/boards-service.ts
@@ -95,7 +95,7 @@ export interface CheckDebugEnabledParams {
    * The FQBN might contain custom board config options. For example, `arduino:esp32:nano_nora:USBMode=hwcdc,option2=value2`.
    */
   readonly fqbn: string;
-  readonly programmer: string;
+  readonly programmer?: string;
 }
 
 export interface BoardSearch extends Searchable.Options {

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -178,7 +178,7 @@ export class BoardsServiceImpl
     const req = new IsDebugSupportedRequest()
       .setInstance(instance)
       .setFqbn(fqbn)
-      .setProgrammer(programmer);
+      .setProgrammer(programmer ?? '');
     try {
       const debugFqbn = await new Promise<string>((resolve, reject) =>
         client.isDebugSupported(req, (err, resp) => {

--- a/arduino-ide-extension/src/test/browser/debug.test.ts
+++ b/arduino-ide-extension/src/test/browser/debug.test.ts
@@ -28,7 +28,6 @@ import {
   debuggingNotSupported,
   isDebugEnabled,
   noPlatformInstalledFor,
-  noProgrammerSelectedFor,
 } from '../../browser/contributions/debug';
 import { NotificationCenter } from '../../browser/notification-center';
 import { noBoardSelected } from '../../common/nls';
@@ -117,20 +116,20 @@ describe('debug', () => {
       );
     });
 
-    it('should error when no programmer selected', async () => {
+    it('should resolve when no programmer is selected (arduino/arduino-cli#2540)', async () => {
       const copyData: Mutable<BoardsDataStore.Data> = deepClone(data);
       delete copyData.selectedProgrammer;
-      await rejects(
+      await doesNotReject(
         isDebugEnabled(
           board,
           () => boardDetails,
           () => copyData,
           (fqbn) => fqbn,
-          unexpectedCall()
-        ),
-        (reason) =>
-          reason instanceof Error &&
-          reason.message === noProgrammerSelectedFor(board.name)
+          async (params) => {
+            expect(params.programmer).to.be.undefined;
+            return params.fqbn;
+          }
+        )
       );
     });
 

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -196,7 +196,7 @@
   "theiaPlugins": {
     "vscode-builtin-cpp": "https://open-vsx.org/api/vscode/cpp/1.52.1/file/vscode.cpp-1.52.1.vsix",
     "vscode-arduino-api": "https://github.com/dankeboy36/vscode-arduino-api/releases/download/0.1.2/vscode-arduino-api-0.1.2.vsix",
-    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.1.2.vsix",
+    "vscode-arduino-tools": "https://downloads.arduino.cc/vscode-arduino-tools/vscode-arduino-tools-0.1.3.vsix",
     "vscode-builtin-json": "https://open-vsx.org/api/vscode/json/1.46.1/file/vscode.json-1.46.1.vsix",
     "vscode-builtin-json-language-features": "https://open-vsx.org/api/vscode/json-language-features/1.46.1/file/vscode.json-language-features-1.46.1.vsix",
     "cortex-debug": "https://downloads.arduino.cc/marus25.cortex-debug/marus25.cortex-debug-1.5.1.vsix",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -213,7 +213,6 @@
       "debuggingNotSupported": "Debugging is not supported by '{0}'",
       "getDebugInfo": "Getting debug info...",
       "noPlatformInstalledFor": "Platform is not installed for '{0}'",
-      "noProgrammerSelectedFor": "No programmer selected for '{0}'",
       "optimizeForDebugging": "Optimize for Debugging",
       "sketchIsNotCompiled": "Sketch '{0}' must be verified before starting a debug session. Please verify the sketch and start debugging again. Do you want to verify the sketch now?"
     },


### PR DESCRIPTION
### Motivation

<!-- Why this pull request? -->

Allow debugging when the platform supports it but has no programmer.

### Change description

 - No premature error when checking whether debugging is supported for a board without a selected programmer. This should help platforms without a programmer to keep the debug functionality. (https://github.com/arduino/arduino-ide/issues/2368#issuecomment-1945593840, https://github.com/earlephilhower/arduino-pico/issues/2003),
 - Update Arduino Tools VSIX version to `0.1.3`.
 - CI: use `go@1.21` to build the CLI on the fly from a commitish.

<!-- What does your code do? -->

### Other information

Ref: arduino/arduino-cli#2540
Ref: arduino/vscode-arduino-tools#47 

Closes: arduino/arduino-ide#2368

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
