### PR TITLE
fix(security): use `ip@2.0.1` for CVE-2023-42282

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "@theia/cli/@babel/traverse": "^7.23.2",
     "@theia/cli/@theia/application-package/nano": "^10.1.3",
     "**/@theia/core/msgpackr": "^1.10.1",
-    "nx/axios": "^1.6.7"
+    "nx/axios": "^1.6.7",
+    "**/ip": "^2.0.1"
   },
   "devDependencies": {
     "@theia/cli": "1.41.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7838,10 +7838,10 @@ ip-regex@^4.0.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
   integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
-ip@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.0.tgz#4cf4ab182fee2314c75ede1276f8c80b479936da"
-  integrity sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==
+ip@^2.0.0, ip@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-2.0.1.tgz#e8f3595d33a3ea66490204234b77636965307105"
+  integrity sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==
 
 ipaddr.js@1.9.1:
   version "1.9.1"


### PR DESCRIPTION
### Motivation

Update [`ip`](https://www.npmjs.com/package/ip) to fix security vulnerability CVE-2023-42282.

<!-- Why this pull request? -->

### Change description

<!-- What does your code do? -->

### Other information

Refs:
 - https://github.com/advisories/GHSA-78xj-cgh5-2h22
 - https://github.com/indutny/node-ip/commit/32f468f1245574785ec080705737a579be1223aa

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
