### PR TITLE
chore: switch to version `2.3.3` after the release

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide-extension",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "An extension for Theia building the Arduino IDE",
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "electron-app",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "license": "AGPL-3.0-or-later",
   "main": "./src-gen/backend/electron-main.js",
   "dependencies": {
@@ -19,7 +19,7 @@
     "@theia/preferences": "1.41.0",
     "@theia/terminal": "1.41.0",
     "@theia/workspace": "1.41.0",
-    "arduino-ide-extension": "2.3.2"
+    "arduino-ide-extension": "2.3.3"
   },
   "devDependencies": {
     "@theia/cli": "1.41.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Arduino IDE",
   "repository": "https://github.com/arduino/arduino-ide.git",
   "author": "Arduino SA",


### PR DESCRIPTION
## ~⚠️ MUST BE MERGED AFTER THE `2.3.2` RELEASE!~ Done ✅ 

### Motivation

<!-- Why this pull request? -->

Produce the nightly builds (and IDE2 updates) with the correct `2.3.3-nightly*` version.

### Change description

Bump version from `2.3.2` to `2.3.3`

<!-- What does your code do? -->

### Other information

See the [documentation](https://github.com/arduino/arduino-ide/blob/1b9c7e93e029e65765010eb84e1604b5e483a963/docs/internal/release-procedure.md#7-%EF%B8%8F-bump-version-metadata-of-packages) for more details on why we have to do this or reference a previous after-release version metadata bump PR [here](https://github.com/arduino/arduino-ide/pull/2369).

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
