### PR TITLE
fix: add missing installed version to the platform

### DIFF
--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -1,6 +1,7 @@
 import { ILogger } from '@theia/core/lib/common/logger';
 import { nls } from '@theia/core/lib/common/nls';
 import { notEmpty } from '@theia/core/lib/common/objects';
+import { Mutable } from '@theia/core/lib/common/types';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import {
   BoardDetails,
@@ -592,7 +593,7 @@ function createBoardsPackage(
   const availableVersions = Array.from(versionReleaseMap.keys())
     .sort(Installable.Version.COMPARATOR)
     .reverse();
-  return {
+  const boardsPackage: Mutable<BoardsPackage> = {
     id,
     name,
     summary: nls.localize(
@@ -607,6 +608,10 @@ function createBoardsPackage(
     deprecated,
     availableVersions,
   };
+  if (summary.installedVersion) {
+    boardsPackage.installedVersion = summary.installedVersion;
+  }
+  return boardsPackage;
 }
 
 type PlatformSummaryWithMetadata = PlatformSummary.AsObject &


### PR DESCRIPTION
### Motivation

IDE must correctly indicate when a platform is installed.


https://github.com/arduino/arduino-ide/assets/1405703/46fad8bf-42de-4de4-9ed7-ada55d79bfb7



<!-- Why this pull request? -->

### Change description

Sets the missing `installedVersion` property on the object.

<!-- What does your code do? -->

### Other information

<!-- Any additional information that could help the review process -->

Closes arduino/arduino-ide#2378

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
