### PR TITLE
fix: copy example with `.pde` main sketch file

### DIFF
--- a/arduino-ide-extension/src/node/sketches-service-impl.ts
+++ b/arduino-ide-extension/src/node/sketches-service-impl.ts
@@ -609,9 +609,13 @@ export class SketchesServiceImpl
       force: true,
     });
 
+    const sourceMainSketchFilePath = FileUri.fsPath(sketch.mainFileUri);
+    // Can copy sketch with pde main sketch file: https://github.com/arduino/arduino-ide/issues/2377
+    const ext = path.extname(sourceMainSketchFilePath);
+
     // rename the main sketch file
     await fs.rename(
-      join(temp, `${sourceFolderBasename}.ino`),
+      join(temp, `${sourceFolderBasename}${ext}`),
       join(temp, `${destinationFolderBasename}.ino`)
     );
 

--- a/arduino-ide-extension/src/test/node/sketches-service-impl.slow-test.ts
+++ b/arduino-ide-extension/src/test/node/sketches-service-impl.slow-test.ts
@@ -3,18 +3,19 @@ import {
   DisposableCollection,
 } from '@theia/core/lib/common/disposable';
 import { isWindows } from '@theia/core/lib/common/os';
+import { URI } from '@theia/core/lib/common/uri';
 import { FileUri } from '@theia/core/lib/node/file-uri';
 import { Container } from '@theia/core/shared/inversify';
 import { expect } from 'chai';
-import { promises as fs } from 'node:fs';
-import { basename, join } from 'node:path';
 import { rejects } from 'node:assert/strict';
+import { promises as fs } from 'node:fs';
+import path, { basename, join } from 'node:path';
 import { sync as rimrafSync } from 'rimraf';
 import temp from 'temp';
 import { Sketch, SketchesError, SketchesService } from '../../common/protocol';
 import {
-  isAccessibleSketchPath,
   SketchesServiceImpl,
+  isAccessibleSketchPath,
 } from '../../node/sketches-service-impl';
 import { ErrnoException } from '../../node/utils/errors';
 import { createBaseContainer, startDaemon } from './node-test-bindings';
@@ -330,6 +331,37 @@ describe('sketches-service-impl', () => {
         fs.readFile(join(destinationPath, logBasename)),
         ErrnoException.isENOENT
       );
+    });
+
+    it('should copy sketch if the main sketch file has pde extension (#2377)', async () => {
+      const sketchesService =
+        container.get<SketchesServiceImpl>(SketchesService);
+      let sketch = await sketchesService.createNewSketch();
+      toDispose.push(disposeSketch(sketch));
+      expect(sketch.mainFileUri.endsWith('.ino')).to.be.true;
+
+      // Create a sketch and rename the main sketch file to .pde
+      const mainSketchFilePathIno = FileUri.fsPath(new URI(sketch.mainFileUri));
+      const sketchFolderPath = path.dirname(mainSketchFilePathIno);
+      const mainSketchFilePathPde = path.join(
+        sketchFolderPath,
+        `${basename(sketchFolderPath)}.pde`
+      );
+      await fs.rename(mainSketchFilePathIno, mainSketchFilePathPde);
+
+      sketch = await sketchesService.loadSketch(sketch.uri);
+      expect(sketch.mainFileUri.endsWith('.pde')).to.be.true;
+
+      const tempDirPath = await sketchesService['createTempFolder']();
+      const destinationPath = join(tempDirPath, 'GH-2377');
+      const destinationUri = FileUri.create(destinationPath).toString();
+
+      await sketchesService.copy(sketch, {
+        destinationUri,
+      });
+
+      const copiedSketch = await sketchesService.loadSketch(destinationUri);
+      expect(copiedSketch.mainFileUri.endsWith('.ino')).to.be.true;
     });
 
     it('should copy sketch inside the sketch folder', async () => {


### PR DESCRIPTION
### Motivation

Fix the examples opening with the `.pde` main sketch file extension.


https://github.com/arduino/arduino-ide/assets/1405703/04467b9a-ac07-4d9d-8358-6e3608bd9be4

<!-- Why this pull request? -->

### Change description

Do not assume the `.ino` extension for the main sketch file when copying a sketch.

<!-- What does your code do? -->

### Other information

Closes arduino/arduino-ide#2377

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
