### PR TITLE
fix: disable open keymap split editor from toolbar

### DIFF
--- a/arduino-ide-extension/src/browser/theia/keymaps/keymaps-frontend-contribution.ts
+++ b/arduino-ide-extension/src/browser/theia/keymaps/keymaps-frontend-contribution.ts
@@ -1,14 +1,20 @@
+import { CommandRegistry } from '@theia/core/lib/common/command';
+import { MenuModelRegistry } from '@theia/core/lib/common/menu/menu-model-registry';
+import { nls } from '@theia/core/lib/common/nls';
 import { injectable } from '@theia/core/shared/inversify';
-import { MenuModelRegistry } from '@theia/core';
 import {
-  KeymapsFrontendContribution as TheiaKeymapsFrontendContribution,
   KeymapsCommands,
+  KeymapsFrontendContribution as TheiaKeymapsFrontendContribution,
 } from '@theia/keymaps/lib/browser/keymaps-frontend-contribution';
 import { ArduinoMenus } from '../../menu/arduino-menus';
-import { nls } from '@theia/core/lib/common';
 
 @injectable()
 export class KeymapsFrontendContribution extends TheiaKeymapsFrontendContribution {
+  override registerCommands(registry: CommandRegistry): void {
+    super.registerCommands(registry);
+    registry.unregisterCommand(KeymapsCommands.OPEN_KEYMAPS_JSON_TOOLBAR.id);
+  }
+
   override registerMenus(menus: MenuModelRegistry): void {
     menus.registerMenuAction(ArduinoMenus.FILE__ADVANCED_SUBMENU, {
       commandId: KeymapsCommands.OPEN_KEYMAPS.id,


### PR DESCRIPTION
### Motivation

<!-- Why this pull request? -->

The complete support for split editor is yet to be added to IDE2. For now, this commit turns off opening the keymaps in the JSON split editor. So that it cannot get the primary IDE2 layout into an inconsistent state.

### Change description

<!-- What does your code do? -->

### Other information

Closes arduino/arduino-ide#1850

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
