### PR TITLE
feat: can skip verify before upload

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -137,6 +137,18 @@ const properties: ArduinoPreferenceSchemaProperties = {
   'arduino.upload.verify': {
     type: 'boolean',
     default: false,
+    description: nls.localize(
+      'arduino/preferences/upload.verify',
+      'After upload, verify that the contents of the memory on the board match the uploaded binary.'
+    ),
+  },
+  'arduino.upload.autoVerify': {
+    type: 'boolean',
+    default: true,
+    description: nls.localize(
+      'arduino/preferences/upload.autoVerify',
+      "True if the IDE should automatically verify the code before the upload. True by default. When this value is false, IDE does not recompile the code before uploading the binary to the board. It's highly advised to only set this value to false if you know what you are doing."
+    ),
   },
   'arduino.window.autoScale': {
     type: 'boolean',
@@ -319,6 +331,7 @@ export interface ArduinoConfiguration {
   'arduino.compile.warnings': CompilerWarnings;
   'arduino.upload.verbose': boolean;
   'arduino.upload.verify': boolean;
+  'arduino.upload.autoVerify': boolean;
   'arduino.window.autoScale': boolean;
   'arduino.ide.updateChannel': UpdateChannel;
   'arduino.ide.updateBaseUrl': string;

--- a/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/upload-sketch.ts
@@ -104,6 +104,7 @@ export class UploadSketch extends CoreServiceContribution {
     }
 
     try {
+      const autoVerify = this.preferences['arduino.upload.autoVerify'];
       // toggle the toolbar button and menu item state.
       // uploadInProgress will be set to false whether the upload fails or not
       this.uploadInProgress = true;
@@ -116,7 +117,7 @@ export class UploadSketch extends CoreServiceContribution {
           'arduino-verify-sketch',
           <VerifySketchParams>{
             exportBinaries: false,
-            silent: true,
+            mode: autoVerify ? 'auto' : 'dry-run',
           }
         );
       if (!verifyOptions) {

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -411,7 +411,9 @@
       "survey.notification": "True if users should be notified if a survey is available. True by default.",
       "unofficialBoardSupport": "Click for a list of unofficial board support URLs",
       "upload": "upload",
+      "upload.autoVerify": "True if the IDE should automatically verify the code before the upload. True by default. When this value is false, IDE does not recompile the code before uploading the binary to the board. It's highly advised to only set this value to false if you know what you are doing.",
       "upload.verbose": "True for verbose upload output. False by default.",
+      "upload.verify": "After upload, verify that the contents of the memory on the board match the uploaded binary.",
       "verifyAfterUpload": "Verify code after upload",
       "window.autoScale": "True if the user interface automatically scales with the font size.",
       "window.zoomLevel": {


### PR DESCRIPTION
### Motivation

From [here](https://forum.arduino.cc/t/add-an-option-to-upload-without-recompiling/1213940):

> For example, I'm now developing using for an ESP32. It requires that I hold down the EN button to put the board into the correct mode to accept the download. It's a tiny button that's hard to hold down, and if I forget to push it or accidentally release it too soon, I'm forced to wait for a long compile before I can try it again.

> I also need to program three of these boards with identical code. Again, I have to sit and wait through multiple compiles that produce exactly the same binary.

<!-- Why this pull request? -->

### Change description

This PR adds a new preference to control whether the verify command should automatically run before the upload. If the `arduino.upload.autoVerify` setting value is `false`, IDE does not recompile the sketch code before uploading it to the board.


https://github.com/arduino/arduino-ide/assets/111981763/64d53901-05d1-4dc3-b4c0-f260662a2d7d


<!-- What does your code do? -->

### Other information

 - Download the [tester build](https://github.com/arduino/arduino-ide/blob/main/docs/contributor-guide/beta-testing.md#testing-pull-requests) from this PR,
 - Set the `arduino.upload.autoVerify` [advanced settings](https://github.com/arduino/arduino-ide/blob/main/docs/advanced-usage.md#advanced-settings) to `false`,
 - Run an upload,
 - IDE does not recompile the code.

<!-- Any additional information that could help the review process -->

Reference the [Beta Testing Guide](https://github.com/arduino/arduino-ide/blob/main/docs/contributor-guide/beta-testing.md#beta-testing-guide) documentation on how to use this tester build.

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
