### PR TITLE
feat: upload using programmer by default if board requires it

### DIFF
--- a/arduino-ide-extension/src/common/protocol/core-service.ts
+++ b/arduino-ide-extension/src/common/protocol/core-service.ts
@@ -71,6 +71,7 @@ export namespace CoreError {
     Upload: 4002,
     UploadUsingProgrammer: 4003,
     BurnBootloader: 4004,
+    UploadRequiresProgrammer: 4005,
   };
   export const VerifyFailed = declareCoreError(Codes.Verify);
   export const UploadFailed = declareCoreError(Codes.Upload);
@@ -78,6 +79,10 @@ export namespace CoreError {
     Codes.UploadUsingProgrammer
   );
   export const BurnBootloaderFailed = declareCoreError(Codes.BurnBootloader);
+  export const UploadRequiresProgrammer = declareCoreError(
+    Codes.UploadRequiresProgrammer
+  );
+
   export function is(
     error: unknown
   ): error is ApplicationError<number, ErrorLocation[]> {

--- a/arduino-ide-extension/src/node/service-error.ts
+++ b/arduino-ide-extension/src/node/service-error.ts
@@ -1,14 +1,54 @@
 import { Metadata, StatusObject } from '@grpc/grpc-js';
+import { Status } from './cli-protocol/google/rpc/status_pb';
+import { stringToUint8Array } from '../common/utils';
+import { ProgrammerIsRequiredForUploadError } from './cli-protocol/cc/arduino/cli/commands/v1/upload_pb';
+
+type ProtoError = typeof ProgrammerIsRequiredForUploadError;
+const protoErrorsMap = new Map<string, ProtoError>([
+  [
+    'type.googleapis.com/cc.arduino.cli.commands.v1.ProgrammerIsRequiredForUploadError',
+    ProgrammerIsRequiredForUploadError,
+  ],
+  // handle other cli defined errors here
+]);
 
 export type ServiceError = StatusObject & Error;
 export namespace ServiceError {
   export function isCancel(arg: unknown): arg is ServiceError & { code: 1 } {
     return is(arg) && arg.code === 1; // https://grpc.github.io/grpc/core/md_doc_statuscodes.html
   }
+
   export function is(arg: unknown): arg is ServiceError {
-    return arg instanceof Error && isStatusObjet(arg);
+    return arg instanceof Error && isStatusObject(arg);
   }
-  function isStatusObjet(arg: unknown): arg is StatusObject {
+
+  export function isInstanceOf(arg: unknown, type: unknown): boolean {
+    if (!isStatusObject(arg)) {
+      return false;
+    }
+
+    const bin = arg.metadata.get('grpc-status-details-bin')[0];
+
+    const uint8Array =
+      typeof bin === 'string'
+        ? stringToUint8Array(bin)
+        : new Uint8Array(bin.buffer, bin.byteOffset, bin.byteLength);
+
+    const errors = Status.deserializeBinary(uint8Array)
+      .getDetailsList()
+      .map((details) => {
+        const typeUrl = details.getTypeUrl();
+        const ErrorType = protoErrorsMap.get(typeUrl);
+        return ErrorType?.deserializeBinary(details.getValue_asU8());
+      });
+
+    return !!errors.find((error) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return error && error instanceof <any>type;
+    });
+  }
+
+  function isStatusObject(arg: unknown): arg is StatusObject {
     if (typeof arg === 'object') {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const any = arg as any;


### PR DESCRIPTION
### Motivation

https://github.com/arduino/arduino-ide/issues/103

### Change description

1. Add utility to map grcp errors to custom generated CLI errors
2. If default upload fails with `ProgrammerIsRequiredForUploadError` , perform upload request again using selected programmer



### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
