### PR TITLE
Use `macos-13` for Intel build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ env:
           name: Linux_X86-64_app_image
     - config:
         name: macOS x86
-        runs-on: macos-latest
+        runs-on: macos-13
         container: |
           null
         # APPLE_SIGNING_CERTIFICATE_P12 secret was produced by following the procedure from:


### PR DESCRIPTION
### Motivation

We noticed the CI builds are no longer producing artifacts for intel mac.

This is due to the fact that Github Actions runners referenced with "macos-latest", i.e. MacOS v14 OS runners, will now default to arm systems.

At the moment the only intel based Mac OS 14 runner image is `macos-14-large` ([ref](https://github.com/actions/runner-images/issues/9741#issuecomment-2075259811)) which is a paid solution.

We've decided to change the referenced image to "macos-13" as a work-around, to start reproducing the intel builds of IDE 2.x whilst avoiding additional cost.

### Change description

Change the referenced image to "macos-13" in `build.yml`

### Other information

https://github.com/actions/runner-images/issues/9741

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
