### PR TITLE
Use `macos-latest` runner for macOS ARM build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,10 +113,9 @@ env:
           name: macOS_X86-64_dmg
         - path: '*macOS_64bit.zip'
           name: macOS_X86-64_zip
-  PAID_RUNNER_BUILD_DATA: |
     - config:
         name: macOS ARM
-        runs-on: macos-latest-xlarge
+        runs-on: macos-latest
         container: |
           null
         certificate-secret: APPLE_SIGNING_CERTIFICATE_P12


### PR DESCRIPTION
### Motivation

MacOS ARM build does not required a paid build solution anymore as `macos-latest` workflow uses Apple silicon machines by default. 
