### PR TITLE
fix(doc): add missing prerequisites to dev docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -50,6 +50,7 @@ This repository contains the main code, but two more repositories are included d
 
 - To build the application, follow the Theia IDE [prerequisites](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites).
 - This project recommends using [Visual Studio Code (VS Code)](https://code.visualstudio.com/) for the development.
+- Optionally, you might need to build the [Arduino CLI](https://github.com/arduino/arduino-cli), the [Arduino Language Server](https://github.com/arduino/arduino-language-server), and other tools from the sources. For more details, refer to the Arduino CLI's [prerequisites section](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#prerequisites).
 
 ## Build from source
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -50,7 +50,7 @@ This repository contains the main code, but two more repositories are included d
 
 - To build the application, follow the Theia IDE [prerequisites](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites).
 - This project recommends using [Visual Studio Code (VS Code)](https://code.visualstudio.com/) for the development.
-- Optionally, you might need to build the [Arduino CLI](https://github.com/arduino/arduino-cli), the [Arduino Language Server](https://github.com/arduino/arduino-language-server), and other tools from the sources. For more details, refer to the Arduino CLI's [prerequisites section](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#prerequisites).
+- The build system might also need to build the [Arduino CLI](https://github.com/arduino/arduino-cli), the [Arduino Language Server](https://github.com/arduino/arduino-language-server), and other tools from the sources. In this case it is also necessary to have the build prerequisites for those projects installed. For more details, refer to the Arduino CLI's [prerequisites section](https://arduino.github.io/arduino-cli/latest/CONTRIBUTING/#prerequisites).
 
 ## Build from source
 


### PR DESCRIPTION
### Motivation

When the IDE depends on a non-released version of the Arduino CLI, LS, etc., tools, it must check out the corresponding pinned commit from Git and build them from the sources. This process requires Go, but it's preferable to use [taskfile](https://taskfile.dev/) for the correct timestamps and dev versions. This pull request refers to the existing documentation of the Arduino CLI, and it should be sufficient to build all other binaries.

<!-- Why this pull request? -->

### Change description

Document prerequisites of the Arduino CLI, LS, etc. tools when built from a Git commitish.

<!-- What does your code do? -->

### Other information

The preview version of the change: https://github.com/arduino/arduino-ide/blob/fda5a5f7714aea8fb4c447fa650e839a1473553d/docs/development.md#prerequisites.

closes: arduino/arduino-ide#2499

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
