### PR TITLE
Bump version metadata post release

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide-extension",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "An extension for Theia building the Arduino IDE",
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "electron-app",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "license": "AGPL-3.0-or-later",
   "main": "./src-gen/backend/electron-main.js",
   "dependencies": {
@@ -19,7 +19,7 @@
     "@theia/preferences": "1.41.0",
     "@theia/terminal": "1.41.0",
     "@theia/workspace": "1.41.0",
-    "arduino-ide-extension": "2.3.3"
+    "arduino-ide-extension": "2.3.4"
   },
   "devDependencies": {
     "@theia/cli": "1.41.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Arduino IDE",
   "repository": "https://github.com/arduino/arduino-ide.git",
   "author": "Arduino SA",


### PR DESCRIPTION
### Motivation

On every startup, Arduino IDE checks for new versions of the IDE. If a newer version is available, a notification/dialog is shown offering an update.

"Newer" is determined by comparing the version of the user's IDE to the latest available version on the update channel. This comparison is done according to [the Semantic Versioning Specification](https://semver.org/) ("SemVer").
In order to facilitate [beta testing](https://github.com/arduino/arduino-ide/blob/main/docs/contributor-guide/beta-testing.md#beta-testing-guide), builds are generated of the Arduino IDE at the each stage in development. These builds are given an identifying version of the following form:

- `<version>-snapshot-<short hash>` - builds generated for every push and pull request that modifies relevant files
- `<version>-nightly-<YYYYMMDD>` - daily builds of the tip of the default branch

### Change description

In order to cause these builds to be correctly considered "newer" than the release version, the version metadata must be bumped immediately following each release. This was not done for the 2.3.3 release.

The change proposed here will also serve as the metadata bump for the next release in the event that release is a minor release. In case it is instead a minor or major release, the version metadata will need to be updated once more before the release tag is created.

### Other information

Fixes https://github.com/arduino/arduino-ide/issues/2538

Reference:

https://github.com/arduino/arduino-ide/blob/main/docs/internal/release-procedure.md#4-%EF%B8%8F-bump-version-metadata-of-packages

Related:

- https://github.com/arduino/arduino-ide/issues/1440

### Reviewer checklist

* [ ] PR addresses a single concern.
* [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
* [ ] PR title and description are properly filled.
* [ ] Docs have been added / updated (for bug fixes / features)