### PR TITLE
fix: disable local windows signing for external contributions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -286,6 +286,8 @@ jobs:
       SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.19041.0/x86/signtool.exe"
       WIN_CERT_PASSWORD: ${{ secrets.INSTALLER_CERT_WINDOWS_PASSWORD }}
       WIN_CERT_CONTAINER_NAME: ${{ secrets.INSTALLER_CERT_WINDOWS_CONTAINER }}
+      WIN_SIGNING_ENABLED: ${{ !github.event.pull_request.head.repo.fork }}
+
     strategy:
       matrix:
         config: ${{ fromJson(needs.select-targets.outputs.build-matrix) }}

--- a/electron-app/scripts/windowsCustomSign.js
+++ b/electron-app/scripts/windowsCustomSign.js
@@ -1,7 +1,10 @@
 const childProcess = require('child_process');
 
 exports.default = async function (configuration) {
-  if (!process.env.GITHUB_ACTIONS) {
+  if (
+    !process.env.GITHUB_ACTIONS ||
+    process.env.WIN_SIGNING_ENABLED !== 'true'
+  ) {
     return;
   }
 


### PR DESCRIPTION
### Motivation

### Change description

Disable windows signing for pull requests coming from forks.

### Other information

Resolves https://github.com/arduino/arduino-ide/issues/2545

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
