### PR TITLE
Simplify and generalize configurable working directory code in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -378,7 +378,7 @@ jobs:
           CREATE_USERNAME: ${{ secrets.CREATE_USERNAME }}
           CREATE_PASSWORD: ${{ secrets.CREATE_PASSWORD }}
           CREATE_CLIENT_SECRET: ${{ secrets.CREATE_CLIENT_SECRET }}
-        working-directory: ${{ runner.os == 'Windows' && matrix.config.working-directory || './' }}
+        working-directory: ${{ matrix.config.working-directory || './' }}
         run: |
           # See: https://www.electron.build/code-signing
           if [ $CAN_SIGN = false ] || [ $IS_WINDOWS_CONFIG = true ]; then
@@ -408,7 +408,7 @@ jobs:
         if: >
           needs.select-targets.outputs.merge-channel-files == 'true' &&
           matrix.config.mergeable-channel-file == 'true'
-        working-directory: ${{ runner.os == 'Windows' && matrix.config.working-directory || './' }}
+        working-directory: ${{ matrix.config.working-directory || './' }}
         run: |
           staged_channel_files_path="${{ runner.temp }}/staged-channel-files"
           mkdir "$staged_channel_files_path"
@@ -428,13 +428,13 @@ jobs:
         with:
           if-no-files-found: error
           name: ${{ env.STAGED_CHANNEL_FILES_ARTIFACT }}
-          path: ${{ runner.os == 'Windows' && matrix.config.working-directory && format('{0}/{1}', matrix.config.working-directory, env.STAGED_CHANNEL_FILES_PATH) || env.STAGED_CHANNEL_FILES_PATH }}
+          path: ${{ matrix.config.working-directory && format('{0}/{1}', matrix.config.working-directory, env.STAGED_CHANNEL_FILES_PATH) || env.STAGED_CHANNEL_FILES_PATH }}
 
       - name: Upload [GitHub Actions]
         uses: actions/upload-artifact@v3
         with:
           name: ${{ env.JOB_TRANSFER_ARTIFACT }}
-          path: ${{ runner.os == 'Windows' && matrix.config.working-directory && format('{0}/{1}', matrix.config.working-directory, env.BUILD_ARTIFACTS_PATH) || env.BUILD_ARTIFACTS_PATH }}
+          path: ${{ matrix.config.working-directory && format('{0}/{1}', matrix.config.working-directory, env.BUILD_ARTIFACTS_PATH) || env.BUILD_ARTIFACTS_PATH }}
 
       - name: Manual Clean up for self-hosted runners
         if: runner.os == 'Windows' && matrix.config.working-directory


### PR DESCRIPTION
### Motivation

The Windows builds of the application are cryptographically signed. The signing requires an "eToken" hardware authentication device be connected to the machine performing the signing (https://github.com/arduino/arduino-ide/pull/2452). This means that it is necessary to use a [self-hosted GitHub Actions runner](https://docs.github.com/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners) for the Windows job of the build workflow rather than the [runners hosted by GitHub](https://docs.github.com/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners).

There are some unique characteristics of the self-hosted runner which the workflow code must accommodate. The default working directory of the self-hosted runner is not suitable to perform the build under because the the resulting folder structure produced paths that exceeded the ridiculously small [maximum path length of Windows](https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation). So the workflow must be configured to use a [custom working directory](https://docs.github.com/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsworking-directory) with a short path (`C:\a`).

This custom working directory must be used only for the job running on the self-hosted Windows runner so the working directory of the relevant workflow steps are configured using a [ternary expression](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#:~:text=GitHub%20offers%20ternary%20operator). Previously, this expression had multiple conditions:

* the value of the [`runner.os` context item](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context:~:text=the%20same%20name.-,runner.os,-string)
* the definition of a custom working directory value in the [job matrix](https://docs.github.com/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix)

The second condition is entirely sufficient. The use of the first condition only added unnecessary complexity to the workflow code, and imposed a pointless limitation of only allowing the use of the custom working directory system on Windows runners.

### Change description

Remove the unnecessary condition from the ternary expressions used to configure the working directory of workflow steps.

This makes the workflow easier to understand and maintain, and makes it possible to configure any job to use a custom working directory if necessary.

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
