### PR TITLE
Use appropriate indicator for dependency installation conditionals in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -321,7 +321,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Node.js
-        if: fromJSON(matrix.config.container) == null && runner.os != 'Windows'
+        if: fromJSON(matrix.config.container) == null && runner.name != 'WINDOWS-SIGN-PC'
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
@@ -329,26 +329,26 @@ jobs:
           cache: 'yarn'
 
       - name: Install Python 3.x
-        if: fromJSON(matrix.config.container) == null && runner.os != 'Windows'
+        if: fromJSON(matrix.config.container) == null && runner.name != 'WINDOWS-SIGN-PC'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11.x'
 
       - name: Install Go
-        if: fromJSON(matrix.config.container) == null && runner.os != 'Windows'
+        if: fromJSON(matrix.config.container) == null && runner.name != 'WINDOWS-SIGN-PC'
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install Go
         # actions/setup-go@v5 has dependency on a higher version of glibc than available in the Linux container.
-        if: fromJSON(matrix.config.container) != null && runner.os != 'Windows'
+        if: fromJSON(matrix.config.container) != null && runner.name != 'WINDOWS-SIGN-PC'
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Install Taskfile
-        if: fromJSON(matrix.config.container) == null && runner.os != 'Windows'
+        if: fromJSON(matrix.config.container) == null && runner.name != 'WINDOWS-SIGN-PC'
         uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -356,7 +356,7 @@ jobs:
 
       - name: Install Taskfile
         # actions/setup-task@v2 has dependency on a higher version of glibc than available in the Linux container.
-        if: fromJSON(matrix.config.container) != null && runner.os != 'Windows'
+        if: fromJSON(matrix.config.container) != null && runner.name != 'WINDOWS-SIGN-PC'
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Motivation

The Windows builds of the application are cryptographically signed. The signing requires an "eToken" hardware authentication device be connected to the machine performing the signing. This means that it is necessary to use a [self-hosted GitHub Actions runner](https://docs.github.com/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners) for the Windows job of the build workflow rather than the [runners hosted by GitHub](https://docs.github.com/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners) (https://github.com/arduino/arduino-ide/pull/2452).

There are some unique characteristics of the self-hosted runner which the workflow code must accommodate. One of these is that, rather than installing dependencies of the build process during the workflow run as is done for the GitHub-hosted runners, the dependencies are preinstalled in the self-hosted runner machine. So the dependency installation steps must be configured so that they will be skipped when the job is running on the self-hosted runner.

This is done by adding a [conditional to the steps](https://docs.github.com/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsif). Previously the conditional was based on the value of the [`runner.os` context item](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context:~:text=the%20same%20name.-,runner.os,-string). This is not an appropriate indicator of the job running on the self-hosted runner because `runner.os` will have the same value if the job was running on a GitHub-hosted Windows runner. That might seem like only a hypothetical problem since the workflow does not use a GitHub-hosted Windows runner. However, it is important to support the use of the workflow in forks of the repository. In addition to the possible value to hard forked projects, this is essential to allow conscientious contributors to test contributions to the build and release system in their own fork prior to submitting a pull request.

### Change description

The conditionals are changed to use the more appropriate indicator of the specific name of the self-hosted Windows runner via the [`runner.name` context item](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context:~:text=properties%20listed%20below.-,runner.name,-string).

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
