### PR TITLE
Get job-specific configuration from matrix in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -288,8 +288,8 @@ jobs:
       # We are hardcoding the path for signtool because is not present on the windows PATH env var by default.
       # Keep in mind that this path could change when upgrading to a new runner version
       SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.19041.0/x86/signtool.exe"
-      WIN_CERT_PASSWORD: ${{ secrets.INSTALLER_CERT_WINDOWS_PASSWORD }}
-      WIN_CERT_CONTAINER_NAME: ${{ secrets.INSTALLER_CERT_WINDOWS_CONTAINER }}
+      WIN_CERT_PASSWORD: ${{ secrets[matrix.config.certificate-password-secret] }}
+      WIN_CERT_CONTAINER_NAME: ${{ secrets[matrix.config.certificate-container] }}
       WIN_SIGNING_ENABLED: ${{ !github.event.pull_request.head.repo.fork }}
 
     strategy:


### PR DESCRIPTION
### Motivation

The "build" workflow builds the application for a range of target hosts. This is done by using a [job matrix](https://docs.github.com/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix). A separate parallel job runs for each target. The target-specific configuration data is defined in the job matrix array.

This configuration data includes the information related to the code signing certificates. Inexplicably, during the work to add support for signing the Windows builds with an "eToken" hardware authentication device (https://github.com/arduino/arduino-ide/pull/2452), this data was not used for the Windows code signing configuration. Instead the certificate data was redundantly hardcoded into the workflow code.

### Change description

Use the established flexible job configuration data system for configuring the Windows code signing certificate.

This makes the workflow easier to understand and maintain.

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
