### PR TITLE
Remove inaccurate and redundant signing determination code from build system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,6 @@ jobs:
       SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.19041.0/x86/signtool.exe"
       WIN_CERT_PASSWORD: ${{ secrets[matrix.config.certificate-password-secret] }}
       WIN_CERT_CONTAINER_NAME: ${{ secrets[matrix.config.certificate-container] }}
-      WIN_SIGNING_ENABLED: ${{ secrets[matrix.config.certificate-password-secret] != '' }}
 
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -290,7 +290,7 @@ jobs:
       SIGNTOOL_PATH: "C:/Program Files (x86)/Windows Kits/10/bin/10.0.19041.0/x86/signtool.exe"
       WIN_CERT_PASSWORD: ${{ secrets[matrix.config.certificate-password-secret] }}
       WIN_CERT_CONTAINER_NAME: ${{ secrets[matrix.config.certificate-container] }}
-      WIN_SIGNING_ENABLED: ${{ !github.event.pull_request.head.repo.fork }}
+      WIN_SIGNING_ENABLED: ${{ secrets[matrix.config.certificate-password-secret] != '' }}
 
     strategy:
       matrix:

--- a/electron-app/scripts/windowsCustomSign.js
+++ b/electron-app/scripts/windowsCustomSign.js
@@ -1,10 +1,7 @@
 const childProcess = require('child_process');
 
 exports.default = async function (configuration) {
-  if (
-    !process.env.GITHUB_ACTIONS ||
-    process.env.WIN_SIGNING_ENABLED !== 'true'
-  ) {
+  if (!process.env.GITHUB_ACTIONS || process.env.CAN_SIGN !== 'true') {
     return;
   }
 


### PR DESCRIPTION
### Motivation

The "build" workflow signs the macOS and Windows builds of the application. The signing process relies on access to [GitHub Actions secrets](https://docs.github.com/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions). For this reason, the workflow is configured to only sign the builds when it has access to GitHub Actions secrets to avoid spurious failures of the workflow that would otherwise be caused by signing failure.

A flexible general purpose system for accurately determining whether to attempt signing of a build was established years ago (https://github.com/arduino/arduino-ide/pull/1115) However, when the Windows signing system was reworked to support the new "eToken" hardware authenticator-based approach (https://github.com/arduino/arduino-ide/pull/2452), that system was circumvented, causing workflow runs triggered by pull requests to fail spuriously (https://github.com/arduino/arduino-ide/issues/2545). When this was later discovered, an inferior redundant system was added (https://github.com/arduino/arduino-ide/pull/2554) specific to the Windows build instead of just using the existing system.

This redundant system determines whether to sign based on the value of the [`github.event.pull_request.head.repo.fork` context item](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context:~:text=GitHub%20Actions.%22-,github.event,-object). That is effective for the use case of the workflow being triggered by a pull request from a fork (for security reasons, [GitHub Actions does not give access to secrets under these conditions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow:~:text=secrets%20are%20not%20passed%20to%20the%20runner%20when%20a%20workflow%20is%20triggered%20from%20a%20forked%20repository)).

However, there is another context under which the workflow might run without access to the signing secrets, for which the use of context item is not appropriate. It is important to support the use of the workflow in forks of the repository. In addition to the possible value to hard forked projects, this is essential to allow conscientious contributors to test contributions to the build and release system in their own fork prior to submitting a pull request. The previous configuration would cause a workflow run performed by a contributor in a fork to attempt to sign the Windows build. Unless the contributor had set up the ridiculously complex infrastructure required to perform the signing for the Windows build (https://github.com/arduino/arduino-ide/pull/2452), which is utterly infeasible, this would cause the workflow to fail spuriously:

```text
Custom windows signing was no performed one of the following variables was not provided: SIGNTOOL_PATH (C:/Program Files (x86)/Windows Kits/10/bin/10.0.19041.0/x86/signtool.exe), INSTALLER_CERT_WINDOWS_CERT (C:/Users/RUNNER~1/AppData/Local/Temp/cert.cer), CERT_PASSWORD (), CONTAINER_NAME ()
file:///D:/a/arduino-ide/arduino-ide/electron-app/node_modules/execa/lib/error.js:60
		error = new Error(message);
		        ^

Error: Command failed with exit code 1: electron-builder --publish never -c.electronVersion 27.0.3 -c.extraMetadata.version 2.3.4 -c.extraMetadata.name arduino-ide -c.win.artifactName arduino-ide_2.3.4_Windows_64bit.${ext} -c.extraMetadata.theia.frontend.config.appVersion 2.3.4 -c.extraMetadata.theia.frontend.config.cliVersion 1.0.4 -c.extraMetadata.theia.frontend.config.buildDate 2024-11-16T13:27:51.643Z -c.extraMetadata.main ./arduino-ide-electron-main.js
    at makeError (file:///D:/a/arduino-ide/arduino-ide/electron-app/node_modules/execa/lib/error.js:60:11)
    at handlePromise (file:///D:/a/arduino-ide/arduino-ide/electron-app/node_modules/execa/index.js:124:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async exec (D:\a\arduino-ide\arduino-ide\electron-app\scripts\package.js:162:22)
    at async run (D:\a\arduino-ide\arduino-ide\electron-app\scripts\package.js:49:3) {
  shortMessage: 'Command failed with exit code 1: electron-builder --publish never -c.electronVersion 27.0.3 -c.extraMetadata.version 2.3.4 -c.extraMetadata.name arduino-ide -c.win.artifactName arduino-ide_2.3.4_Windows_64bit.${ext} -c.extraMetadata.theia.frontend.config.appVersion 2.3.4 -c.extraMetadata.theia.frontend.config.cliVersion 1.0.4 -c.extraMetadata.theia.frontend.config.buildDate 2024-11-16T13:27:51.643Z -c.extraMetadata.main ./arduino-ide-electron-main.js',
  command: 'electron-builder --publish never -c.electronVersion 27.0.3 -c.extraMetadata.version 2.3.4 -c.extraMetadata.name arduino-ide -c.win.artifactName arduino-ide_2.3.4_Windows_64bit.${ext} -c.extraMetadata.theia.frontend.config.appVersion 2.3.4 -c.extraMetadata.theia.frontend.config.cliVersion 1.0.4 -c.extraMetadata.theia.frontend.config.buildDate 2024-11-16T13:27:51.643Z -c.extraMetadata.main ./arduino-ide-electron-main.js',
  escapedCommand: 'electron-builder --publish never -c.electronVersion 27.0.3 -c.extraMetadata.version 2.3.4 -c.extraMetadata.name arduino-ide -c.win.artifactName "arduino-ide_2.3.4_Windows_64bit.${ext}" -c.extraMetadata.theia.frontend.config.appVersion 2.3.4 -c.extraMetadata.theia.frontend.config.cliVersion 1.0.4 -c.extraMetadata.theia.frontend.config.buildDate "2024-11-16T13:27:51.643Z" -c.extraMetadata.main "./arduino-ide-electron-main.js"',
  exitCode: 1,
  signal: undefined,
  signalDescription: undefined,
  stdout: undefined,
  stderr: undefined,
  cwd: 'D:\\a\\arduino-ide\\arduino-ide\\electron-app',
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}

Node.js v18.17.1
error Command failed with exit code 1.
```

### Change description

Remove the inferior and redundant signing determination code and use the previously established system for all targets.

This makes the workflow easier to understand and maintain.

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
