### PR TITLE
Move non-build tasks to dedicated GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -395,7 +395,6 @@ jobs:
           yarn --cwd arduino-ide-extension build
           yarn test
           yarn --cwd arduino-ide-extension test:slow
-          yarn --cwd arduino-ide-extension lint
 
           yarn --cwd electron-app rebuild
           yarn --cwd electron-app build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,11 +372,6 @@ jobs:
           IS_NIGHTLY: ${{ needs.build-type-determination.outputs.is-nightly }}
           IS_RELEASE: ${{ needs.build-type-determination.outputs.is-release }}
           CAN_SIGN: ${{ secrets[matrix.config.certificate-secret] != '' }}
-          # The CREATE_* environment vars are only used to run tests. These secrets are optional. Dependent tests will
-          # be skipped if not available.
-          CREATE_USERNAME: ${{ secrets.CREATE_USERNAME }}
-          CREATE_PASSWORD: ${{ secrets.CREATE_PASSWORD }}
-          CREATE_CLIENT_SECRET: ${{ secrets.CREATE_CLIENT_SECRET }}
         working-directory: ${{ matrix.config.working-directory || './' }}
         run: |
           # See: https://www.electron.build/code-signing
@@ -393,9 +388,6 @@ jobs:
           yarn install --immutable
 
           yarn --cwd arduino-ide-extension build
-          yarn test
-          yarn --cwd arduino-ide-extension test:slow
-
           yarn --cwd electron-app rebuild
           yarn --cwd electron-app build
           yarn --cwd electron-app package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -385,7 +385,7 @@ jobs:
           fi
 
           npx node-gyp install
-          yarn install --immutable
+          yarn install
 
           yarn --cwd arduino-ide-extension build
           yarn --cwd electron-app rebuild

--- a/.github/workflows/check-javascript.yml
+++ b/.github/workflows/check-javascript.yml
@@ -1,0 +1,88 @@
+# Source: https://github.com/arduino/tooling-project-assets/blob/main/workflow-templates/check-javascript-task.md
+name: Check JavaScript
+
+env:
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: 18.17
+
+# See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
+on:
+  create:
+  push:
+    paths:
+      - '.github/workflows/check-javascript.ya?ml'
+      - '**/.eslintignore'
+      - '**/.eslintrc*'
+      - '**/.npmrc'
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '**/yarn.lock'
+      - '**.jsx?'
+  pull_request:
+    paths:
+      - '.github/workflows/check-javascript.ya?ml'
+      - '**/.eslintignore'
+      - '**/.eslintrc*'
+      - '**/.npmrc'
+      - '**/package.json'
+      - '**/package-lock.json'
+      - '**/yarn.lock'
+      - '**.jsx?'
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
+  check:
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install npm package dependencies
+        env:
+          # Avoid failure of @vscode/ripgrep installation due to GitHub API rate limiting:
+          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          yarn install
+
+      - name: Lint
+        run: |
+          yarn \
+            --cwd arduino-ide-extension \
+            lint

--- a/.github/workflows/check-yarn.yml
+++ b/.github/workflows/check-yarn.yml
@@ -1,0 +1,91 @@
+name: Check Yarn
+
+# See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  create:
+  push:
+    paths:
+      - ".github/workflows/check-yarn.ya?ml"
+      - "**/.yarnrc"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/yarn.lock"
+  pull_request:
+    paths:
+      - ".github/workflows/check-yarn.ya?ml"
+      - "**/.yarnrc"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/yarn.lock"
+  schedule:
+    # Run every Tuesday at 8 AM UTC to catch breakage resulting from changes to the JSON schema.
+    - cron: "0 8 * * TUE"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
+  check-sync:
+    name: check-sync (${{ matrix.project.path }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - path: .
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install npm package dependencies
+        env:
+          # Avoid failure of @vscode/ripgrep installation due to GitHub API rate limiting:
+          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          yarn \
+            install \
+            --ignore-scripts
+
+      - name: Check yarn.lock
+        run: |
+          git \
+            diff \
+              --color \
+              --exit-code \
+              "${{ matrix.project.path }}/yarn.lock"

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -1,0 +1,134 @@
+name: Test JavaScript
+
+env:
+  # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
+  GO_VERSION: '1.21'
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: 18.17
+
+on:
+  push:
+    paths:
+      - ".github/workflows/test-javascript.ya?ml"
+      - "**/.mocharc.js"
+      - "**/.mocharc.jsonc?"
+      - "**/.mocharc.ya?ml"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/yarn.lock"
+      - "tests/testdata/**"
+      - "**/tsconfig.json"
+      - "**.[jt]sx?"
+  pull_request:
+    paths:
+      - ".github/workflows/test-javascript.ya?ml"
+      - "**/.mocharc.js"
+      - "**/.mocharc.jsonc?"
+      - "**/.mocharc.ya?ml"
+      - "**/package.json"
+      - "**/package-lock.json"
+      - "**/yarn.lock"
+      - "tests/testdata/**"
+      - "**/tsconfig.json"
+      - "**.[jt]sx?"
+  workflow_dispatch:
+  repository_dispatch:
+
+jobs:
+  run-determination:
+    runs-on: ubuntu-latest
+    permissions: {}
+    outputs:
+      result: ${{ steps.determination.outputs.result }}
+    steps:
+      - name: Determine if the rest of the workflow should run
+        id: determination
+        run: |
+          RELEASE_BRANCH_REGEX="refs/heads/[0-9]+.[0-9]+.x"
+          # The `create` event trigger doesn't support `branches` filters, so it's necessary to use Bash instead.
+          if [[
+            "${{ github.event_name }}" != "create" ||
+            "${{ github.ref }}" =~ $RELEASE_BRANCH_REGEX
+          ]]; then
+            # Run the other jobs.
+            RESULT="true"
+          else
+            # There is no need to run the other jobs.
+            RESULT="false"
+          fi
+
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+
+  test:
+    name: test (${{ matrix.project.path }}, ${{ matrix.operating-system }})
+    needs: run-determination
+    if: needs.run-determination.outputs.result == 'true'
+    runs-on: ${{ matrix.operating-system }}
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          - path: .
+        operating-system:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: yarn
+          node-version: ${{ env.NODE_VERSION }}
+
+      # See: https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11.x'
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install Taskfile
+        uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: 3.x
+
+      - name: Install npm package dependencies
+        env:
+          # Avoid failure of @vscode/ripgrep installation due to GitHub API rate limiting:
+          # https://github.com/microsoft/vscode-ripgrep#github-api-limit-note
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          yarn install
+
+      - name: Compile TypeScript
+        run: |
+          yarn \
+            --cwd arduino-ide-extension \
+            build
+
+      - name: Run tests
+        env:
+          # These secrets are optional. Dependent tests will be skipped if not available.
+          CREATE_USERNAME: ${{ secrets.CREATE_USERNAME }}
+          CREATE_PASSWORD: ${{ secrets.CREATE_PASSWORD }}
+          CREATE_CLIENT_SECRET: ${{ secrets.CREATE_CLIENT_SECRET }}
+        run: |
+          yarn test
+          yarn \
+            --cwd arduino-ide-extension \
+            test:slow

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 # Arduino IDE 2.x
 
-[![Arduino IDE](https://github.com/arduino/arduino-ide/workflows/Arduino%20IDE/badge.svg)](https://github.com/arduino/arduino-ide/actions?query=workflow%3A%22Arduino+IDE%22)
+[![Build status](https://github.com/arduino/arduino-ide/actions/workflows/build.yml/badge.svg)](https://github.com/arduino/arduino-ide/actions/workflows/build.yml)
 [![Check JavaScript status](https://github.com/arduino/arduino-ide/actions/workflows/check-javascript.yml/badge.svg)](https://github.com/arduino/arduino-ide/actions/workflows/check-javascript.yml)
+[![Test JavaScript status](https://github.com/arduino/arduino-ide/actions/workflows/test-javascript.yml/badge.svg)](https://github.com/arduino/arduino-ide/actions/workflows/test-javascript.yml)
 
 This repository contains the source code of the Arduino IDE 2.x. If you're looking for the old IDE, go to the [repository of the 1.x version](https://github.com/arduino/Arduino).
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 # Arduino IDE 2.x
 
 [![Arduino IDE](https://github.com/arduino/arduino-ide/workflows/Arduino%20IDE/badge.svg)](https://github.com/arduino/arduino-ide/actions?query=workflow%3A%22Arduino+IDE%22)
+[![Check JavaScript status](https://github.com/arduino/arduino-ide/actions/workflows/check-javascript.yml/badge.svg)](https://github.com/arduino/arduino-ide/actions/workflows/check-javascript.yml)
 
 This repository contains the source code of the Arduino IDE 2.x. If you're looking for the old IDE, go to the [repository of the 1.x version](https://github.com/arduino/Arduino).
 


### PR DESCRIPTION
### Motivation

The "build" workflow builds the application for all supported targets, generates workflow artifacts from which the builds can be downloaded by users and [beta testers](https://github.com/arduino/arduino-ide/blob/main/docs/contributor-guide/beta-testing.md), and publishes [nightly](https://github.com/arduino/arduino-ide/blob/main/docs/contributor-guide/beta-testing.md#testing-nightly-build) and production releases.

As if that wasn't enough, additional operations unrelated to building the application were jammed into the workflow:

* Lint code
* Run tests
* [Check for out of sync Yarn lockfile](https://yarnpkg.com/cli/install#options-immutable)

This monolithic approach is harmful for multiple reasons:

* Makes it difficult to interpret a failed workflow run
* Unnecessarily adds a significant amount of extra content to the already extensive logs produced by the build process
* Makes the build workflow more difficult to maintain
* Increases the length of a build workflow run
* Increases the impact of a spurious failure
* Increases the turnaround time for contributors and maintainers to get feedback from the CI system

### Change description

Move the non-build operations to dedicated workflows. Aligning the project infrastructure more closely to [standard practices for Arduino Tooling projects](https://github.com/arduino/tooling-project-assets).

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
