### PR TITLE
Correct eslint command in `lint` script

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -13,7 +13,7 @@
     "download-ls": "node ./scripts/download-ls.js",
     "download-examples": "node ./scripts/download-examples.js",
     "generate-protocol": "node ./scripts/generate-protocol.js",
-    "lint": "eslint",
+    "lint": "eslint .",
     "prebuild": "rimraf lib",
     "build": "tsc",
     "build:dev": "yarn build",

--- a/arduino-ide-extension/scripts/compose-changelog.js
+++ b/arduino-ide-extension/scripts/compose-changelog.js
@@ -34,7 +34,7 @@
   }, '');
 
   const args = process.argv.slice(2);
-  if (args.length == 0) {
+  if (args.length === 0) {
     console.error('Missing argument to destination file');
     process.exit(1);
   }


### PR DESCRIPTION
### Motivation

The `lint` script of the "arduino-ide-extension" package is intended to use the [**ESLint**](https://eslint.org/) linter tool to check for problems in all the package's JavaScript and TypeScript code files. It is [used by the continuous integration system to validate contributions:

https://github.com/arduino/arduino-ide/blob/788017bb994b9d8fda04df33d7ad3b5feb4879fd/.github/workflows/check-javascript.yml#L84-L88

Previously, the command invoked `eslint` without any arguments. With the 8.x version of **ESLint** used by the project, it is necessary to provide a path argument in order to cause it to lint the contents of files (support for linting all files when the argument is omitted was [added in 9.0.0](https://github.com/eslint/eslint/commit/12be3071d014814149e8e6d602f5c192178ca771)). Because that argument was not provided, the script didn't do anything at all and so would return a 0 exit status even if the code had linting rule violations.

### Change description

Add a `.` path argument to the command invoked by the script. This will cause **ESLint** to recurse through the `arduino-ide-extension` folder and lint the code in all relevant files.

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
