### PR TITLE
feat: Use Arduino CLI v1.1.1

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -171,7 +171,7 @@
   ],
   "arduino": {
     "arduino-cli": {
-      "version": "1.1.0"
+      "version": "1.1.1"
     },
     "arduino-fwuploader": {
       "version": "2.4.1"


### PR DESCRIPTION
### Motivation

- Use Arduino CLI `v1.1.1`
- Use `arduino_cli_{version}_proto.zip` to generate CLI binding for official releases

### Change description

Since https://github.com/arduino/arduino-cli/pull/2673 google profile have been removed from source so the generation script is now fetching proto files from the `arduino_cli_{version}_proto.zip` file generated for every release as it includes the google proto files, see https://github.com/arduino/arduino-cli/pull/2761

Fetching protos from source is still used if a specific `commitsh` is provided or is CLI version is 1.1.0, see https://github.com/arduino/arduino-cli/issues/2755
In this case, google proto are fetched separately from [arduino_cli_1.1.1_proto.zip](https://downloads.arduino.cc/arduino-cli/arduino-cli_1.1.1_proto.zip) and copied to the source folder.

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
