### PR TITLE
chore: switch to version `2.3.5` after the release

### DIFF
--- a/arduino-ide-extension/package.json
+++ b/arduino-ide-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide-extension",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "An extension for Theia building the Arduino IDE",
   "license": "AGPL-3.0-or-later",
   "scripts": {

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "electron-app",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "license": "AGPL-3.0-or-later",
   "main": "./src-gen/backend/electron-main.js",
   "dependencies": {
@@ -19,7 +19,7 @@
     "@theia/preferences": "1.41.0",
     "@theia/terminal": "1.41.0",
     "@theia/workspace": "1.41.0",
-    "arduino-ide-extension": "2.3.4"
+    "arduino-ide-extension": "2.3.5"
   },
   "devDependencies": {
     "@theia/cli": "1.41.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "arduino-ide",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Arduino IDE",
   "repository": "https://github.com/arduino/arduino-ide.git",
   "author": "Arduino SA",


### PR DESCRIPTION
Motivation
Produce the nightly builds (and IDE2 updates) with the correct 2.3.5-nightly* version.

Change description
Bump version from 2.3.4 to 2.3.5

### Other information

To produce a correctly versioned nightly build.
See the [docs](https://github.com/arduino/arduino-ide/blob/1b9c7e93e029e65765010eb84e1604b5e483a963/docs/internal/release-procedure.md#7-%EF%B8%8F-bump-version-metadata-of-packages) for more details.

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
