### PR TITLE
fix: add missing linux dependencies after ubuntu-latest runner update

### DIFF
--- a/.github/workflows/check-i18n-task.yml
+++ b/.github/workflows/check-i18n-task.yml
@@ -76,6 +76,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev
+
       - name: Install dependencies
         run: yarn install --immutable
         env:

--- a/.github/workflows/check-javascript.yml
+++ b/.github/workflows/check-javascript.yml
@@ -73,6 +73,12 @@ jobs:
           cache: yarn
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install Dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev
+
       - name: Install npm package dependencies
         env:
           # Avoid failure of @vscode/ripgrep installation due to GitHub API rate limiting:

--- a/.github/workflows/check-yarn.yml
+++ b/.github/workflows/check-yarn.yml
@@ -72,6 +72,12 @@ jobs:
           cache: yarn
           node-version: ${{ env.NODE_VERSION }}
 
+      - name: Install Dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev
+
       - name: Install npm package dependencies
         env:
           # Avoid failure of @vscode/ripgrep installation due to GitHub API rate limiting:

--- a/.github/workflows/i18n-nightly-push.yml
+++ b/.github/workflows/i18n-nightly-push.yml
@@ -34,6 +34,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev
+
       - name: Install dependencies
         run: yarn install --immutable
 

--- a/.github/workflows/i18n-weekly-pull.yml
+++ b/.github/workflows/i18n-weekly-pull.yml
@@ -34,6 +34,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev
+
       - name: Install dependencies
         run: yarn install --immutable
 

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -107,6 +107,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install Dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev
+
       - name: Install npm package dependencies
         env:
           # Avoid failure of @vscode/ripgrep installation due to GitHub API rate limiting:

--- a/.github/workflows/themes-weekly-pull.yml
+++ b/.github/workflows/themes-weekly-pull.yml
@@ -36,6 +36,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev
+
       - name: Install dependencies
         run: yarn install --immutable
 


### PR DESCRIPTION
### Motivation

<!-- Why this pull request? -->
Ubuntu 24.04 is the new default version for Ubuntu latest runner https://github.com/actions/runner-images/issues/10636

Ubuntu 24.04 no longer includes the following dependencies:

- `libx11-dev`, `libxkbfile-dev` required by `native-keymap`
- `libsecret-1-dev` required by `keytar` package.

Note that `keytar` is now deprecated and it's a dependency on both IDE2 and Theia https://github.com/eclipse-theia/theia/issues/13593


### Change description

Manually install missing dependencies in CI workflows only for Linux

### Other information

<!-- Any additional information that could help the review process -->
Adopted in favour of https://github.com/arduino/arduino-ide/pull/2649

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
