### PR TITLE
chore: pin `ubuntu-22.04` runner for linux actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ env:
           name: Windows_X86-64_zip
     - config:
         name: Linux
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         container: |
           {
             \"image\": \"ghcr.io/arduino/arduino-ide/linux:main\"
@@ -140,7 +140,7 @@ env:
 
 jobs:
   run-determination:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       result: ${{ steps.determination.outputs.result }}
     permissions: {}
@@ -166,7 +166,7 @@ jobs:
   build-type-determination:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       is-release: ${{ steps.determination.outputs.is-release }}
       is-nightly: ${{ steps.determination.outputs.is-nightly }}
@@ -207,7 +207,7 @@ jobs:
 
   select-targets:
     needs: build-type-determination
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       artifact-matrix: ${{ steps.assemble.outputs.artifact-matrix }}
       build-matrix: ${{ steps.assemble.outputs.build-matrix }}
@@ -434,7 +434,7 @@ jobs:
       - select-targets
       - build
     if: needs.select-targets.outputs.merge-channel-files == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions: {}
     steps:
       - name: Set environment variables
@@ -498,7 +498,7 @@ jobs:
       - select-targets
       - build
     if: always() && needs.build.result != 'skipped'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       BUILD_ARTIFACTS_FOLDER: build-artifacts
@@ -524,7 +524,7 @@ jobs:
     needs:
       - build-type-determination
       - build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       BODY: ${{ steps.changelog.outputs.BODY }}
     steps:
@@ -583,7 +583,7 @@ jobs:
       needs.changelog.result == 'success' &&
       needs.build-type-determination.outputs.publish-to-s3 == 'true' &&
       needs.build-type-determination.outputs.is-nightly == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       ARTIFACTS_FOLDER: build-artifacts
@@ -620,7 +620,7 @@ jobs:
       ) &&
       needs.changelog.result == 'success' &&
       needs.build-type-determination.outputs.is-release == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       ARTIFACTS_FOLDER: build-artifacts
@@ -668,7 +668,7 @@ jobs:
       - release
       - artifacts
     if: always() && needs.build.result != 'skipped'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Remove unneeded job transfer artifacts

--- a/.github/workflows/check-certificates.yml
+++ b/.github/workflows/check-certificates.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   run-determination:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       result: ${{ steps.determination.outputs.result }}
     steps:
@@ -64,7 +64,7 @@ jobs:
     name: ${{ matrix.certificate.identifier }}
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
 

--- a/.github/workflows/check-containers.yml
+++ b/.github/workflows/check-containers.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   run:
     name: Run (${{ matrix.image.path }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions: {}
     services:
       registry:

--- a/.github/workflows/check-i18n-task.yml
+++ b/.github/workflows/check-i18n-task.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   run-determination:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       result: ${{ steps.determination.outputs.result }}
     permissions: {}
@@ -52,7 +52,7 @@ jobs:
   check:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/check-javascript.yml
+++ b/.github/workflows/check-javascript.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   run-determination:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions: {}
     outputs:
       result: ${{ steps.determination.outputs.result }}
@@ -59,7 +59,7 @@ jobs:
   check:
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
 

--- a/.github/workflows/check-yarn.yml
+++ b/.github/workflows/check-yarn.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   run-determination:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions: {}
     outputs:
       result: ${{ steps.determination.outputs.result }}
@@ -52,7 +52,7 @@ jobs:
     name: check-sync (${{ matrix.project.path }})
     needs: run-determination
     if: needs.run-determination.outputs.result == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
 

--- a/.github/workflows/compose-full-changelog.yml
+++ b/.github/workflows/compose-full-changelog.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   create-changelog:
     if: github.repository == 'arduino/arduino-ide'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/i18n-nightly-push.yml
+++ b/.github/workflows/i18n-nightly-push.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   push-to-transifex:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/i18n-weekly-pull.yml
+++ b/.github/workflows/i18n-weekly-pull.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pull-from-transifex:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/push-container-images.yml
+++ b/.github/workflows/push-container-images.yml
@@ -28,7 +28,7 @@ jobs:
         github.event_name == 'pull_request' &&
         github.event.pull_request.head.repo.full_name == 'arduino/arduino-ide'
       )
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository
@@ -54,7 +54,7 @@ jobs:
 
   download:
     needs: check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
@@ -81,7 +81,7 @@ jobs:
 
   sync:
     needs: download
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Set environment variables

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   run-determination:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions: {}
     outputs:
       result: ${{ steps.determination.outputs.result }}
@@ -77,7 +77,7 @@ jobs:
           - path: .
         operating-system:
           - macos-latest
-          - ubuntu-latest
+          - ubuntu-22.04
           - windows-latest
 
     steps:

--- a/.github/workflows/themes-weekly-pull.yml
+++ b/.github/workflows/themes-weekly-pull.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   pull-from-jsonbin:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation

<!-- Why this pull request? -->
Ubuntu 24.04 is the new default version for Ubuntu latest runner https://github.com/actions/runner-images/issues/10636

Ubuntu 24.04 no longer includes the `libsecret-1-dev` dependency required by `keytar` on Linux.
`keytar` is now deprecated and it's a dependency on both IDE2 and Theia https://github.com/eclipse-theia/theia/issues/13593

During the transition of getting away from`keytar`, we should use pin runner to `ubuntu-22.04` to ensure `libsecret-1-dev` is present.

### Change description

<!-- What does your code do? -->

### Other information

<!-- Any additional information that could help the review process -->
This might be a better solution then manually installing dependency on each task https://github.com/arduino/arduino-ide/pull/2647

Any suggestion on which solution to adopt is appreciated

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
