### PR TITLE
Give build workflow step access to required deployment environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -589,7 +589,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read 
+      contents: read
 
     steps:
       - name: Download all job transfer artifacts
@@ -602,8 +602,8 @@ jobs:
       - name: Configure AWS Credentials for Nightly [S3]
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }} 
-          aws-region: us-east-1 
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
 
       - name: Publish Nightly [S3]
         run: |
@@ -661,8 +661,8 @@ jobs:
         if: needs.build-type-determination.outputs.publish-to-s3 == 'true'
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }} 
-          aws-region: us-east-1 
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: us-east-1
 
       - name: Publish Release [S3]
         if: needs.build-type-determination.outputs.publish-to-s3 == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,6 +172,7 @@ jobs:
       is-nightly: ${{ steps.determination.outputs.is-nightly }}
       channel-name: ${{ steps.determination.outputs.channel-name }}
       publish-to-s3: ${{ steps.determination.outputs.publish-to-s3 }}
+    environment: production
     permissions: {}
     steps:
       - name: Determine the type of build


### PR DESCRIPTION
Certain operations in the "Arduino IDE" GitHub Actions workflow use [GitHub Actions secrets](https://docs.github.com/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions) which are defined in the repository's administrative settings.

These secrets will typically not be defined when the workflow is run in a [fork](https://docs.github.com/get-started/quickstart/fork-a-repo). However, the workflow's base functionality, the automated building of the application, does not require secrets. Since that base functionality alone is very useful to contributors (either to validate relevant changes to the application and infrastructure, or to generate [tester builds](https://github.com/arduino/arduino-ide/blob/main/docs/contributor-guide/beta-testing.md)) who are performing development work in a fork. For this reason, the workflow is configured to only perform the secret-dependent operations when the required secrets have been defined in the repository settings.

One such operation is publishing the generated builds to [Amazon S3](https://aws.amazon.com/s3/), which Arduino uses to host files for distribution. This operation depends on the `AWS_ROLE_ARN` secret. As a security measure, this secret is defined inside a [deployment environment](https://docs.github.com/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-an-environment) (named `production`). GitHub Actions workflow jobs can only use secrets from deployment environments which they have been explicitly configured to have access to.

At the time the workflow was originally developed, GitHub did not have the [deployment environment feature](https://docs.github.com/actions/writing-workflows/choosing-what-your-workflow-does/using-environments-for-deployment), and so the workflow was not configured to use environments. The switch to using a deployment environment for this secret was made only recently (https://github.com/arduino/arduino-ide/pull/2651), and when that was done, the workflow job that checks whether the secret is defined was not configured to have access to the `production` environment. This caused the workflow to think it was running in a context where that secret is not defined even when the secret is in fact defined. The bug caused the workflow to always spuriously skip the `publish` job which publishes [nightly builds](https://github.com/arduino/arduino-ide/blob/main/docs/contributor-guide/beta-testing.md#testing-nightly-build) of Arduino IDE, and the "publish release" step which publishes production releases.

For example, if you look at the latest `schedule` event triggered run of the workflow, which is intended to publish the nightly build, you can see that the `publish` job was incorrectly skipped:

https://github.com/arduino/arduino-ide/actions/runs/14163321599/job/39672908643

> This job was skipped

The bug is fixed by [configuring](https://docs.github.com/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idenvironment) the `build-type-determination` job so that it has access to the "production" environment.

---

Originally reported by @KurtE:

https://forum.arduino.cc/t/software-download-item-nightly-2-x-builds/1369196