### PR TITLE
fix: safer electron version parsing for electron-builder command

### DIFF
--- a/electron-app/scripts/package.js
+++ b/electron-app/scripts/package.js
@@ -6,8 +6,14 @@ const { isNightly, isRelease } = require('./utils');
 
 async function run() {
   /** @type {string} */
-  const electronVersion =
+  const rawElectronVersion =
     require('../package.json').devDependencies['electron'];
+  const electronVersion = semver.clean(rawElectronVersion.replace(/^\^/, ''));
+  if (!electronVersion) {
+    throw new Error(
+      `Electron semver validation failed for version: '${rawElectronVersion}'.`
+    );
+  }
   const platform = electronPlatform();
   const version = await getVersion();
   /** @type {string|unknown} */
@@ -18,7 +24,7 @@ async function run() {
     '--publish',
     'never',
     '-c.electronVersion',
-    semver.clean(electronVersion.replace(/^\^/, '')),
+    electronVersion,
     '-c.extraMetadata.version',
     version,
     // overrides the `name` in the `package.json` to keep the `localStorage` location. (https://github.com/arduino/arduino-ide/pull/2144#pullrequestreview-1554005028)


### PR DESCRIPTION
### Motivation

Check if electron version parsing is correctly parsed by semver package. Also fix error warning for invalid type

### Change description

<!-- What does your code do? -->

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
