### PR TITLE
fix: add missing linux dependencies for `merge-channel-files` job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -473,6 +473,12 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           version: 3.x
 
+      - name: Install dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev
+
       - name: Install dependencies
         run: yarn
 


### PR DESCRIPTION
### Motivation

Motivation of this change is the same as https://github.com/arduino/arduino-ide/pull/2647

This specific change has been overlooked in the above PR because `merge-channel-files` runs only when a release is triggered, so the additional error wan't exposed during normal builds. 

### Change description

Add missing linux dependencies for actions that invokes `yarn install`.
