### PR TITLE
fix: allow write permission on release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -639,7 +639,7 @@ jobs:
 
     permissions:
       id-token: write
-      contents: read
+      contents: write
 
     steps:
       - name: Download all job transfer artifacts


### PR DESCRIPTION
Permission were previously changed here https://github.com/arduino/arduino-ide/pull/2651 Repo write permission is needed to allow creating the github release and publishing files

### Motivation

<!-- Why this pull request? -->

### Change description

<!-- What does your code do? -->

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
