### PR TITLE
fix: add missing linux dependencies for `create-changelog` job

### DIFF
--- a/.github/workflows/compose-full-changelog.yml
+++ b/.github/workflows/compose-full-changelog.yml
@@ -29,6 +29,12 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Install Dependencies (Linux only)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libx11-dev libxkbfile-dev libsecret-1-dev
+
       - name: Get Tag
         id: tag_name
         run: |


### PR DESCRIPTION
### Motivation

Motivation of this change is the same as https://github.com/arduino/arduino-ide/pull/2647

This specific change has been overlooked in the above PR because `create-changelog`  is skipped during normal builds. 

### Change description

Add missing linux dependencies for actions that use `yarn`.