### PR TITLE
fix: wait for theia `initalWindow` to be set before opening sketch through `open-file` event

### DIFF
--- a/arduino-ide-extension/src/common/utils.ts
+++ b/arduino-ide-extension/src/common/utils.ts
@@ -38,3 +38,26 @@ export function uint8ArrayToString(uint8Array: Uint8Array): string {
 export function stringToUint8Array(text: string): Uint8Array {
   return Uint8Array.from(text, (char) => char.charCodeAt(0));
 }
+
+export function poolWhile(
+  whileCondition: () => boolean,
+  intervalMs: number,
+  timeoutMs: number
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!whileCondition) {
+      resolve();
+    }
+
+    const start = Date.now();
+    const interval = setInterval(() => {
+      if (!whileCondition()) {
+        clearInterval(interval);
+        resolve();
+      } else if (Date.now() - start > timeoutMs) {
+        clearInterval(interval);
+        reject(new Error('Timed out while polling.'));
+      }
+    }, intervalMs);
+  });
+}

--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -30,6 +30,7 @@ import type { AddressInfo } from 'node:net';
 import { isAbsolute, join, resolve } from 'node:path';
 import type { Argv } from 'yargs';
 import { Sketch } from '../../common/protocol';
+import { poolWhile } from '../../common/utils';
 import {
   AppInfo,
   appInfoPropertyLiterals,
@@ -292,6 +293,16 @@ export class ElectronMainApplication extends TheiaElectronMainApplication {
           );
           if (sketchFolderPath) {
             this.openFilePromise.reject(new InterruptWorkspaceRestoreError());
+
+            // open-file event is triggered before the app is ready and initialWindow is created.
+            // Wait for initialWindow to be set before opening the sketch on the first instance.
+            // See https://github.com/arduino/arduino-ide/pull/2693
+            try {
+              await app.whenReady();
+              if (!this.firstWindowId) {
+                await poolWhile(() => !this.initialWindow, 100, 3000);
+              }
+            } catch {}
             await this.openSketch(sketchFolderPath);
           }
         }

--- a/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
+++ b/arduino-ide-extension/src/electron-main/theia/electron-main-application.ts
@@ -890,7 +890,10 @@ const fallbackFrontendAppConfig: FrontendApplicationConfig = {
   defaultIconTheme: 'none',
   validatePreferencesSchema: false,
   defaultLocale: '',
-  electron: { showWindowEarly: true, uriScheme: 'custom://arduino-ide' },
+  electron: {
+    showWindowEarly: true,
+    uriScheme: 'arduino-ide',
+  },
   reloadOnReconnect: true,
 };
 

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -67,7 +67,8 @@
         "defaultIconTheme": "none",
         "validatePreferencesSchema": false,
         "electron": {
-          "showWindowEarly": true
+          "showWindowEarly": true,
+          "uriScheme": "arduino-ide"
         },
         "reloadOnReconnect": true,
         "preferences": {


### PR DESCRIPTION
### Motivation

Resolves https://github.com/arduino/arduino-ide/issues/2688

### Change description

Theia internally create an initial empty window on app start to improve UX while first loading the app instance, see https://github.com/eclipse-theia/theia/pull/12897
On MacOS, since open sketch via file association was triggered before initial window reference was set, the open sketch logic would create a new window instance instead of reusing the early created window reference, leaving an unresponsive additional empty window.

The `open-file` event is triggered before the app is ready and `initialWindow` is created, leading to `openSketch`
to create a new window instead of reusing the `initialWindow`.
Currently there is no ideal way to wait or react to `initialWindow` value change, so we pool on the value.
Note that this only needed on the first window startup as on other instances, `showWindowEarly` is not used `initialWindow` is null.
The pool set a generous amount of retries but should bail consistently on the first try as `initialWindow` is set right after the app is ready. Note that in case the pools timeout, we open the sketch on a new window anyway.
