### PR TITLE
fix: use `ElectronConnectionHandler` to connect the ide updater frontend and the electron main process 

### DIFF
--- a/arduino-ide-extension/src/electron-main/arduino-electron-main-module.ts
+++ b/arduino-ide-extension/src/electron-main/arduino-electron-main-module.ts
@@ -1,5 +1,5 @@
-import { ConnectionHandler } from '@theia/core/lib/common/messaging/handler';
-import { JsonRpcConnectionHandler } from '@theia/core/lib/common/messaging/proxy-factory';
+import { ElectronConnectionHandler } from '@theia/core/lib/electron-main/messaging/electron-connection-handler';
+import { RpcConnectionHandler } from '@theia/core/lib/common/messaging/proxy-factory';
 import { ElectronMainWindowService } from '@theia/core/lib/electron-common/electron-main-window-service';
 import { TheiaMainApi } from '@theia/core/lib/electron-main/electron-api-main';
 import {
@@ -33,18 +33,15 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(IDEUpdaterImpl).toSelf().inSingletonScope();
   bind(IDEUpdater).toService(IDEUpdaterImpl);
   bind(ElectronMainApplicationContribution).toService(IDEUpdater);
-  bind(ConnectionHandler)
+  bind(ElectronConnectionHandler)
     .toDynamicValue(
       (context) =>
-        new JsonRpcConnectionHandler<IDEUpdaterClient>(
-          IDEUpdaterPath,
-          (client) => {
-            const server = context.container.get<IDEUpdater>(IDEUpdater);
-            server.setClient(client);
-            client.onDidCloseConnection(() => server.disconnectClient(client));
-            return server;
-          }
-        )
+        new RpcConnectionHandler<IDEUpdaterClient>(IDEUpdaterPath, (client) => {
+          const server = context.container.get<IDEUpdater>(IDEUpdater);
+          server.setClient(client);
+          client.onDidCloseConnection(() => server.disconnectClient(client));
+          return server;
+        })
     )
     .inSingletonScope();
 


### PR DESCRIPTION
### Motivation

Resolves https://github.com/arduino/arduino-ide/issues/2696

### Change description

Use `ElectronConnectionHandler` instead of `ConnectionHandler` to establish communication between the frontend and the electron main process. This is needed specifically for services interacting with electron.

### Other information

The issue seems to appear also on the [Theia IDE example](https://github.com/eclipse-theia/theia/blob/436de3c4571e0000fdcbbf2e94ddfc992f38ccb2/examples/api-samples/src/electron-main/update/sample-updater-main-module.ts#L28). An issue will follow on Theia side.

