### PR TITLE
Order custom board option menus as defined in platform configuration

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/boards-data-menu-updater.ts
+++ b/arduino-ide-extension/src/browser/contributions/boards-data-menu-updater.ts
@@ -71,9 +71,7 @@ export class BoardsDataMenuUpdater extends Contribution {
               ...ArduinoMenus.TOOLS__BOARD_SETTINGS_GROUP,
               'z01_boardsConfig',
             ]; // `z_` is for ordering.
-            for (const { label, option, values } of configOptions.sort(
-              ConfigOption.LABEL_COMPARATOR
-            )) {
+            for (const { label, option, values } of configOptions ) {
               const menuPath = [...boardsConfigMenuPath, `${option}`];
               const commands = new Map<
                 string,

--- a/arduino-ide-extension/src/browser/contributions/boards-data-menu-updater.ts
+++ b/arduino-ide-extension/src/browser/contributions/boards-data-menu-updater.ts
@@ -7,8 +7,6 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import PQueue from 'p-queue';
 import {
   BoardIdentifier,
-  // Produces Error: src/browser/contributions/boards-data-menu-updater.ts(10,3): error TS6133: 'ConfigOption' is declared but its value is never read.
-  // ConfigOption,
   isBoardIdentifierChangeEvent,
   Programmer,
 } from '../../common/protocol';
@@ -72,8 +70,11 @@ export class BoardsDataMenuUpdater extends Contribution {
               ...ArduinoMenus.TOOLS__BOARD_SETTINGS_GROUP,
               'z01_boardsConfig',
             ]; // `z_` is for ordering.
-            for (const { label, option, values } of configOptions ) {
-              const menuPath = [...boardsConfigMenuPath, `${option}`];
+            let i:number = 0;
+            for (const { label, option, values } of configOptions) {
+              // We want Menu Entries in order of configOptions
+              const order = String(i++).padStart(4)
+              const menuPath = [...boardsConfigMenuPath, `${order}`];
               const commands = new Map<
                 string,
                 Disposable & { label: string }

--- a/arduino-ide-extension/src/browser/contributions/boards-data-menu-updater.ts
+++ b/arduino-ide-extension/src/browser/contributions/boards-data-menu-updater.ts
@@ -7,7 +7,8 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import PQueue from 'p-queue';
 import {
   BoardIdentifier,
-  ConfigOption,
+  // Produces Error: src/browser/contributions/boards-data-menu-updater.ts(10,3): error TS6133: 'ConfigOption' is declared but its value is never read.
+  // ConfigOption,
   isBoardIdentifierChangeEvent,
   Programmer,
 } from '../../common/protocol';

--- a/arduino-ide-extension/src/common/protocol/boards-service.ts
+++ b/arduino-ide-extension/src/common/protocol/boards-service.ts
@@ -377,12 +377,6 @@ export namespace ConfigOption {
       Object.setPrototypeOf(this, ConfigOptionError.prototype);
     }
   }
-
-  export const LABEL_COMPARATOR = (left: ConfigOption, right: ConfigOption) =>
-    naturalCompare(
-      left.label.toLocaleLowerCase(),
-      right.label.toLocaleLowerCase()
-    );
 }
 
 export interface ConfigValue {


### PR DESCRIPTION
The use of `sort` on `configOptions` caused the custom board options menus to be ordered according to the lexicographical order of the machine identifiers of the menus instead of allowing the platform developer to control the order in a manner that will be most friendly for human users (via the ordering in the `boards.txt` platform configuration file).

Removing the sorting code allows the order to be as intended by the platform developer, and aligns the behavior with that of Arduino IDE 1.x.

---

Fixes #2036

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [x] PR title and description are properly filled.
- [x] Docs have been added / updated (for bug fixes / features)
