### PR TITLE
Document localization capabilities in Translator Guide

### DIFF
--- a/docs/contributor-guide/translation.md
+++ b/docs/contributor-guide/translation.md
@@ -1,12 +1,40 @@
 # Translator Guide
 
-The text of the Arduino IDE interface is translated into several languages. The language can be selected in the dialog opened via **File > Preferences** in the Arduino IDE menus (**Arduino IDE > Preferences** for macOS users).
+The text of the Arduino IDE user interface is translated into several languages. The language can be selected in the dialog opened via **File > Preferences** in the Arduino IDE menus (**Arduino IDE > Preferences** for macOS users).
 
 Translating text and improving on existing translations is a valuable contribution to the project, helping make Arduino accessible to everyone.
 
-The translations for the text found in the Arduino IDE come from several sources:
+The translations for the text found in Arduino IDE come from several sources:
 
 ## Arduino IDE Text
+
+The text of the Arduino IDE application can be translated to the following languages:
+
+- čeština (Czech)
+- Deutsch (German)
+- Dutch
+- español (Spanish)
+- français (French)
+- italiano (Italian)
+- magyar (Hungarian)
+- polski (Polish)
+- português (Portuguese)
+- Türkçe (Turkish)
+- български (Bulgarian)
+- русский (Russian)
+- українська (Ukrainian)
+- 한국어 (Korean)
+- 中文(简体) (Chinese Simplified)
+- 中文(繁體) (Chinese Traditional)
+- 日本語 (Japanese)
+
+---
+
+⚠ Unfortunately the 3rd party localization system used by the Arduino IDE application imposes a technical limitation to that set of languages. For this reason, we are unable to add support to Arduino IDE for additional languages (see [`arduino/arduino-ide#1447`](https://github.com/arduino/arduino-ide/issues/1447) for details).
+
+There is no technical limitation on the set of languages to which **Arduino CLI** can be translated. If you would like to contribute translations for a language not on the above list, you are welcome to [contribute to the **Arduino CLI** project](#arduino-cli-text).
+
+---
 
 Translations of Arduino IDE's text is done in the "**Arduino IDE 2.0**" project on the **Transifex** localization platform:
 


### PR DESCRIPTION
The system used for localization of this project leverages the infrastructure and data that already exists for **VS Code**. These assets are applicable to Arduino IDE due to the project being built on the [**Eclipse Theia Platform** IDE framework](https://theia-ide.org/theia-platform/). In this way, the Arduino IDE developers and community are only responsible for internationalization and localization of the Arduino-specific strings (e.g., "Sketchbook") used in the IDE's UI.

The unfortunate downside to this approach is that there is a hard technical limit on localization of the project to [languages for which a **VS Code** "language pack" is available](https://open-vsx.org/?search=&category=Language%20Packs) (https://github.com/arduino/arduino-ide/issues/1447).

It will be helpful to clearly communicate the set of languages for which we are able to ship contributions from translators.

Likewise, it will be useful to also communicate that, we are able to ship contributions of translations of **Arduino CLI** user interface strings for any language. This is due to the fact that the **Arduino CLI** codebase uses [a completely different internationalization system](https://github.com/arduino/arduino-cli/tree/master/internal/i18n) that does not impose any technical limits on the scope of localization.
