### PR TITLE
Remove donation links from contributor guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ See [**the contributor guide**](docs/CONTRIBUTING.md#contributor-guide) for more
 
 See the [**development guide**](docs/development.md) for a technical overview of the application and instructions for building the code.
 
-## Donations
+### Support the project
 
-This open source code was written by the Arduino team and is maintained on a daily basis with the help of the community. We invest a considerable amount of time in development, testing and optimization. Please consider [donating](https://www.arduino.cc/en/donate/) or [sponsoring](https://github.com/sponsors/arduino) to support our work, as well as [buying original Arduino boards](https://store.arduino.cc/) which is the best way to make sure our effort can continue in the long term.
+This open source code was written by the Arduino team and is maintained on a daily basis with the help of the community. We invest a considerable amount of time in development, testing and optimization. Please consider [buying original Arduino boards](https://store.arduino.cc/) to support our work on the project.
 
 ## License
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,22 +6,20 @@ Thanks for your interest in contributing to this project!
 
 There are several ways you can get involved:
 
-| Type of contribution                      | Contribution method                                                              |
-| ----------------------------------------- | -------------------------------------------------------------------------------- |
-| - Support<br/>- Question<br/>- Discussion | Post on the [**Arduino Forum**][forum]                                           |
-| - Bug report<br/>- Feature request        | Issue report (see the guide [**here**][issues])                                  |
-| Testing                                   | Beta testing, PR review (see the guide [**here**][beta-testing])                 |
-| Translation                               | See the guide [**here**][translate]                                              |
-| - Bug fix<br/>- Enhancement               | Pull request (see the guide [**here**][prs])                                     |
-| Monetary                                  | - [Donate][donate]<br/>- [Sponsor][sponsor]<br/>- [Buy official products][store] |
+| Type of contribution                      | Contribution method                                              |
+| ----------------------------------------- | ---------------------------------------------------------------- |
+| - Support<br/>- Question<br/>- Discussion | Post on the [**Arduino Forum**][forum]                           |
+| - Bug report<br/>- Feature request        | Issue report (see the guide [**here**][issues])                  |
+| Testing                                   | Beta testing, PR review (see the guide [**here**][beta-testing]) |
+| Translation                               | See the guide [**here**][translate]                              |
+| - Bug fix<br/>- Enhancement               | Pull request (see the guide [**here**][prs])                     |
+| Monetary                                  | [Buy official products][store]                                   |
 
 [forum]: https://forum.arduino.cc
 [issues]: contributor-guide/issues.md#issue-report-guide
 [beta-testing]: contributor-guide/beta-testing.md#beta-testing-guide
 [translate]: contributor-guide/translation.md#translator-guide
 [prs]: contributor-guide/pull-requests.md#pull-request-guide
-[donate]: https://www.arduino.cc/en/donate/
-[sponsor]: https://github.com/sponsors/arduino
 [store]: https://store.arduino.cc
 
 ## Resources


### PR DESCRIPTION
The Arduino company is no longer soliciting monetary donations. Community members who wish to contribute to the project still have opportunities to do so via the other options listed in the contributor guide.
