### PR TITLE
Escape asterisks in error message content for notification display

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/contribution.ts
+++ b/arduino-ide-extension/src/browser/contributions/contribution.ts
@@ -264,7 +264,6 @@ export abstract class CoreServiceContribution extends SketchContribution {
     let message: undefined | string = undefined;
     if (CoreError.is(error)) {
       message = error.message;
-
       if (error.code === CoreError.Codes.Verify) {
         message = message.replace(/[*]/g, '\\*');
       }


### PR DESCRIPTION
### Motivation

Fixes #2777

### Change description

Escape asterisks in error message to prevent rendering as markup

### Other information

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [x] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
