### PR TITLE
Add "installed" filter in boards manager

### DIFF
--- a/arduino-ide-extension/src/common/nls.ts
+++ b/arduino-ide-extension/src/common/nls.ts
@@ -4,6 +4,7 @@ import { nls } from '@theia/core/lib/common/nls';
 export const Unknown = nls.localize('arduino/common/unknown', 'Unknown');
 export const Later = nls.localize('arduino/common/later', 'Later');
 export const Updatable = nls.localize('arduino/common/updateable', 'Updatable');
+export const Installed = nls.localize('arduino/common/installed', 'Installed');
 export const All = nls.localize('arduino/common/all', 'All');
 export const Type = nls.localize('arduino/common/type', 'Type');
 export const Partner = nls.localize('arduino/common/partner', 'Partner');

--- a/arduino-ide-extension/src/common/protocol/boards-service.ts
+++ b/arduino-ide-extension/src/common/protocol/boards-service.ts
@@ -8,6 +8,7 @@ import {
   Partner,
   Type as TypeLabel,
   Updatable,
+  Installed
 } from '../nls';
 import type { Defined } from '../types';
 import { naturalCompare } from './../utils';
@@ -113,6 +114,7 @@ export namespace BoardSearch {
   export const TypeLiterals = [
     'All',
     'Updatable',
+    'Installed',
     'Arduino',
     'Contributed',
     'Arduino Certified',
@@ -128,6 +130,7 @@ export namespace BoardSearch {
   export const TypeLabels: Record<Type, string> = {
     All: All,
     Updatable: Updatable,
+    Installed: Installed,
     Arduino: 'Arduino',
     Contributed: Contributed,
     'Arduino Certified': nls.localize(

--- a/arduino-ide-extension/src/node/boards-service-impl.ts
+++ b/arduino-ide-extension/src/node/boards-service-impl.ts
@@ -423,6 +423,8 @@ export class BoardsServiceImpl
     switch (options.type) {
       case 'Updatable':
         return Installable.Updateable;
+      case 'Installed':
+        return Installable.Installed;
       case 'Arduino':
       case 'Partner':
       case 'Arduino@Heart':

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -140,6 +140,7 @@
       "all": "All",
       "contributed": "Contributed",
       "installManually": "Install Manually",
+      "installed": "Installed",
       "later": "Later",
       "noBoardSelected": "No board selected",
       "noSketchOpened": "No sketch opened",


### PR DESCRIPTION
### Motivation

Resolves #2638

### Change description

Adds "installed" filter option to boards manager

### Other information

### Reviewer checklist

- [x] PR addresses a single concern.
- [x] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [x] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
