### PR TITLE
chore: use `macos-15-intel` runner for MacOS x86_64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ env:
           name: Linux_X86-64_app_image
     - config:
         name: macOS x86
-        runs-on: macos-13
+        runs-on: macos-15-intel
         container: |
           null
         # APPLE_SIGNING_CERTIFICATE_P12 secret was produced by following the procedure from:


### PR DESCRIPTION
### Motivation

`macos-13` runner used for MacOS builds  has shutdown

### Change description

Use the new (and last supported for intel macs) `macos-15-intel` runner for MacOS x86_64 builds

### Other information

https://github.com/actions/runner-images/issues/13046

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
