### PR TITLE
feat: updates installs libraries dependencies by default

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/first-startup-installer.ts
+++ b/arduino-ide-extension/src/browser/contributions/first-startup-installer.ts
@@ -61,7 +61,6 @@ export class FirstStartupInstaller extends Contribution {
         try {
           await this.libraryService.install({
             item: builtInLibrary,
-            installDependencies: true,
             noOverwrite: true, // We don't want to automatically replace custom libraries the user might already have in place
             installLocation: LibraryLocation.BUILTIN,
           });

--- a/arduino-ide-extension/src/browser/library/library-list-widget.ts
+++ b/arduino-ide-extension/src/browser/library/library-list-widget.ts
@@ -167,23 +167,21 @@ export class LibraryListWidget extends ListWidget<
       installDependencies = false;
     }
 
-    if (typeof installDependencies === 'boolean') {
-      await this.service.install({
-        item,
-        version,
-        progressId,
-        installDependencies,
-      });
-      this.messageService.info(
-        nls.localize(
-          'arduino/library/installedSuccessfully',
-          'Successfully installed library {0}:{1}',
-          item.name,
-          version
-        ),
-        { timeout: 3000 }
-      );
-    }
+    await this.service.install({
+      item,
+      version,
+      progressId,
+      noDeps: !installDependencies,
+    });
+    this.messageService.info(
+      nls.localize(
+        'arduino/library/installedSuccessfully',
+        'Successfully installed library {0}:{1}',
+        item.name,
+        version
+      ),
+      { timeout: 3000 }
+    );
   }
 
   protected override async uninstall({

--- a/arduino-ide-extension/src/common/protocol/library-service.ts
+++ b/arduino-ide-extension/src/common/protocol/library-service.ts
@@ -27,7 +27,7 @@ export interface LibraryService
     item: LibraryPackage;
     progressId?: string;
     version?: Installable.Version;
-    installDependencies?: boolean;
+    noDeps?: boolean;
     noOverwrite?: boolean;
     installLocation?: LibraryLocation.BUILTIN | LibraryLocation.USER;
   }): Promise<void>;

--- a/arduino-ide-extension/src/node/library-service-impl.ts
+++ b/arduino-ide-extension/src/node/library-service-impl.ts
@@ -306,7 +306,7 @@ export class LibraryServiceImpl
     item: LibraryPackage;
     progressId?: string;
     version?: Installable.Version;
-    installDependencies?: boolean;
+    noDeps?: boolean;
     noOverwrite?: boolean;
     installLocation?: LibraryLocation.BUILTIN | LibraryLocation.USER;
   }): Promise<void> {
@@ -321,7 +321,7 @@ export class LibraryServiceImpl
     req.setInstance(instance);
     req.setName(item.name);
     req.setVersion(version);
-    req.setNoDeps(!options.installDependencies);
+    req.setNoDeps(Boolean(options.noDeps));
     req.setNoOverwrite(Boolean(options.noOverwrite));
     if (options.installLocation === LibraryLocation.BUILTIN) {
       req.setInstallLocation(


### PR DESCRIPTION
### Motivation

Resolves #2505

### Change description

`libraryService.install` now automatically installs all required dependencies for a selected library by default.
If the user explicitly chooses the “Install without dependencies” option, the installation proceeds without pulling additional libraries.

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
