### PR TITLE
fix: replace null characters in copied monitor output

### DIFF
--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -75,9 +75,12 @@ export class SerialMonitorOutput extends React.Component<
       this.props.clearConsoleEvent(() =>
         this.setState({ lines: [], charCount: 0 })
       ),
-      this.props.copyOutputEvent(() => 
-        this.props.clipboardService.writeText(joinLines(this.state.lines))
-      ),
+      this.props.copyOutputEvent(() => {
+        const text = joinLines(this.state.lines);
+        // Replace null characters with a visible symbol
+        const safe = text.replace(/\u0000/g, '\u25A1');
+        this.props.clipboardService.writeText(safe);
+      }),
       this.props.monitorModel.onChange(({ property }) => {
         if (property === 'timestamp') {
           const { timestamp } = this.props.monitorModel;


### PR DESCRIPTION
### Motivation

Resolves #2827

### Change description

In some OSes implementation of `clipboard.writeText`,  null (U+0000) characters are parsed as string termination symbol, effectively truncating the copied output.
We now replace null characters code with a visual representation (☐) to make string consistent cross platform.

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
