### PR TITLE
Update target of Help > Getting Started

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/help.ts
+++ b/arduino-ide-extension/src/browser/contributions/help.ts
@@ -37,7 +37,7 @@ export class Help extends Contribution {
       };
     registry.registerCommand(
       Help.Commands.GETTING_STARTED,
-      createOpenHandler('https://www.arduino.cc/en/Guide')
+      createOpenHandler('https://docs.arduino.cc/learn/starting-guide/getting-started-arduino/')
     );
     registry.registerCommand(
       Help.Commands.ENVIRONMENT,


### PR DESCRIPTION
The "Help > Getting Started" menu item is intended to open the web page of an introductory tutorial about Arduino in general.

The page at the URL previously targeted by the menu item was moved as part of the continuous churn of the Arduino website structure. This caused the menu item to only lead to a 404 page.

The target of the menu item is hereby updated to point to the current URL of the general introductory tutorial.

---

Resolves https://github.com/arduino/arduino-ide/issues/2892