### PR TITLE
Added Preferences option for automatic sketch name sanitization

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-preferences.ts
+++ b/arduino-ide-extension/src/browser/arduino-preferences.ts
@@ -315,6 +315,14 @@ const properties: ArduinoPreferenceSchemaProperties = {
     ),
     default: defaultMonitorWidgetDockPanel,
   },
+  'arduino.sketch.autoSanitizeName': {
+    type: 'boolean',
+    description: nls.localize(
+      'arduino/preferences/sketch/autoSanitizeName',
+      'Default true to automatically sanitize invalid sketch names when saving. False to be prompted to choose a different name'
+    ),
+    default: true,
+  }
 };
 export const ArduinoConfigSchema: PreferenceSchema = {
   type: 'object',
@@ -351,6 +359,7 @@ export interface ArduinoConfiguration {
   'arduino.sketch.inoBlueprint': string;
   'arduino.checkForUpdates': boolean;
   'arduino.monitor.dockPanel': MonitorWidgetDockPanel;
+  'arduino.sketch.autoSanitizeName': boolean;
 }
 
 export const ArduinoPreferences = Symbol('ArduinoPreferences');

--- a/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/save-as-sketch.ts
@@ -27,6 +27,7 @@ import {
   RenameCloudSketchParams,
 } from './rename-cloud-sketch';
 import { assertConnectedToBackend } from './save-sketch';
+import { ArduinoPreferences } from '../arduino-preferences';
 
 @injectable()
 export class SaveAsSketch extends CloudSketchContribution {
@@ -34,6 +35,8 @@ export class SaveAsSketch extends CloudSketchContribution {
   private readonly shell: ApplicationShell;
   @inject(WindowService)
   private readonly windowService: WindowService;
+  @inject(ArduinoPreferences)
+  private readonly arduinoPreferences: ArduinoPreferences;
 
   override registerCommands(registry: CommandRegistry): void {
     registry.registerCommand(SaveAsSketch.Commands.SAVE_AS_SKETCH, {
@@ -229,18 +232,35 @@ export class SaveAsSketch extends CloudSketchContribution {
         const sketchFolderName = new URI(destinationUri).path.base;
         const errorMessage = Sketch.validateSketchFolderName(sketchFolderName);
         if (errorMessage) {
-          dialogContent = {
-            message: nls.localize(
-              'arduino/sketch/invalidSketchFolderNameMessage',
-              "Invalid sketch folder name: '{0}'",
-              sketchFolderName
-            ),
-            details: errorMessage,
-            question: nls.localize(
-              'arduino/sketch/editInvalidSketchFolderQuestion',
-              'Do you want to try saving the sketch with a different name?'
-            ),
-          };
+          if(this.arduinoPreferences['arduino.sketch.autoSanitizeName']) {
+            let sanitizedName = Sketch.toValidSketchFolderName(sketchFolderName);
+              if (Sketch.validateSketchFolderName(sanitizedName)) {
+                sanitizedName = Sketch.defaultSketchFolderName;
+              }
+            sketchFolderDestinationUri = new URI(destinationUri).parent.resolve(sanitizedName).toString();
+            this.messageService.info(
+              nls.localize(
+                'arduino/sketch/autoRenamedSketchFolder',
+                "Sketch folder name changed from '{0}' to '{1}'.",
+                sketchFolderName,
+                sanitizedName)
+            );
+            continue;
+          }
+          else {
+            dialogContent = {
+              message: nls.localize(
+                'arduino/sketch/invalidSketchFolderNameMessage',
+                "Invalid sketch folder name: '{0}'",
+                sketchFolderName
+              ),
+              details: errorMessage,
+              question: nls.localize(
+                'arduino/sketch/editInvalidSketchFolderQuestion',
+                'Do you want to try saving the sketch with a different name?'
+              ),
+            };
+          }
         }
       }
       if (dialogContent) {

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings-component.tsx
@@ -144,6 +144,17 @@ export class SettingsComponent extends React.Component<
             'Show files inside Sketches'
           )}
         </label>
+        <label className="flex-line">
+          <input
+            type="checkbox"
+            checked={this.state.autoSanitizeSketchName === true}
+            onChange={this.autoSanitizeSketchNameDidChange}
+          />
+          {nls.localize(
+            'arduino/preferences/sketch/autoSanitizeName',
+            'Sanitize invalid Sketch names when saving'
+          )}
+        </label>
         <div className="column-container">
           <div className="column">
             <div className="flex-line">
@@ -622,6 +633,12 @@ export class SettingsComponent extends React.Component<
     event: React.ChangeEvent<HTMLInputElement>
   ): void => {
     this.setState({ sketchbookShowAllFiles: event.target.checked });
+  };
+
+  protected autoSanitizeSketchNameDidChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    this.setState({ autoSanitizeSketchName: event.target.checked });
   };
 
   protected autoSaveDidChange = (

--- a/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
@@ -46,6 +46,7 @@ export const COMPILE_WARNINGS_SETTING = `${COMPILE_SETTING}.warnings`;
 export const UPLOAD_VERBOSE_SETTING = `${UPLOAD_SETTING}.verbose`;
 export const UPLOAD_VERIFY_SETTING = `${UPLOAD_SETTING}.verify`;
 export const SHOW_ALL_FILES_SETTING = `${SKETCHBOOK_SETTING}.showAllFiles`;
+export const AUTO_SANITIZE_SETTING = `${ARDUINO_SETTING}.sketch.autoSanitizeName`;
 
 export interface Settings {
   editorFontSize: number; // `editor.fontSize`
@@ -63,6 +64,7 @@ export interface Settings {
   verboseOnUpload: boolean; // `arduino.upload.verbose`
   verifyAfterUpload: boolean; // `arduino.upload.verify`
   sketchbookShowAllFiles: boolean; // `arduino.sketchbook.showAllFiles`
+  autoSanitizeSketchName: boolean; // `arduino.sketch.autoSanitizeName`
 
   sketchbookPath: string; // CLI
   additionalUrls: AdditionalUrls; // CLI
@@ -152,6 +154,7 @@ export class SettingsService {
       verboseOnUpload,
       verifyAfterUpload,
       sketchbookShowAllFiles,
+      autoSanitizeSketchName,
       cliConfig,
     ] = await Promise.all([
       ['en', ...(await this.localizationProvider.getAvailableLanguages())],
@@ -181,6 +184,7 @@ export class SettingsService {
       this.preferenceService.get<boolean>(UPLOAD_VERBOSE_SETTING, true),
       this.preferenceService.get<boolean>(UPLOAD_VERIFY_SETTING, true),
       this.preferenceService.get<boolean>(SHOW_ALL_FILES_SETTING, false),
+      this.preferenceService.get<boolean>(AUTO_SANITIZE_SETTING, true),
       this.configService.getConfiguration(),
     ]);
     const {
@@ -207,6 +211,7 @@ export class SettingsService {
       verboseOnUpload,
       verifyAfterUpload,
       sketchbookShowAllFiles,
+      autoSanitizeSketchName,
       additionalUrls,
       sketchbookPath,
       network,
@@ -297,6 +302,7 @@ export class SettingsService {
       additionalUrls,
       network,
       sketchbookShowAllFiles,
+      autoSanitizeSketchName,
     } = this._settings;
     const [cliConfig, sketchDirUri] = await Promise.all([
       this.configService.getConfiguration(),
@@ -328,6 +334,7 @@ export class SettingsService {
       this.savePreference(UPLOAD_VERBOSE_SETTING, verboseOnUpload),
       this.savePreference(UPLOAD_VERIFY_SETTING, verifyAfterUpload),
       this.savePreference(SHOW_ALL_FILES_SETTING, sketchbookShowAllFiles),
+      this.savePreference(AUTO_SANITIZE_SETTING, autoSanitizeSketchName),
       this.configService.setConfiguration(config),
     ]);
     this.onDidChangeEmitter.fire(this._settings);

--- a/arduino-ide-extension/src/common/protocol/sketches-service.ts
+++ b/arduino-ide-extension/src/common/protocol/sketches-service.ts
@@ -251,6 +251,7 @@ export namespace Sketch {
     return undefined;
   }
 
+
   function endsWithPeriod(candidate: string): boolean {
     return candidate.length > 1 && candidate[candidate.length - 1] === '.';
   }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -409,6 +409,7 @@
       },
       "showVerbose": "Show verbose output during",
       "sketch": {
+        "autoSanitizeName": "Sanitize invalid Sketch names when saving",
         "inoBlueprint": "Absolute filesystem path to the default `.ino` blueprint file. If specified, the content of the blueprint file will be used for every new sketch created by the IDE. The sketches will be generated with the default Arduino content if not specified. Unaccessible blueprint files are ignored. **A restart of the IDE is needed** for this setting to take effect."
       },
       "sketchbook.location": "Sketchbook location",
@@ -445,6 +446,7 @@
     },
     "sketch": {
       "archiveSketch": "Archive Sketch",
+      "autoRenamedSketchFolder": "Sketch folder name changed from '{0}' to '{1}'.",
       "cantOpen": "A folder named \"{0}\" already exists. Can't open sketch.",
       "compile": "Compiling sketch...",
       "configureAndUpload": "Configure and Upload",


### PR DESCRIPTION
### Motivation
Adding back a convenient feature that the community seemed to like.

### Change description
Implemented checkbox in Preferences to toggle automatic sketch name sanitization. Made use of toValidSketchName (already written) sanitize sketch names.
    - True: All invalid characters are replaced with _. Pop up message notifies user.
    - False: Reminds the user of correct naming format and prompts to rename sketch.

Resolves (https://github.com/arduino/arduino-ide/issues/2866)