### PR TITLE
Expose last build outcome via BuildStateService

### DIFF
--- a/arduino-ide-extension/src/common/protocol/build-state-service.ts
+++ b/arduino-ide-extension/src/common/protocol/build-state-service.ts
@@ -1,0 +1,33 @@
+/**
+ * Read-only record of the most recent build (compile or upload) result.
+ *
+ * Plugins and contributions can inject `BuildStateService` to react to
+ * build outcomes without re-running the build themselves — for example to
+ * power "rerun last build", to gate features on a successful compile, or
+ * to capture artifacts in CI.
+ *
+ * The IDE writes to this service from `CoreServiceImpl` at the end of
+ * every `compile` and `upload`; consumers should treat it as read-only.
+ */
+
+export const BuildStateServicePath = '/services/build-state';
+export const BuildStateService = Symbol('BuildStateService');
+
+/** A single build (compile or upload) outcome. */
+export interface BuildState {
+  /** Concatenated build output (stdout + progress messages). */
+  readonly output: string;
+  /** Compiler or upload error details, empty if the build succeeded. */
+  readonly errors: string;
+  /** ISO timestamp of when the build completed. */
+  readonly timestamp: string;
+  /** True if the build finished with exit code 0. */
+  readonly success: boolean;
+}
+
+export interface BuildStateService {
+  /** Returns the most recent build outcome, or `undefined` if none yet. */
+  getLastBuild(): Promise<BuildState | undefined>;
+  /** Internal use only — called by `CoreServiceImpl`. */
+  setLastBuild(state: BuildState): Promise<void>;
+}

--- a/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
+++ b/arduino-ide-extension/src/node/arduino-ide-backend-module.ts
@@ -121,6 +121,11 @@ import {
 import { SettingsReader } from './settings-reader';
 import { VsCodePluginScanner } from './theia/plugin-ext-vscode/scanner-vscode';
 import { rebindParcelFileSystemWatcher } from './theia/filesystem/parcel-bindings';
+import {
+  BuildStateService,
+  BuildStateServicePath,
+} from '../common/protocol/build-state-service';
+import { BuildStateServiceImpl } from './build-state-service-impl';
 
 export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(BackendApplication).toSelf().inSingletonScope();
@@ -149,6 +154,19 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
       (context) =>
         new JsonRpcConnectionHandler(ArduinoDaemonPath, () =>
           context.container.get(ArduinoDaemon)
+        )
+    )
+    .inSingletonScope();
+
+  // Shared build-state service: captures the latest compile/upload result
+  // so plugins can react without re-running the build.
+  bind(BuildStateServiceImpl).toSelf().inSingletonScope();
+  bind(BuildStateService).toService(BuildStateServiceImpl);
+  bind(ConnectionHandler)
+    .toDynamicValue(
+      ({ container }) =>
+        new JsonRpcConnectionHandler(BuildStateServicePath, () =>
+          container.get(BuildStateService)
         )
     )
     .inSingletonScope();

--- a/arduino-ide-extension/src/node/build-state-service-impl.ts
+++ b/arduino-ide-extension/src/node/build-state-service-impl.ts
@@ -1,0 +1,18 @@
+import { injectable } from '@theia/core/shared/inversify';
+import type {
+  BuildState,
+  BuildStateService,
+} from '../common/protocol/build-state-service';
+
+@injectable()
+export class BuildStateServiceImpl implements BuildStateService {
+  private lastBuild: BuildState | undefined;
+
+  async getLastBuild(): Promise<BuildState | undefined> {
+    return this.lastBuild;
+  }
+
+  async setLastBuild(state: BuildState): Promise<void> {
+    this.lastBuild = state;
+  }
+}

--- a/arduino-ide-extension/src/node/core-service-impl.ts
+++ b/arduino-ide-extension/src/node/core-service-impl.ts
@@ -54,6 +54,7 @@ import { ExecuteWithProgress, ProgressResponse } from './grpc-progressible';
 import { MonitorManager } from './monitor-manager';
 import { ServiceError } from './service-error';
 import { AutoFlushingBuffer } from './utils/buffers';
+import { BuildStateService } from '../common/protocol/build-state-service';
 
 namespace Uploadable {
   export type Request = UploadRequest | UploadUsingProgrammerRequest;
@@ -70,6 +71,8 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
   private readonly monitorManager: MonitorManager;
   @inject(BoardDiscovery)
   private readonly boardDiscovery: BoardDiscovery;
+  @inject(BuildStateService)
+  private readonly buildStateService: BuildStateService;
 
   async compile(
     options: CoreService.Options.Compile,
@@ -130,6 +133,11 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
             .filter(notEmpty)
             .shift() ?? error.details
         );
+        this.recordBuildState(
+          handler.content,
+          error.details + '\n\n' + message,
+          false
+        );
         this.sendResponse(
           error.details + '\n\n' + message,
           OutputMessage.Severity.Error
@@ -163,6 +171,7 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
           .on('error', handleError)
           .on('end', () => {
             if (isCompileSummary(compileSummary)) {
+              this.recordBuildState(handler.content, '', true);
               resolve(compileSummary);
             } else {
               console.error(
@@ -324,6 +333,7 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
               error.details
             );
 
+            this.recordBuildState(handler.content, error.details, false);
             this.sendResponse(error.details, OutputMessage.Severity.Error);
             reject(
               errorCtor(
@@ -337,6 +347,7 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
           })
           .on('end', () => {
             if (isUploadResponse(uploadResponseFragment)) {
+              this.recordBuildState(handler.content, '', true);
               resolve(uploadResponseFragment);
             } else {
               reject(
@@ -507,6 +518,39 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
     severity: OutputMessage.Severity = OutputMessage.Severity.Info
   ): void {
     this.responseService.appendToOutput({ chunk, severity });
+  }
+
+  /**
+   * Snapshot the latest compile/upload outcome into `BuildStateService` so
+   * plugins (e.g. an AI assistant, a "rerun last build" UI, CI integrations)
+   * can read it without having to re-run the build themselves.
+   *
+   * Failures here are swallowed: `BuildStateService` is observational and
+   * must never break a real build.
+   */
+  private recordBuildState(
+    content: Uint8Array[],
+    errors: string,
+    success: boolean
+  ): void {
+    let output = '';
+    try {
+      output = Buffer.concat(
+        content.map((c) => (c instanceof Buffer ? c : Buffer.from(c)))
+      ).toString('utf-8');
+    } catch {
+      /* leave output empty */
+    }
+    this.buildStateService
+      .setLastBuild({
+        output,
+        errors,
+        timestamp: new Date().toISOString(),
+        success,
+      })
+      .catch((err) =>
+        console.warn('Failed to record build state:', err)
+      );
   }
 
   private async notifyUploadWillStart({


### PR DESCRIPTION
## Motivation

There is no in-process way today for an Arduino IDE contribution to read the result of the last `compile` / `upload` without re-running the build. This is a recurring pain point for anything that wants to react to build outcomes — "rerun the last failed build" UI, build-history widgets, CI integration helpers, third-party assistants, etc.

## What this PR adds

A small, read-only `BuildStateService` (under `arduino-ide-extension/src/common/protocol/` and `node/`) that captures the result of the most recent compile or upload:

```ts
interface BuildState {
  readonly output: string;
  readonly errors: string;
  readonly timestamp: string;
  readonly success: boolean;
}

interface BuildStateService {
  getLastBuild(): Promise<BuildState | undefined>;
  setLastBuild(state: BuildState): Promise<void>; // internal, called by CoreServiceImpl
}
```

`CoreServiceImpl` writes to it from the existing `compile` and `upload` flows. The recording call is wrapped so that failures are swallowed — `BuildStateService` is observational and can never break a real build.

Exposed as a JSON-RPC service at `/services/build-state` following the same `bind/ConnectionHandler/JsonRpcConnectionHandler` pattern as the other shared backend services.

## Why now

We're building a third-party AI assistant plugin on top of Arduino IDE 2.x and ran into this gap. Rather than fork, we'd like the service upstream so anyone (including future first-party features like a build-history view) can consume it.

The PR is intentionally scoped to *just* the service:
- no UI changes
- no behavioral changes
- no public API beyond `getLastBuild()`
- existing types & file layout untouched

## Testing

- `npx tsc --noEmit` passes against `arduino-ide-extension`
- Builds via standard `yarn build`
- Verified the service receives both success and failure cases by triggering compile + a deliberate compile error in a local IDE build

## Scope

Strictly one enhancement, per the PR guidelines. Happy to split further if reviewers prefer (e.g. service interface in one commit, `CoreServiceImpl` hook in another), but it's currently a single atomic commit.

## Related

Part of an [RFC](https://github.com/jainapurva/ArduinoIDE_agent/blob/feat/agentic-core/docs/rfc/0001-ai-assistant-extension-points.md) we've drafted around small extension points that would let AI assistant plugins exist without forking. Posting that as a Discussion separately; this PR stands on its own merits.