### PR TITLE
fix: standardize NODE_VERSION format across workflow files

### DIFF
--- a/.github/workflows/check-i18n-task.yml
+++ b/.github/workflows/check-i18n-task.yml
@@ -3,6 +3,8 @@ name: Check Internationalization
 env:
   # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
   GO_VERSION: '1.21'
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: '18.17'
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
@@ -61,7 +63,7 @@ jobs:
       - name: Install Node.js 18.17
         uses: actions/setup-node@v4
         with:
-          node-version: '18.17'
+          node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 

--- a/.github/workflows/check-javascript.yml
+++ b/.github/workflows/check-javascript.yml
@@ -3,7 +3,7 @@ name: Check JavaScript
 
 env:
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 18.17
+  NODE_VERSION: '18.17'
 
 # See: https://docs.github.com/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows
 on:

--- a/.github/workflows/check-yarn.yml
+++ b/.github/workflows/check-yarn.yml
@@ -1,5 +1,10 @@
 name: Check Yarn
 
+env:
+  # See: https://github.com/actions/setup-node/#readme
+  NODE_VERSION: '18.17'
+
+
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:
   create:

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -4,7 +4,7 @@ env:
   # See vars.GO_VERSION field of https://github.com/arduino/arduino-cli/blob/master/DistTasks.yml
   GO_VERSION: '1.21'
   # See: https://github.com/actions/setup-node/#readme
-  NODE_VERSION: 18.17
+  NODE_VERSION: '18.17'
 
 on:
   push:


### PR DESCRIPTION
### Motivation

`check yarn` action fails as a fixed node version is not set like in every other workflow file.
Regression is probably caused by ongoing migration to node24 https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
 

### Change description

Use fixed node version in `check yarn` action and make usage of `NODE_VERSION` consistent across workflow (the latter being just a small improvement, not a fix)

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
