### PR TITLE
fix: explicitly get `directories.data` and `directories.user` in separate commands in CLI config init

### DIFF
--- a/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
+++ b/arduino-ide-extension/src/browser/dialogs/settings/settings.ts
@@ -311,10 +311,13 @@ export class SettingsService {
       );
     }
 
-    (config as any).additionalUrls = additionalUrls;
-    (config as any).sketchDirUri = sketchDirUri;
-    (config as any).network = network;
-    (config as any).locale = currentLanguage;
+    const updatedConfig: typeof config = {
+      ...config,
+      additionalUrls,
+      sketchDirUri,
+      network,
+      locale: currentLanguage,
+    };
 
     await Promise.all([
       this.savePreference('editor.fontSize', editorFontSize),
@@ -328,7 +331,7 @@ export class SettingsService {
       this.savePreference(UPLOAD_VERBOSE_SETTING, verboseOnUpload),
       this.savePreference(UPLOAD_VERIFY_SETTING, verifyAfterUpload),
       this.savePreference(SHOW_ALL_FILES_SETTING, sketchbookShowAllFiles),
-      this.configService.setConfiguration(config),
+      this.configService.setConfiguration(updatedConfig),
     ]);
     this.onDidChangeEmitter.fire(this._settings);
 

--- a/arduino-ide-extension/src/node/config-service-impl.ts
+++ b/arduino-ide-extension/src/node/config-service-impl.ts
@@ -223,34 +223,38 @@ export class ConfigServiceImpl
 
   private async getFallbackCliConfig(): Promise<DefaultCliConfig> {
     const cliPath = this.daemon.getExecPath();
-    const [configRaw, directoriesRaw] = await Promise.all([
-      spawnCommand(cliPath, ['config', 'dump', '--json']),
-      // Since CLI 1.0, the command `config dump` only returns user-modified values and not default ones.
-      // directories.user and directories.data are required by IDE2 so we get the default value explicitly.
-      spawnCommand(cliPath, ['config', 'get', 'directories', '--json']),
-    ]);
+    const configRaw = await spawnCommand(cliPath, ['config', 'dump', '--json']);
 
     const config = JSON.parse(configRaw) as { config?: CliConfig };
-    const directories = JSON.parse(directoriesRaw) as Partial<Directories>;
-    const { user, data } = directories;
 
-    if (!user || !data) {
-      const missing = [
-        !user && 'directories.user',
-        !data && 'directories.data',
-      ].filter(Boolean);
-
-      throw new InvalidConfigError([
-        `Could not resolve required CLI configuration values: ${missing.join(
-          ', '
-        )}`,
-      ]);
-    }
+    // Since CLI 1.0, the command `config dump` only returns user-modified values and not default ones.
+    // directories.user and directories.data are required by IDE2 so we get the default value for each explicitly.
+    const user = await this.getDirectoryValue(cliPath, 'user');
+    const data = await this.getDirectoryValue(cliPath, 'data');
 
     return {
       ...config.config,
       directories: { user, data },
     };
+  }
+
+  private async getDirectoryValue(
+    cliPath: string,
+    key: keyof Directories
+  ): Promise<string> {
+    const raw = await spawnCommand(cliPath, [
+      'config',
+      'get',
+      `directories.${key}`,
+      '--json',
+    ]);
+    const value = JSON.parse(raw) as string;
+    if (!value) {
+      throw new InvalidConfigError([
+        `Could not resolve required CLI configuration value: directories.${key}`,
+      ]);
+    }
+    return value;
   }
 
   private async initCliConfigTo(fsPathToDir: string): Promise<void> {

--- a/arduino-ide-extension/src/node/config-service-impl.ts
+++ b/arduino-ide-extension/src/node/config-service-impl.ts
@@ -16,7 +16,12 @@ import {
 } from '../common/protocol';
 import { spawnCommand } from './exec-util';
 import { ArduinoDaemonImpl } from './arduino-daemon-impl';
-import { DefaultCliConfig, CLI_CONFIG, CliConfig } from './cli-config';
+import {
+  DefaultCliConfig,
+  CLI_CONFIG,
+  CliConfig,
+  Directories,
+} from './cli-config';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { deepClone, nls } from '@theia/core';
@@ -203,6 +208,7 @@ export class ConfigServiceImpl
           mergedModel
         )}`
       );
+
       return mergedModel;
     } catch (error) {
       if (ErrnoException.isENOENT(error)) {
@@ -224,10 +230,27 @@ export class ConfigServiceImpl
       spawnCommand(cliPath, ['config', 'get', 'directories', '--json']),
     ]);
 
-    const config = JSON.parse(configRaw);
-    const { user, data } = JSON.parse(directoriesRaw);
+    const config = JSON.parse(configRaw) as { config?: CliConfig };
+    const directories = JSON.parse(directoriesRaw) as Partial<Directories>;
+    const { user, data } = directories;
 
-    return { ...config.config, directories: { user, data } };
+    if (!user || !data) {
+      const missing = [
+        !user && 'directories.user',
+        !data && 'directories.data',
+      ].filter(Boolean);
+
+      throw new InvalidConfigError([
+        `Could not resolve required CLI configuration values: ${missing.join(
+          ', '
+        )}`,
+      ]);
+    }
+
+    return {
+      ...config.config,
+      directories: { user, data },
+    };
   }
 
   private async initCliConfigTo(fsPathToDir: string): Promise<void> {


### PR DESCRIPTION
### Motivation

Arduino IDE uses `arduino-cli config get directories` to get default global system values for `directories.user` and `directories.data` folders if not explicitly set by user. 
This values are needed by IDE to work correctly even if not explicitly returned by  CLI. 

🐛 If only one value is set in global CLI config, `arduino-cli config get directories` only return that value, leaving the other undefined.

### Change description

Get both `directories.data` and `directories.user` fields on separate commands, instead of only fetching its parent (`directories` node).

### Other information

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
