### PR TITLE
feat: add clean verify/compile

### DIFF
--- a/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
@@ -4,7 +4,10 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import type { CompileSummary, CoreService } from '../../common/protocol';
 import { ArduinoMenus } from '../menu/arduino-menus';
 import { CurrentSketch } from '../sketches-service-client-impl';
-import { ArduinoToolbar } from '../toolbar/arduino-toolbar';
+import {
+  ArduinoToolbar,
+  type ArduinoToolbarItemExtras,
+} from '../toolbar/arduino-toolbar';
 import {
   Command,
   CommandRegistry,
@@ -44,6 +47,10 @@ export interface VerifySketchParams {
    * The mode specifying how verify should run. It's `'explicit'` by default.
    */
   readonly mode?: VerifySketchMode;
+  /**
+   * Same as `CoreService.Options.Compile#clean`. Forces a full recompile.
+   */
+  readonly clean?: boolean;
 }
 
 /**
@@ -72,6 +79,10 @@ export class VerifySketch
       execute: (params?: VerifySketchParams) => this.verifySketch(params),
       isEnabled: () => this.verifyProgress === 'idle',
     });
+    registry.registerCommand(VerifySketch.Commands.VERIFY_SKETCH_CLEAN, {
+      execute: () => this.verifySketch({ clean: true }),
+      isEnabled: () => this.verifyProgress === 'idle',
+    });
     registry.registerCommand(VerifySketch.Commands.EXPORT_BINARIES, {
       execute: () => this.verifySketch({ exportBinaries: true }),
       isEnabled: () => this.verifyProgress === 'idle',
@@ -83,8 +94,16 @@ export class VerifySketch
       // toggled only when verify is running, but not toggled when automatic verify is running before the upload
       // https://github.com/arduino/arduino-ide/pull/1750#pullrequestreview-1214762975
       isToggled: () => this.verifyProgress === 'explicit',
-      execute: () =>
-        registry.executeCommand(VerifySketch.Commands.VERIFY_SKETCH.id),
+      execute: (
+        _widget: unknown,
+        _target: unknown,
+        args?: { shiftKey?: boolean }
+      ) =>
+        registry.executeCommand(VerifySketch.Commands.VERIFY_SKETCH.id, <
+          VerifySketchParams
+        >{
+          clean: args?.shiftKey === true,
+        }),
     });
   }
 
@@ -93,6 +112,14 @@ export class VerifySketch
       commandId: VerifySketch.Commands.VERIFY_SKETCH.id,
       label: nls.localize('arduino/sketch/verifyOrCompile', 'Verify/Compile'),
       order: '0',
+    });
+    registry.registerMenuAction(ArduinoMenus.SKETCH__MAIN_GROUP, {
+      commandId: VerifySketch.Commands.VERIFY_SKETCH_CLEAN.id,
+      label: nls.localize(
+        'arduino/sketch/verifyOrCompileClean',
+        'Verify/Compile (Clean)'
+      ),
+      order: '0_1',
     });
     registry.registerMenuAction(ArduinoMenus.SKETCH__MAIN_GROUP, {
       commandId: VerifySketch.Commands.EXPORT_BINARIES.id,
@@ -110,6 +137,10 @@ export class VerifySketch
       keybinding: 'CtrlCmd+R',
     });
     registry.registerKeybinding({
+      command: VerifySketch.Commands.VERIFY_SKETCH_CLEAN.id,
+      keybinding: 'CtrlCmd+Shift+R',
+    });
+    registry.registerKeybinding({
       command: VerifySketch.Commands.EXPORT_BINARIES.id,
       keybinding: 'CtrlCmd+Alt+S',
     });
@@ -120,9 +151,13 @@ export class VerifySketch
       id: VerifySketch.Commands.VERIFY_SKETCH_TOOLBAR.id,
       command: VerifySketch.Commands.VERIFY_SKETCH_TOOLBAR.id,
       tooltip: nls.localize('arduino/sketch/verify', 'Verify'),
+      tooltipWhenShiftPressed: nls.localize(
+        'arduino/sketch/verifyClean',
+        'Verify (Clean)'
+      ),
       priority: 0,
       onDidChange: this.onDidChange,
-    });
+    } as Parameters<TabBarToolbarRegistry['registerItem']>[0] & ArduinoToolbarItemExtras);
   }
 
   protected override handleError(error: unknown): void {
@@ -160,7 +195,7 @@ export class VerifySketch
       this.coreErrorHandler.reset();
       const dryRun = this.verifyProgress === 'dry-run';
 
-      const options = await this.options(params?.exportBinaries);
+      const options = await this.options(params?.exportBinaries, params?.clean);
       if (!options) {
         return undefined;
       }
@@ -206,7 +241,8 @@ export class VerifySketch
   }
 
   private async options(
-    exportBinaries?: boolean
+    exportBinaries?: boolean,
+    clean?: boolean
   ): Promise<CoreService.Options.Compile | undefined> {
     const sketch = await this.sketchServiceClient.currentSketch();
     if (!CurrentSketch.isValid(sketch)) {
@@ -230,6 +266,7 @@ export class VerifySketch
       exportBinaries,
       sourceOverride,
       compilerWarnings,
+      clean,
     };
   }
 }
@@ -238,6 +275,9 @@ export namespace VerifySketch {
   export namespace Commands {
     export const VERIFY_SKETCH: Command = {
       id: 'arduino-verify-sketch',
+    };
+    export const VERIFY_SKETCH_CLEAN: Command = {
+      id: 'arduino-verify-sketch-clean',
     };
     export const EXPORT_BINARIES: Command = {
       id: 'arduino-export-binaries',

--- a/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
+++ b/arduino-ide-extension/src/browser/contributions/verify-sketch.ts
@@ -114,14 +114,6 @@ export class VerifySketch
       order: '0',
     });
     registry.registerMenuAction(ArduinoMenus.SKETCH__MAIN_GROUP, {
-      commandId: VerifySketch.Commands.VERIFY_SKETCH_CLEAN.id,
-      label: nls.localize(
-        'arduino/sketch/verifyOrCompileClean',
-        'Verify/Compile (Clean)'
-      ),
-      order: '0_1',
-    });
-    registry.registerMenuAction(ArduinoMenus.SKETCH__MAIN_GROUP, {
       commandId: VerifySketch.Commands.EXPORT_BINARIES.id,
       label: nls.localize(
         'arduino/sketch/exportBinary',

--- a/arduino-ide-extension/src/browser/toolbar/arduino-toolbar.tsx
+++ b/arduino-ide-extension/src/browser/toolbar/arduino-toolbar.tsx
@@ -12,6 +12,10 @@ import { LabelParser, LabelIcon } from '@theia/core/lib/browser/label-parser';
 
 export const ARDUINO_TOOLBAR_ITEM_CLASS = 'arduino-tool-item';
 
+export interface ArduinoToolbarItemExtras {
+  readonly tooltipWhenShiftPressed?: string;
+}
+
 export namespace ArduinoToolbarComponent {
   export interface Props {
     side: 'left' | 'right';
@@ -23,7 +27,8 @@ export namespace ArduinoToolbarComponent {
     executeCommand: (e: React.MouseEvent<HTMLElement>) => void;
   }
   export interface State {
-    tooltip: string;
+    hoveredItemId?: string;
+    shiftPressed: boolean;
   }
 }
 export class ArduinoToolbarComponent extends React.Component<
@@ -32,7 +37,29 @@ export class ArduinoToolbarComponent extends React.Component<
 > {
   constructor(props: ArduinoToolbarComponent.Props) {
     super(props);
-    this.state = { tooltip: '' };
+    this.state = { shiftPressed: false };
+  }
+
+  override componentDidMount(): void {
+    document.addEventListener('keydown', this.onShiftChange, true);
+    document.addEventListener('keyup', this.onShiftChange, true);
+  }
+
+  override componentWillUnmount(): void {
+    document.removeEventListener('keydown', this.onShiftChange, true);
+    document.removeEventListener('keyup', this.onShiftChange, true);
+  }
+
+  private readonly onShiftChange = (e: KeyboardEvent) => {
+    if (e.key === 'Shift' && this.state.shiftPressed !== e.shiftKey) {
+      this.setState({ shiftPressed: e.shiftKey });
+    }
+  };
+
+  private resolveTooltip(item: RenderedToolbarItem): string {
+    const alt = (item as RenderedToolbarItem & ArduinoToolbarItemExtras)
+      .tooltipWhenShiftPressed;
+    return (this.state.shiftPressed && alt) || item.tooltip || '';
   }
 
   protected renderItem = (item: RenderedToolbarItem) => {
@@ -54,6 +81,8 @@ export class ArduinoToolbarComponent extends React.Component<
     } ${command && this.props.commandIsEnabled(command.id) ? 'enabled' : ''} ${
       command && this.props.commandIsToggled(command.id) ? 'toggled' : ''
     }`;
+    const isHovered = this.state.hoveredItemId === item.id;
+    const resolvedTooltip = this.resolveTooltip(item);
     return (
       <div key={item.id} className={cls}>
         <div className={item.id}>
@@ -62,9 +91,14 @@ export class ArduinoToolbarComponent extends React.Component<
             id={item.id}
             className={className}
             onClick={this.props.executeCommand}
-            onMouseOver={() => this.setState({ tooltip: item.tooltip || '' })}
-            onMouseOut={() => this.setState({ tooltip: '' })}
-            title={item.tooltip}
+            onMouseOver={(e) =>
+              this.setState({
+                hoveredItemId: item.id,
+                shiftPressed: e.shiftKey,
+              })
+            }
+            onMouseOut={() => this.setState({ hoveredItemId: undefined })}
+            title={isHovered ? resolvedTooltip : item.tooltip}
           >
             {innerText}
           </div>
@@ -74,9 +108,16 @@ export class ArduinoToolbarComponent extends React.Component<
   };
 
   override render(): React.ReactNode {
+    const hoveredItem = this.state.hoveredItemId
+      ? this.props.items.find(
+          (it): it is RenderedToolbarItem =>
+            (it as RenderedToolbarItem).id === this.state.hoveredItemId
+        )
+      : undefined;
+    const tooltipText = hoveredItem ? this.resolveTooltip(hoveredItem) : '';
     const tooltip = (
       <div key="arduino-toolbar-tooltip" className={'arduino-toolbar-tooltip'}>
-        {this.state.tooltip}
+        {tooltipText}
       </div>
     );
     const items = [
@@ -163,7 +204,9 @@ export class ArduinoToolbar extends ReactWidget {
   protected executeCommand = (e: React.MouseEvent<HTMLElement>) => {
     const item = this.items.get(e.currentTarget.id);
     if (item && item.command) {
-      this.commands.executeCommand(item.command, this, e.target);
+      this.commands.executeCommand(item.command, this, e.target, {
+        shiftKey: e.shiftKey,
+      });
     }
   };
 }

--- a/arduino-ide-extension/src/common/protocol/core-service.ts
+++ b/arduino-ide-extension/src/common/protocol/core-service.ts
@@ -236,6 +236,7 @@ export namespace CoreService {
       readonly sourceOverride: Record<string, string>; // TODO: (API) make this optional
       readonly exportBinaries?: boolean;
       readonly compilerWarnings?: CompilerWarnings;
+      readonly clean?: boolean;
     }
     export interface Upload extends Base, SketchBased, BoardBased {
       readonly userFields: BoardUserField[];

--- a/arduino-ide-extension/src/node/core-service-impl.ts
+++ b/arduino-ide-extension/src/node/core-service-impl.ts
@@ -207,6 +207,9 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
     if (typeof options.exportBinaries === 'boolean') {
       request.setExportBinaries(options.exportBinaries);
     }
+    if (options.clean) {
+      request.setClean(true);
+    }
     this.mergeSourceOverrides(request, options);
     return request;
   }
@@ -224,7 +227,9 @@ export class CoreServiceImpl extends CoreClientAware implements CoreService {
       (client) =>
         (usingProgrammer ? client.uploadUsingProgrammer : client.upload).bind(
           client
-        ),
+        ) as unknown as (
+          request: Uploadable.Request
+        ) => ClientReadableStream<Uploadable.Response>,
       usingProgrammer
         ? CoreError.UploadUsingProgrammerFailed
         : CoreError.UploadFailed,

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -482,7 +482,9 @@
       "uploading": "Uploading...",
       "userFieldsNotFoundError": "Can't find user fields for connected board",
       "verify": "Verify",
-      "verifyOrCompile": "Verify/Compile"
+      "verifyClean": "Verify (Clean)",
+      "verifyOrCompile": "Verify/Compile",
+      "verifyOrCompileClean": "Verify/Compile (Clean)"
     },
     "sketchbook": {
       "newCloudSketch": "New Cloud Sketch",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -483,8 +483,7 @@
       "userFieldsNotFoundError": "Can't find user fields for connected board",
       "verify": "Verify",
       "verifyClean": "Verify (Clean)",
-      "verifyOrCompile": "Verify/Compile",
-      "verifyOrCompileClean": "Verify/Compile (Clean)"
+      "verifyOrCompile": "Verify/Compile"
     },
     "sketchbook": {
       "newCloudSketch": "New Cloud Sketch",


### PR DESCRIPTION
### Motivation

The IDE's Verify action runs an incremental compile that reuses cached build artifacts from previous compilations.
This behaviour is the current default for all compile and upload operation in IDE.

### Change description

This PR add a new "Clean Verify" action that recompiles the sketch from scratch, bypassing the build cache. It is exposed in two ways:

- Keybinding: `Ctrl/Cmd + Shift + R`
- Toolbar: hold `Shift` and click the Verify button; the tooltip updates to "Verify (Clean)" while Shift is held so the alternate action is discoverable

Upload is unchanged.

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
