### PR TITLE
fix: flaky Windows CI tests

### DIFF
--- a/arduino-ide-extension/src/node/sketches-service-impl.ts
+++ b/arduino-ide-extension/src/node/sketches-service-impl.ts
@@ -784,7 +784,11 @@ export async function isAccessibleSketchPath(
   try {
     stats = await fs.stat(path);
   } catch (err) {
-    if (ErrnoException.isENOENT(err) || ErrnoException.isUNKNOWN(err)) {
+    if (
+      ErrnoException.isENOENT(err) ||
+      ErrnoException.isUNKNOWN(err) ||
+      ErrnoException.isECONNRESET(err)
+    ) {
       return undefined;
     }
     throw err;

--- a/arduino-ide-extension/src/node/utils/errors.ts
+++ b/arduino-ide-extension/src/node/utils/errors.ts
@@ -51,4 +51,14 @@ export namespace ErrnoException {
   ): arg is ErrnoException & { code: 'UNKNOWN' } {
     return is(arg) && arg.code === 'UNKNOWN';
   }
+
+  /**
+   * _(Connection reset by peer):_ A connection was forcibly closed by a peer. Commonly observed on Windows
+   * when an unreachable UNC path (e.g. `\\host\share`) is stat'd and the SMB negotiation is aborted.
+   */
+  export function isECONNRESET(
+    arg: unknown
+  ): arg is ErrnoException & { code: 'ECONNRESET' } {
+    return is(arg) && arg.code === 'ECONNRESET';
+  }
 }

--- a/arduino-ide-extension/src/test/node/clang-formatter.test.ts
+++ b/arduino-ide-extension/src/test/node/clang-formatter.test.ts
@@ -98,7 +98,8 @@ describe('clang-formatter', () => {
   let formatter: ClangFormatter;
   let toDispose: DisposableCollection;
 
-  before(async () => {
+  before(async function () {
+    this.timeout(20_000);
     tracked = temp.track();
     toDispose = new DisposableCollection(
       Disposable.create(() => tracked.cleanupSync())


### PR DESCRIPTION
### Motivation

Addresses two flaky tests in Windows runner
- the `clang-formatter` before hook occasionally exceeded Mocha's default timeout during daemon startup
- `isAccessibleSketchPath` rejected with ECONNRESET (instead of UNKNOWN) when testing an unreachable UNC path. 

### Change description

<!-- What does your code do? -->

### Other information

<!-- Any additional information that could help the review process -->

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
