### PR TITLE
Build changes for Arm64 to produce binaries that will run on Linux on a Chromebook (2026)

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "prepare": "theia download:plugins",
-    "prebuild": "rimraf lib",
+    "prebuild": "node ./scripts/ensure-extension-build.js && rimraf lib",
     "build": "theia build",
     "prebuild:dev": "yarn prebuild",
     "build:dev": "theia build --config webpack.dev.js --mode development",

--- a/electron-app/scripts/ensure-extension-build.js
+++ b/electron-app/scripts/ensure-extension-build.js
@@ -1,0 +1,29 @@
+// @ts-check
+'use strict';
+
+const { existsSync } = require('node:fs');
+const { join } = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const extensionRoot = join(__dirname, '..', '..', 'arduino-ide-extension');
+const parcelWatcherEntryPoint = join(
+  extensionRoot,
+  'lib',
+  'node',
+  'theia',
+  'filesystem',
+  'parcel-watcher',
+  'index.js'
+);
+
+if (existsSync(parcelWatcherEntryPoint)) {
+  process.exit(0);
+}
+
+const result = spawnSync('yarn', ['build'], {
+  cwd: extensionRoot,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+process.exit(result.status ?? 1);

--- a/electron-app/scripts/package.js
+++ b/electron-app/scripts/package.js
@@ -1,6 +1,8 @@
 // @ts-check
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const semver = require('semver');
 const { isNightly, isRelease } = require('./utils');
 
@@ -42,6 +44,13 @@ async function run() {
     '-c.extraMetadata.main',
     './arduino-ide-electron-main.js',
   ];
+  const env = { ...process.env };
+  if (process.platform === 'linux') {
+    prepareLinuxPackagingTools(env);
+    // app-builder-bin 4.2.0 defaults to zstd, but its ARM64 mksquashfs payload
+    // supports gzip and xz only.
+    args.push('-c.compression', 'maximum');
+  }
   const updateChannel = getChannel();
   if (updateChannel) {
     // TODO: fix the default nightly update channel preference value if required.
@@ -51,8 +60,144 @@ async function run() {
     //   updateChannel
     // );
   }
-  const cp = exec('electron-builder', args, { stdio: 'inherit' });
+  ensureWorkspaceDependencyLink('arduino-ide-extension');
+  ensureHoistedDependencyLinks();
+  const cp = exec('electron-builder', args, { stdio: 'inherit', env });
   await cp;
+}
+
+/**
+ * @param {NodeJS.ProcessEnv} env
+ */
+function prepareLinuxPackagingTools(env) {
+  const { appBuilderPath } = require('app-builder-bin');
+  fs.chmodSync(appBuilderPath, 0o755);
+
+  const { path7za } = require('7zip-bin');
+  env.PATH = `${path.dirname(path7za)}${path.delimiter}${env.PATH ?? ''}`;
+}
+
+/**
+ * electron-builder validates dependencies from the application directory, but
+ * Yarn workspaces link local packages from the repository root.
+ *
+ * @param {string} dependency
+ */
+function ensureWorkspaceDependencyLink(dependency) {
+  const appNodeModules = path.join(__dirname, '..', 'node_modules');
+  const dependencyPath = path.join(appNodeModules, dependency);
+
+  const workspacePath = path.join(__dirname, '..', '..', dependency);
+  if (!fs.existsSync(workspacePath)) {
+    throw new Error(
+      `Could not find workspace dependency '${dependency}' at '${workspacePath}'.`
+    );
+  }
+
+  fs.mkdirSync(appNodeModules, { recursive: true });
+  ensureSymlink(dependencyPath, workspacePath);
+}
+
+/**
+ * electron-builder scans each production dependency's declared dependencies from
+ * the package-local node_modules folder. Yarn workspaces can hoist those
+ * dependencies to the repository root instead, so create package-local links for
+ * any missing hoisted dependencies before packaging.
+ */
+function ensureHoistedDependencyLinks() {
+  const { appBuilderPath } = require('app-builder-bin');
+  const dependencyTree = JSON.parse(
+    require('child_process').execFileSync(
+      appBuilderPath,
+      ['node-dep-tree', '--dir', path.join(__dirname, '..')],
+      { encoding: 'utf8' }
+    )
+  );
+  const root = path.join(__dirname, '..', '..');
+  for (const info of dependencyTree) {
+    const nodeModulesPath = path.isAbsolute(info.dir)
+      ? info.dir
+      : path.join(root, info.dir);
+    const packagePath = path.dirname(nodeModulesPath);
+    for (const dependency of info.deps ?? []) {
+      ensureHoistedDependencyLink(packagePath, dependency.name);
+    }
+  }
+}
+
+/**
+ * @param {string} packagePath
+ * @param {string} dependency
+ */
+function ensureHoistedDependencyLink(packagePath, dependency) {
+  const localNodeModules = path.join(packagePath, 'node_modules');
+  const localDependencyPath = path.join(localNodeModules, dependency);
+  const dependencyPath = resolvePackagePath(dependency, packagePath);
+  if (dependencyPath === localDependencyPath) {
+    return;
+  }
+  if (path.dirname(dependencyPath) === localNodeModules) {
+    return;
+  }
+
+  fs.mkdirSync(path.dirname(localDependencyPath), { recursive: true });
+  ensureSymlink(localDependencyPath, dependencyPath);
+}
+
+/**
+ * @param {string} linkPath
+ * @param {string} targetPath
+ */
+function ensureSymlink(linkPath, targetPath) {
+  if (linkPath === targetPath) {
+    return;
+  }
+  const stat = fs.lstatSync(linkPath, { throwIfNoEntry: false });
+  if (stat) {
+    if (!stat.isSymbolicLink()) {
+      return;
+    }
+    const currentTarget = path.resolve(
+      path.dirname(linkPath),
+      fs.readlinkSync(linkPath)
+    );
+    if (currentTarget === targetPath) {
+      return;
+    }
+    fs.unlinkSync(linkPath);
+  }
+  fs.symlinkSync(path.relative(path.dirname(linkPath), targetPath), linkPath);
+}
+
+/**
+ * @param {string} packageName
+ * @param {string} basedir
+ * @returns {string}
+ */
+function resolvePackagePath(packageName, basedir) {
+  for (const nodeModulesPath of nodeModuleSearchPaths(basedir)) {
+    const packagePath = path.join(nodeModulesPath, packageName);
+    const packageJsonPath = path.join(packagePath, 'package.json');
+    if (fs.existsSync(packageJsonPath)) {
+      return packagePath;
+    }
+  }
+  throw new Error(`Could not resolve package '${packageName}' from '${basedir}'.`);
+}
+
+/**
+ * @param {string} basedir
+ * @returns {string[]}
+ */
+function nodeModuleSearchPaths(basedir) {
+  const result = [];
+  let current = path.resolve(basedir);
+  while (current !== path.dirname(current)) {
+    result.push(path.join(current, 'node_modules'));
+    current = path.dirname(current);
+  }
+  result.push(path.join(current, 'node_modules'));
+  return result;
 }
 
 function electronPlatform() {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "**/inversify": "6.0.2",
     "**/ip": "^2.0.1",
     "**/perfect-scrollbar": "1.5.5",
+    "app-builder-bin": "4.2.0",
     "nx/axios": "^1.6.7"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3852,10 +3852,10 @@ anymatch@~3.1.2:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-app-builder-bin@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-4.0.0.tgz#1df8e654bd1395e4a319d82545c98667d7eed2f0"
-  integrity sha512-xwdG0FJPQMe0M0UA4Tz0zEB8rBJTRA5a476ZawAqiBkMv16GRK5xpXThOjMaEOFnZ6zabejjG4J3da0SXG63KA==
+app-builder-bin@4.0.0, app-builder-bin@4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/app-builder-bin/-/app-builder-bin-4.2.0.tgz#8ba57c6bbb74510c3ee2c6dc6ad8e2ad7f4074a2"
+  integrity sha512-PGXlkukQnroTgAaDZnnppdLzsRJmab6Rh/rJ5fKyYaYhd+FfaORH59/ArkB5dr2cAeYQU5lCeHFEwURaoBO8BA==
 
 app-builder-lib@24.13.3:
   version "24.13.3"


### PR DESCRIPTION
- Build machine: EC2 Arm64 (t4g instance type) + Ubuntu 24
- Chromebook: ASUS CM1402FM2 + ChromeOS 149 + Linux Penguin 6.6

Tests:
 - Build on EC2 Arm64 VM (using steps in scripts/package.sh)
 - SFTP AppImage to Linux on Chromebook
 - Install libnss3 on Chromebook Linux
 - Run AppImage, Connect ESP32 board (delegate USB to Linux), Upload Sketch

### Motivation

Enable Arduino IDE Linux builds for Arm64 systems; in particular Chromebook Linux environments running on Arm64 hardware.  

Note that Arm64 Chromebook is the standard hardware platform for K-12 education.

### Change description

Updated the Electron packaging flow to support Linux Arm64 AppImage and ZIP generation. The packaging script now prepares the required Linux packaging tools, ensures app-builder-bin is executable, adds the bundled 7zip binary to PATH, and forces maximum compression so AppImage creation uses a compression format supported by the Arm64 mksquashfs payload.

Added workspace dependency linking before packaging so electron-builder can correctly validate dependencies when Yarn workspaces have linked or hoisted packages outside the Electron app directory. This includes linking the local arduino-ide-extension workspace package and creating package-local links for hoisted production dependencies discovered by app-builder-bin.

Added a prebuild helper for the Electron app that builds arduino-ide-extension when the expected compiled extension entry point is missing, ensuring the Electron build has the extension artifacts it needs. Also pinned app-builder-bin through the root package resolutions to keep packaging behavior consistent.

### Other information

The Linux-specific packaging changes are gated to Linux builds. The dependency-linking and extension prebuild safeguards run across platforms to keep workspace packaging consistent, so the primary compatibility risk is symlink behavior on Windows; existing CI should validate that path. 

### Reviewer checklist

- [ ] PR addresses a single concern.
- [ ] The PR has no duplicates (please search among the [Pull Requests](https://github.com/arduino/arduino-ide/pulls) before creating one)
- [ ] PR title and description are properly filled.
- [ ] Docs have been added / updated (for bug fixes / features)
