### PR TITLE
fix: use the output buffer for Serial Monitor select-all and copy

### DIFF
--- a/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
+++ b/arduino-ide-extension/src/browser/arduino-ide-frontend-module.ts
@@ -72,7 +72,11 @@ import {
   ConfigServicePath,
 } from '../common/protocol/config-service';
 import { MonitorWidget } from './serial/monitor/monitor-widget';
-import { MonitorViewContribution } from './serial/monitor/monitor-view-contribution';
+import {
+  MonitorViewContribution,
+  SerialMonitorOutputFocusContext,
+} from './serial/monitor/monitor-view-contribution';
+import { KeybindingContext } from '@theia/core/lib/browser/keybinding';
 import { TabBarDecoratorService as TheiaTabBarDecoratorService } from '@theia/core/lib/browser/shell/tab-bar-decorator';
 import { TabBarDecoratorService } from './theia/core/tab-bar-decorator';
 import { ProblemManager as TheiaProblemManager } from '@theia/markers/lib/browser';
@@ -517,6 +521,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
   bind(MonitorModel).toSelf().inSingletonScope();
   bindViewContribution(bind, MonitorViewContribution);
   bind(TabBarToolbarContribution).toService(MonitorViewContribution);
+  bind(KeybindingContext).toConstantValue(SerialMonitorOutputFocusContext);
   bind(WidgetFactory).toDynamicValue((context) => ({
     id: MonitorWidget.ID,
     createWidget: () => context.container.get(MonitorWidget),

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-utils.ts
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-utils.ts
@@ -71,3 +71,9 @@ export function truncateLines(
 export function joinLines(lines: Line[]): string {
   return lines.map((line: Line) => line.message).join('');
 }
+
+export function linesToPlainText(lines: Line[]): string {
+  // Replace null characters with a visible symbol. Otherwise, the
+  // clipboard content would be truncated at the first null character.
+  return joinLines(lines).replace(/\u0000/g, '\u25A1');
+}

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-view-contribution.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-view-contribution.tsx
@@ -9,7 +9,12 @@ import {
   ApplicationShell,
   codicon,
 } from '@theia/core/lib/browser';
+import {
+  KeybindingContext,
+  KeybindingRegistry,
+} from '@theia/core/lib/browser/keybinding';
 import { MonitorWidget } from './monitor-widget';
+import { SerialMonitorOutput } from './serial-monitor-send-output';
 import { MenuModelRegistry, Command, CommandRegistry } from '@theia/core';
 import {
   TabBarToolbarContribution,
@@ -55,8 +60,23 @@ export namespace SerialMonitor {
     export const COPY_OUTPUT = {
       id: 'serial-monitor-copy-output',
     };
+    export const SELECT_ALL_OUTPUT = {
+      id: 'serial-monitor-select-all-output',
+    };
   }
 }
+
+/**
+ * Enables serial-monitor-specific keybindings when the monitor output area
+ * has the focus.
+ */
+export const SerialMonitorOutputFocusContext: KeybindingContext = {
+  id: 'serialMonitorOutputFocus',
+  isEnabled: () =>
+    !!document.activeElement?.closest(
+      `.${SerialMonitorOutput.CONTAINER_CLASS}`
+    ),
+};
 
 @injectable()
 export class MonitorViewContribution
@@ -179,6 +199,9 @@ export class MonitorViewContribution
         }
       },
     });
+    commands.registerCommand(SerialMonitor.Commands.SELECT_ALL_OUTPUT, {
+      execute: () => this.tryGetWidget()?.selectAllOutput(),
+    });
     if (this.toggleCommand) {
       commands.registerCommand(this.toggleCommand, {
         execute: () => this.toggle(),
@@ -196,6 +219,15 @@ export class MonitorViewContribution
       { id: MonitorViewContribution.RESET_SERIAL_MONITOR },
       { execute: () => this.reset() }
     );
+  }
+
+  override registerKeybindings(keybindings: KeybindingRegistry): void {
+    super.registerKeybindings(keybindings);
+    keybindings.registerKeybinding({
+      command: SerialMonitor.Commands.SELECT_ALL_OUTPUT.id,
+      keybinding: 'CtrlCmd+A',
+      context: SerialMonitorOutputFocusContext.id,
+    });
   }
 
   protected async toggle(): Promise<void> {

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
@@ -49,6 +49,7 @@ export class MonitorWidget extends ReactWidget {
   protected closing = false;
   protected readonly clearOutputEmitter = new Emitter<void>();
   protected readonly copyOutputEmitter = new Emitter<void>();
+  protected readonly selectAllOutputEmitter = new Emitter<void>();
 
   @inject(MonitorModel)
   private readonly monitorModel: MonitorModel;
@@ -71,7 +72,11 @@ export class MonitorWidget extends ReactWidget {
     this.title.closable = true;
     this.scrollOptions = undefined;
     this.toDisposeOnReset = new DisposableCollection();
-    this.toDispose.push(this.clearOutputEmitter);
+    this.toDispose.pushAll([
+      this.clearOutputEmitter,
+      this.copyOutputEmitter,
+      this.selectAllOutputEmitter,
+    ]);
   }
 
   @postConstruct()
@@ -109,6 +114,10 @@ export class MonitorWidget extends ReactWidget {
   
   copyOutput(): void {
     this.copyOutputEmitter.fire();
+  }
+
+  selectAllOutput(): void {
+    this.selectAllOutputEmitter.fire();
   }
 
   override dispose(): void {
@@ -256,6 +265,7 @@ export class MonitorWidget extends ReactWidget {
             monitorManagerProxy={this.monitorManagerProxy}
             clearConsoleEvent={this.clearOutputEmitter.event}
             copyOutputEvent={this.copyOutputEmitter.event}
+            selectAllEvent={this.selectAllOutputEmitter.event}
             clipboardService={this.clipboardService}
             height={Math.floor(this.widgetHeight - 50)}
           />

--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -3,7 +3,11 @@ import { Event } from '@theia/core/lib/common/event';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { areEqual, FixedSizeList as List } from 'react-window';
 import dateFormat from 'dateformat';
-import { messagesToLines, truncateLines, joinLines } from './monitor-utils';
+import {
+  messagesToLines,
+  truncateLines,
+  linesToPlainText,
+} from './monitor-utils';
 import { MonitorManagerProxyClient } from '../../../common/protocol';
 import { MonitorModel } from '../../monitor-model';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
@@ -19,10 +23,17 @@ export class SerialMonitorOutput extends React.Component<
    */
   protected toDisposeBeforeUnmount = new DisposableCollection();
   private listRef: React.RefObject<List>;
+  private containerRef: React.RefObject<HTMLDivElement>;
+  /**
+   * Tracks whether the user has "selected all" output. The DOM selection
+   * alone cannot represent it because only the visible rows are rendered.
+   */
+  private allSelected = false;
 
   constructor(props: Readonly<SerialMonitorOutput.Props>) {
     super(props);
     this.listRef = React.createRef();
+    this.containerRef = React.createRef();
     this.state = {
       lines: [],
       timestamp: this.props.monitorModel.timestamp,
@@ -32,21 +43,30 @@ export class SerialMonitorOutput extends React.Component<
 
   override render(): React.ReactNode {
     return (
-      <List
-        className="serial-monitor-messages"
-        height={this.props.height}
-        itemData={{
-          lines: this.state.lines,
-          timestamp: this.state.timestamp,
-        }}
-        itemCount={this.state.lines.length}
-        itemSize={18}
-        width={'100%'}
-        style={{ whiteSpace: 'nowrap' }}
-        ref={this.listRef}
+      <div
+        className={SerialMonitorOutput.CONTAINER_CLASS}
+        tabIndex={0}
+        ref={this.containerRef}
+        onCopy={this.onCopy}
+        onMouseDown={this.onMouseDown}
+        onBlur={this.onBlur}
       >
-        {Row}
-      </List>
+        <List
+          className="serial-monitor-messages"
+          height={this.props.height}
+          itemData={{
+            lines: this.state.lines,
+            timestamp: this.state.timestamp,
+          }}
+          itemCount={this.state.lines.length}
+          itemSize={18}
+          width={'100%'}
+          style={{ whiteSpace: 'nowrap' }}
+          ref={this.listRef}
+        >
+          {Row}
+        </List>
+      </div>
     );
   }
 
@@ -75,12 +95,12 @@ export class SerialMonitorOutput extends React.Component<
       this.props.clearConsoleEvent(() =>
         this.setState({ lines: [], charCount: 0 })
       ),
-      this.props.copyOutputEvent(() => {
-        const text = joinLines(this.state.lines);
-        // Replace null characters with a visible symbol
-        const safe = text.replace(/\u0000/g, '\u25A1');
-        this.props.clipboardService.writeText(safe);
-      }),
+      this.props.copyOutputEvent(() =>
+        this.props.clipboardService.writeText(
+          linesToPlainText(this.state.lines)
+        )
+      ),
+      this.props.selectAllEvent(() => this.selectAll()),
       this.props.monitorModel.onChange(({ property }) => {
         if (property === 'timestamp') {
           const { timestamp } = this.props.monitorModel;
@@ -93,6 +113,17 @@ export class SerialMonitorOutput extends React.Component<
     ]);
   }
 
+  override componentDidUpdate(): void {
+    if (this.allSelected) {
+      // The selection is lost when `react-window` re-renders the visible
+      // rows. Reselect the container to keep the "select all" state alive.
+      const node = this.containerRef.current;
+      if (node) {
+        document.getSelection()?.selectAllChildren(node);
+      }
+    }
+  }
+
   override componentWillUnmount(): void {
     // TODO: "Your preferred browser's local storage is almost full." Discard `content` before saving layout?
     this.toDisposeBeforeUnmount.dispose();
@@ -101,6 +132,37 @@ export class SerialMonitorOutput extends React.Component<
   private readonly scrollToBottom = () => {
     if (this.listRef.current && this.props.monitorModel.autoscroll) {
       this.listRef.current.scrollToItem(this.state.lines.length, 'end');
+    }
+  };
+
+  private readonly selectAll = (): void => {
+    const node = this.containerRef.current;
+    if (node) {
+      node.focus();
+      document.getSelection()?.selectAllChildren(node);
+      this.allSelected = true;
+    }
+  };
+
+  private readonly onCopy = (event: React.ClipboardEvent): void => {
+    const text = this.allSelected
+      ? linesToPlainText(this.state.lines)
+      : document.getSelection()?.toString();
+    if (text) {
+      // Write the monitor output as plain text to the clipboard. The
+      // default behavior would copy the formatted HTML of the visible rows.
+      event.preventDefault();
+      event.clipboardData.setData('text/plain', text);
+    }
+  };
+
+  private readonly onMouseDown = (): void => {
+    this.allSelected = false;
+  };
+
+  private readonly onBlur = (event: React.FocusEvent<HTMLDivElement>): void => {
+    if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      this.allSelected = false;
     }
   };
 }
@@ -133,11 +195,18 @@ const _Row = ({
 const Row = React.memo(_Row, areEqual);
 
 export namespace SerialMonitorOutput {
+  /**
+   * CSS class of the focusable output container. Keybindings that must only
+   * be active inside the output area check the current focus against it.
+   */
+  export const CONTAINER_CLASS = 'serial-monitor-messages-container';
+
   export interface Props {
     readonly monitorModel: MonitorModel;
     readonly monitorManagerProxy: MonitorManagerProxyClient;
     readonly clearConsoleEvent: Event<void>;
     readonly copyOutputEvent: Event<void>;
+    readonly selectAllEvent: Event<void>;
     readonly clipboardService: ClipboardService;
     readonly height: number;
   }

--- a/arduino-ide-extension/src/browser/style/monitor.css
+++ b/arduino-ide-extension/src/browser/style/monitor.css
@@ -78,6 +78,11 @@
     padding: 5px;
 }
 
+.serial-monitor-messages-container:focus {
+    outline: 1px solid var(--theia-focusBorder);
+    outline-offset: -1px;
+}
+
 .p-TabBar-toolbar .item.arduino-monitor {
     width: 24px;
     justify-content: center;

--- a/arduino-ide-extension/src/test/browser/monitor-utils.test.ts
+++ b/arduino-ide-extension/src/test/browser/monitor-utils.test.ts
@@ -3,6 +3,7 @@ import {
   messagesToLines,
   truncateLines,
   joinLines,
+  linesToPlainText,
 } from '../../browser/serial/monitor/monitor-utils';
 import { Line } from '../../browser/serial/monitor/serial-monitor-send-output';
 import { set, reset } from 'mockdate';
@@ -176,6 +177,24 @@ describe('Monitor Utils', () => {
           expect(joined_str).to.equal(testLine.expectedJoined);
         }
       });
+    });
+  });
+
+  context('when converting lines to plain text', () => {
+    it('should join the lines', () => {
+      const lines: Line[] = [
+        { message: 'Hello\n', lineLen: 6 },
+        { message: 'Dog!', lineLen: 4 },
+      ];
+      expect(linesToPlainText(lines)).to.equal('Hello\nDog!');
+    });
+
+    it('should replace null characters with a visible symbol', () => {
+      const lines: Line[] = [
+        { message: 'He', lineLen: 2 },
+        { message: '\u0000llo!', lineLen: 5 },
+      ];
+      expect(linesToPlainText(lines)).to.equal('He\u25A1llo!');
     });
   });
 });


### PR DESCRIPTION
### Motivation

In IDE 1.x users could click into the Serial Monitor, press Ctrl+A and then Ctrl+C to copy the
whole output. In IDE 2.x this is not possible:

- The output is virtualized with react-window, so only the visible rows exist in the DOM. Mouse
  selection plus copy can only capture roughly one screen of data (#1081).
- Ctrl/Cmd+A is handled by the global `core.selectAll` keybinding, which selects the surrounding
  document instead of the monitor output (#812).
- Copied content arrives as formatted HTML, which pastes badly into spreadsheets (#2093).

This matters in education: schools and universities use Arduinos as low-cost measurement
instruments in physics classes, and copying a recorded measurement series out of the Serial
Monitor is a routine step there (several comments on #812 describe classroom use).

#2718 added a `Copy Output` toolbar button that copies the internal line buffer. This PR connects
the same buffer to the keyboard workflow users expect from IDE 1.x.

### Change description

- Click into the Serial Monitor output and press Ctrl/Cmd+A: the output area is selected. This is
  a new `serial-monitor-select-all-output` command, bound via a keybinding context that is only
  enabled while the output area has focus. The global select-all behavior everywhere else,
  including the monitor's message input field, is untouched.
- Ctrl/Cmd+C then copies the complete buffered output as plain text, with the same null-character
  sanitizing as `Copy Output`. The shared logic is extracted into `linesToPlainText` in
  `monitor-utils.ts`.
- Copying a manual mouse selection inside the output now writes plain text instead of formatted
  HTML to the clipboard (#2093).
- The select-all state is cleared on click or when the output area loses focus. While it is
  active, incoming messages keep the selection alive.
- The focusable output area shows a themed focus outline, so keyboard users can see that the
  shortcut targets it.

### Other information

- The copied "select all" content is the raw buffer without timestamps, identical to the
  `Copy Output` button. A manual mouse selection copies what is rendered, including timestamps if
  they are enabled. In both cases the clipboard receives plain text only.
- Mouse selection is still limited to the rendered rows: lines that are scrolled out of view do
  not exist in the DOM, so a drag selection cannot reach them. Selecting everything is what
  Ctrl/Cmd+A is for.
- #2885 addresses the same issues by replacing the virtualized list with a read-only textarea.
  That gives native selection, but it re-renders the whole buffer on every message batch, which
  is the problem the virtualization was introduced for, and it loses the timestamp rendering.
  This PR keeps the virtualized list and the timestamps and only wires the existing buffer to the
  expected shortcuts.

Fixes #812
Refs #1081, #2093
