### PR TITLE
feat: add a save-output action to the Serial Monitor

### DIFF
--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-utils.ts
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-utils.ts
@@ -71,3 +71,9 @@ export function truncateLines(
 export function joinLines(lines: Line[]): string {
   return lines.map((line: Line) => line.message).join('');
 }
+
+export function linesToPlainText(lines: Line[]): string {
+  // Replace null characters with a visible symbol. Otherwise, the
+  // clipboard content would be truncated at the first null character.
+  return joinLines(lines).replace(/\u0000/g, '\u25A1');
+}

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-view-contribution.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-view-contribution.tsx
@@ -11,6 +11,11 @@ import {
 } from '@theia/core/lib/browser';
 import { MonitorWidget } from './monitor-widget';
 import { MenuModelRegistry, Command, CommandRegistry } from '@theia/core';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import URI from '@theia/core/lib/common/uri';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import dateFormat from 'dateformat';
 import {
   TabBarToolbarContribution,
   TabBarToolbarRegistry,
@@ -20,7 +25,11 @@ import { ArduinoMenus } from '../../menu/arduino-menus';
 import { nls } from '@theia/core/lib/common';
 import { Event } from '@theia/core/lib/common/event';
 import { MonitorModel } from '../../monitor-model';
-import { MonitorManagerProxyClient } from '../../../common/protocol';
+import {
+  FileSystemExt,
+  MonitorManagerProxyClient,
+} from '../../../common/protocol';
+import { DialogService } from '../../dialog-service';
 import {
   ArduinoPreferences,
   defaultMonitorWidgetDockPanel,
@@ -55,6 +64,9 @@ export namespace SerialMonitor {
     export const COPY_OUTPUT = {
       id: 'serial-monitor-copy-output',
     };
+    export const SAVE_OUTPUT = {
+      id: 'serial-monitor-save-output',
+    };
   }
 }
 
@@ -74,6 +86,16 @@ export class MonitorViewContribution
   private readonly monitorManagerProxy: MonitorManagerProxyClient;
   @inject(ArduinoPreferences)
   private readonly arduinoPreferences: ArduinoPreferences;
+  @inject(DialogService)
+  private readonly dialogService: DialogService;
+  @inject(FileService)
+  private readonly fileService: FileService;
+  @inject(FileSystemExt)
+  private readonly fileSystemExt: FileSystemExt;
+  @inject(EnvVariablesServer)
+  private readonly envVariablesServer: EnvVariablesServer;
+  @inject(MessageService)
+  private readonly messageService: MessageService;
 
   private _panel: ApplicationShell.Area;
 
@@ -158,6 +180,12 @@ export class MonitorViewContribution
       icon: codicon('copy'),
       tooltip: nls.localize('arduino/serial/copyOutput', 'Copy Output'),
     });
+    registry.registerItem({
+      id: SerialMonitor.Commands.SAVE_OUTPUT.id,
+      command: SerialMonitor.Commands.SAVE_OUTPUT.id,
+      icon: codicon('save-as'),
+      tooltip: nls.localize('arduino/serial/saveOutput', 'Save Output'),
+    });
   }
 
   override registerCommands(commands: CommandRegistry): void {
@@ -176,6 +204,15 @@ export class MonitorViewContribution
       execute: (widget) => {
         if (widget instanceof MonitorWidget) {
           widget.copyOutput();
+        }
+      },
+    });
+    commands.registerCommand(SerialMonitor.Commands.SAVE_OUTPUT, {
+      isEnabled: (widget) => widget instanceof MonitorWidget,
+      isVisible: (widget) => widget instanceof MonitorWidget,
+      execute: (widget) => {
+        if (widget instanceof MonitorWidget) {
+          return this.saveOutput(widget);
         }
       },
     });
@@ -212,6 +249,48 @@ export class MonitorViewContribution
     if (widget) {
       widget.reset();
     }
+  }
+
+  protected async saveOutput(widget: MonitorWidget): Promise<void> {
+    const text = widget.outputText();
+    const homeDirUri = new URI(await this.envVariablesServer.getHomeDirUri());
+    const defaultUri = homeDirUri.resolve(
+      `serial-monitor-${dateFormat(new Date(), 'yyyymmdd-HHMMss')}.txt`
+    );
+    const defaultPath = await this.fileService.fsPath(defaultUri);
+    const { filePath, canceled } = await this.dialogService.showSaveDialog({
+      title: nls.localize(
+        'arduino/serial/saveOutputAs',
+        'Save Serial Monitor output as...'
+      ),
+      defaultPath,
+      filters: [
+        {
+          name: nls.localize('arduino/serial/textFiles', 'Text Files'),
+          extensions: ['txt', 'log'],
+        },
+        {
+          name: nls.localize('arduino/serial/allFiles', 'All Files'),
+          extensions: ['*'],
+        },
+      ],
+    });
+    if (canceled || !filePath) {
+      return;
+    }
+    const destinationUri = await this.fileSystemExt.getUri(filePath);
+    if (!destinationUri) {
+      return;
+    }
+    await this.fileService.write(new URI(destinationUri), text);
+    this.messageService.info(
+      nls.localize(
+        'arduino/serial/savedOutput',
+        "Saved Serial Monitor output to '{0}'.",
+        filePath
+      ),
+      { timeout: 2000 }
+    );
   }
 
   protected renderAutoScrollButton(): React.ReactNode {

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
@@ -49,6 +49,7 @@ export class MonitorWidget extends ReactWidget {
   protected closing = false;
   protected readonly clearOutputEmitter = new Emitter<void>();
   protected readonly copyOutputEmitter = new Emitter<void>();
+  protected readonly outputRef = React.createRef<SerialMonitorOutput>();
 
   @inject(MonitorModel)
   private readonly monitorModel: MonitorModel;
@@ -109,6 +110,14 @@ export class MonitorWidget extends ReactWidget {
   
   copyOutput(): void {
     this.copyOutputEmitter.fire();
+  }
+
+  /**
+   * The current output as plain text, in the same form as the
+   * `Copy Output` toolbar action puts it on the clipboard.
+   */
+  outputText(): string {
+    return this.outputRef.current?.getPlainText() ?? '';
   }
 
   override dispose(): void {
@@ -252,6 +261,7 @@ export class MonitorWidget extends ReactWidget {
         </div>
         <div className="body">
           <SerialMonitorOutput
+            ref={this.outputRef}
             monitorModel={this.monitorModel}
             monitorManagerProxy={this.monitorManagerProxy}
             clearConsoleEvent={this.clearOutputEmitter.event}

--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -3,7 +3,11 @@ import { Event } from '@theia/core/lib/common/event';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { areEqual, FixedSizeList as List } from 'react-window';
 import dateFormat from 'dateformat';
-import { messagesToLines, truncateLines, joinLines } from './monitor-utils';
+import {
+  messagesToLines,
+  truncateLines,
+  linesToPlainText,
+} from './monitor-utils';
 import { MonitorManagerProxyClient } from '../../../common/protocol';
 import { MonitorModel } from '../../monitor-model';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
@@ -28,6 +32,14 @@ export class SerialMonitorOutput extends React.Component<
       timestamp: this.props.monitorModel.timestamp,
       charCount: 0,
     };
+  }
+
+  /**
+   * The current output as plain text, in the same form as the
+   * `Copy Output` toolbar action puts it on the clipboard.
+   */
+  getPlainText(): string {
+    return linesToPlainText(this.state.lines);
   }
 
   override render(): React.ReactNode {
@@ -75,12 +87,11 @@ export class SerialMonitorOutput extends React.Component<
       this.props.clearConsoleEvent(() =>
         this.setState({ lines: [], charCount: 0 })
       ),
-      this.props.copyOutputEvent(() => {
-        const text = joinLines(this.state.lines);
-        // Replace null characters with a visible symbol
-        const safe = text.replace(/\u0000/g, '\u25A1');
-        this.props.clipboardService.writeText(safe);
-      }),
+      this.props.copyOutputEvent(() =>
+        this.props.clipboardService.writeText(
+          linesToPlainText(this.state.lines)
+        )
+      ),
       this.props.monitorModel.onChange(({ property }) => {
         if (property === 'timestamp') {
           const { timestamp } = this.props.monitorModel;

--- a/arduino-ide-extension/src/test/browser/monitor-utils.test.ts
+++ b/arduino-ide-extension/src/test/browser/monitor-utils.test.ts
@@ -3,6 +3,7 @@ import {
   messagesToLines,
   truncateLines,
   joinLines,
+  linesToPlainText,
 } from '../../browser/serial/monitor/monitor-utils';
 import { Line } from '../../browser/serial/monitor/serial-monitor-send-output';
 import { set, reset } from 'mockdate';
@@ -176,6 +177,24 @@ describe('Monitor Utils', () => {
           expect(joined_str).to.equal(testLine.expectedJoined);
         }
       });
+    });
+  });
+
+  context('when converting lines to plain text', () => {
+    it('should join the lines', () => {
+      const lines: Line[] = [
+        { message: 'Hello\n', lineLen: 6 },
+        { message: 'Dog!', lineLen: 4 },
+      ];
+      expect(linesToPlainText(lines)).to.equal('Hello\nDog!');
+    });
+
+    it('should replace null characters with a visible symbol', () => {
+      const lines: Line[] = [
+        { message: 'He', lineLen: 2 },
+        { message: '\u0000llo!', lineLen: 5 },
+      ];
+      expect(linesToPlainText(lines)).to.equal('He\u25A1llo!');
     });
   });
 });

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -430,6 +430,7 @@
     "replaceMsg": "Replace the existing version of {0}?",
     "selectZip": "Select a zip file containing the library you'd like to add",
     "serial": {
+      "allFiles": "All Files",
       "autoscroll": "Autoscroll",
       "carriageReturn": "Carriage Return",
       "connecting": "Connecting to '{0}' on '{1}'...",
@@ -440,6 +441,10 @@
       "noLineEndings": "No Line Ending",
       "notConnected": "Not connected. Select a board and a port to connect automatically.",
       "openSerialPlotter": "Serial Plotter",
+      "saveOutput": "Save Output",
+      "saveOutputAs": "Save Serial Monitor output as...",
+      "savedOutput": "Saved Serial Monitor output to '{0}'.",
+      "textFiles": "Text Files",
       "timestamp": "Timestamp",
       "toggleTimestamp": "Toggle Timestamp"
     },


### PR DESCRIPTION
### Motivation

Saving the Serial Monitor output to a file is a long-standing request (#549). Until now the only
way was copy and paste, which is limited by the selection issues around the virtualized output.
In physics classes, where Arduinos often serve as low-cost measurement instruments, saving a
recorded run directly from the Serial Monitor replaces a fiddly copy-and-paste step.

#2718 introduced a `Copy Output` toolbar button backed by the monitor's internal line buffer.
This PR adds the matching `Save Output` action.

### Change description

- New `Save Output` toolbar button next to `Copy Output`, backed by a new
  `serial-monitor-save-output` command.
- The button opens the native save dialog (default file name
  `serial-monitor-YYYYMMDD-HHMMSS.txt`, filters for `.txt`/`.log` and all files) and writes the
  currently buffered output as plain text.
- The text is produced by the exact same logic as `Copy Output` (`linesToPlainText`): raw output,
  null characters replaced with a visible symbol, no timestamps.
- A short confirmation notification is shown after saving, following the `Archive Sketch` pattern.

### Other information

This saves the currently buffered output (up to `MAX_CHARACTERS`, 1,000,000 characters), same as
the copy button. Continuous background logging to a file is a different feature and out of scope
here.

Fixes #549
