### PR TITLE
feat: support CSV export in the Serial Monitor save action

### DIFF
--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-utils.ts
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-utils.ts
@@ -71,3 +71,9 @@ export function truncateLines(
 export function joinLines(lines: Line[]): string {
   return lines.map((line: Line) => line.message).join('');
 }
+
+export function linesToPlainText(lines: Line[]): string {
+  // Replace null characters with a visible symbol. Otherwise, the
+  // clipboard content would be truncated at the first null character.
+  return joinLines(lines).replace(/\u0000/g, '\u25A1');
+}

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-utils.ts
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-utils.ts
@@ -1,4 +1,10 @@
+import dateFormat from 'dateformat';
 import { Line, SerialMonitorOutput } from './serial-monitor-send-output';
+
+/**
+ * The format of the timestamps rendered in the Serial Monitor output.
+ */
+export const LINE_TIMESTAMP_FORMAT = 'HH:MM:ss.l';
 
 export function messagesToLines(
   messages: string[],
@@ -76,4 +82,28 @@ export function linesToPlainText(lines: Line[]): string {
   // Replace null characters with a visible symbol. Otherwise, the
   // clipboard content would be truncated at the first null character.
   return joinLines(lines).replace(/\u0000/g, '\u25A1');
+}
+
+export function linesToCsvText(
+  lines: Line[],
+  includeTimestamps: boolean
+): string {
+  const rows = lines
+    .filter((line) => line.lineLen > 0)
+    .map((line) => {
+      // The message is written as-is: Serial Monitor output is typically
+      // already delimiter-separated data, and quoting it would merge the
+      // payload into a single spreadsheet column.
+      const message = line.message
+        .replace(/[\r\n]+$/, '')
+        .replace(/\u0000/g, '\u25A1');
+      if (!includeTimestamps) {
+        return message;
+      }
+      const timestamp = line.timestamp
+        ? dateFormat(line.timestamp, LINE_TIMESTAMP_FORMAT)
+        : '';
+      return `${timestamp},${message}`;
+    });
+  return rows.length ? rows.join('\n') + '\n' : '';
 }

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-view-contribution.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-view-contribution.tsx
@@ -11,6 +11,11 @@ import {
 } from '@theia/core/lib/browser';
 import { MonitorWidget } from './monitor-widget';
 import { MenuModelRegistry, Command, CommandRegistry } from '@theia/core';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import URI from '@theia/core/lib/common/uri';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import dateFormat from 'dateformat';
 import {
   TabBarToolbarContribution,
   TabBarToolbarRegistry,
@@ -20,7 +25,11 @@ import { ArduinoMenus } from '../../menu/arduino-menus';
 import { nls } from '@theia/core/lib/common';
 import { Event } from '@theia/core/lib/common/event';
 import { MonitorModel } from '../../monitor-model';
-import { MonitorManagerProxyClient } from '../../../common/protocol';
+import {
+  FileSystemExt,
+  MonitorManagerProxyClient,
+} from '../../../common/protocol';
+import { DialogService } from '../../dialog-service';
 import {
   ArduinoPreferences,
   defaultMonitorWidgetDockPanel,
@@ -55,6 +64,9 @@ export namespace SerialMonitor {
     export const COPY_OUTPUT = {
       id: 'serial-monitor-copy-output',
     };
+    export const SAVE_OUTPUT = {
+      id: 'serial-monitor-save-output',
+    };
   }
 }
 
@@ -74,6 +86,16 @@ export class MonitorViewContribution
   private readonly monitorManagerProxy: MonitorManagerProxyClient;
   @inject(ArduinoPreferences)
   private readonly arduinoPreferences: ArduinoPreferences;
+  @inject(DialogService)
+  private readonly dialogService: DialogService;
+  @inject(FileService)
+  private readonly fileService: FileService;
+  @inject(FileSystemExt)
+  private readonly fileSystemExt: FileSystemExt;
+  @inject(EnvVariablesServer)
+  private readonly envVariablesServer: EnvVariablesServer;
+  @inject(MessageService)
+  private readonly messageService: MessageService;
 
   private _panel: ApplicationShell.Area;
 
@@ -158,6 +180,12 @@ export class MonitorViewContribution
       icon: codicon('copy'),
       tooltip: nls.localize('arduino/serial/copyOutput', 'Copy Output'),
     });
+    registry.registerItem({
+      id: SerialMonitor.Commands.SAVE_OUTPUT.id,
+      command: SerialMonitor.Commands.SAVE_OUTPUT.id,
+      icon: codicon('save-as'),
+      tooltip: nls.localize('arduino/serial/saveOutput', 'Save Output'),
+    });
   }
 
   override registerCommands(commands: CommandRegistry): void {
@@ -176,6 +204,15 @@ export class MonitorViewContribution
       execute: (widget) => {
         if (widget instanceof MonitorWidget) {
           widget.copyOutput();
+        }
+      },
+    });
+    commands.registerCommand(SerialMonitor.Commands.SAVE_OUTPUT, {
+      isEnabled: (widget) => widget instanceof MonitorWidget,
+      isVisible: (widget) => widget instanceof MonitorWidget,
+      execute: (widget) => {
+        if (widget instanceof MonitorWidget) {
+          return this.saveOutput(widget);
         }
       },
     });
@@ -212,6 +249,48 @@ export class MonitorViewContribution
     if (widget) {
       widget.reset();
     }
+  }
+
+  protected async saveOutput(widget: MonitorWidget): Promise<void> {
+    const text = widget.outputText();
+    const homeDirUri = new URI(await this.envVariablesServer.getHomeDirUri());
+    const defaultUri = homeDirUri.resolve(
+      `serial-monitor-${dateFormat(new Date(), 'yyyymmdd-HHMMss')}.txt`
+    );
+    const defaultPath = await this.fileService.fsPath(defaultUri);
+    const { filePath, canceled } = await this.dialogService.showSaveDialog({
+      title: nls.localize(
+        'arduino/serial/saveOutputAs',
+        'Save Serial Monitor output as...'
+      ),
+      defaultPath,
+      filters: [
+        {
+          name: nls.localize('arduino/serial/textFiles', 'Text Files'),
+          extensions: ['txt', 'log'],
+        },
+        {
+          name: nls.localize('arduino/serial/allFiles', 'All Files'),
+          extensions: ['*'],
+        },
+      ],
+    });
+    if (canceled || !filePath) {
+      return;
+    }
+    const destinationUri = await this.fileSystemExt.getUri(filePath);
+    if (!destinationUri) {
+      return;
+    }
+    await this.fileService.write(new URI(destinationUri), text);
+    this.messageService.info(
+      nls.localize(
+        'arduino/serial/savedOutput',
+        "Saved Serial Monitor output to '{0}'.",
+        filePath
+      ),
+      { timeout: 2000 }
+    );
   }
 
   protected renderAutoScrollButton(): React.ReactNode {

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-view-contribution.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-view-contribution.tsx
@@ -252,7 +252,10 @@ export class MonitorViewContribution
   }
 
   protected async saveOutput(widget: MonitorWidget): Promise<void> {
-    const text = widget.outputText();
+    // Capture the output before showing the dialog; the buffer keeps
+    // changing while the dialog is open.
+    const plainText = widget.outputText();
+    const csvText = widget.outputCsvText();
     const homeDirUri = new URI(await this.envVariablesServer.getHomeDirUri());
     const defaultUri = homeDirUri.resolve(
       `serial-monitor-${dateFormat(new Date(), 'yyyymmdd-HHMMss')}.txt`
@@ -270,6 +273,10 @@ export class MonitorViewContribution
           extensions: ['txt', 'log'],
         },
         {
+          name: nls.localize('arduino/serial/csvFiles', 'CSV Files'),
+          extensions: ['csv'],
+        },
+        {
           name: nls.localize('arduino/serial/allFiles', 'All Files'),
           extensions: ['*'],
         },
@@ -278,6 +285,7 @@ export class MonitorViewContribution
     if (canceled || !filePath) {
       return;
     }
+    const text = filePath.toLowerCase().endsWith('.csv') ? csvText : plainText;
     const destinationUri = await this.fileSystemExt.getUri(filePath);
     if (!destinationUri) {
       return;

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
@@ -120,6 +120,14 @@ export class MonitorWidget extends ReactWidget {
     return this.outputRef.current?.getPlainText() ?? '';
   }
 
+  /**
+   * The current output as CSV rows, one row per line, with a leading
+   * timestamp column when timestamps are enabled.
+   */
+  outputCsvText(): string {
+    return this.outputRef.current?.getCsvText() ?? '';
+  }
+
   override dispose(): void {
     this.toDisposeOnReset.dispose();
     super.dispose();

--- a/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/monitor-widget.tsx
@@ -49,6 +49,7 @@ export class MonitorWidget extends ReactWidget {
   protected closing = false;
   protected readonly clearOutputEmitter = new Emitter<void>();
   protected readonly copyOutputEmitter = new Emitter<void>();
+  protected readonly outputRef = React.createRef<SerialMonitorOutput>();
 
   @inject(MonitorModel)
   private readonly monitorModel: MonitorModel;
@@ -109,6 +110,14 @@ export class MonitorWidget extends ReactWidget {
   
   copyOutput(): void {
     this.copyOutputEmitter.fire();
+  }
+
+  /**
+   * The current output as plain text, in the same form as the
+   * `Copy Output` toolbar action puts it on the clipboard.
+   */
+  outputText(): string {
+    return this.outputRef.current?.getPlainText() ?? '';
   }
 
   override dispose(): void {
@@ -252,6 +261,7 @@ export class MonitorWidget extends ReactWidget {
         </div>
         <div className="body">
           <SerialMonitorOutput
+            ref={this.outputRef}
             monitorModel={this.monitorModel}
             monitorManagerProxy={this.monitorManagerProxy}
             clearConsoleEvent={this.clearOutputEmitter.event}

--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -7,6 +7,8 @@ import {
   messagesToLines,
   truncateLines,
   linesToPlainText,
+  linesToCsvText,
+  LINE_TIMESTAMP_FORMAT,
 } from './monitor-utils';
 import { MonitorManagerProxyClient } from '../../../common/protocol';
 import { MonitorModel } from '../../monitor-model';
@@ -40,6 +42,14 @@ export class SerialMonitorOutput extends React.Component<
    */
   getPlainText(): string {
     return linesToPlainText(this.state.lines);
+  }
+
+  /**
+   * The current output as CSV rows, one row per line, with a leading
+   * timestamp column when timestamps are enabled.
+   */
+  getCsvText(): string {
+    return linesToCsvText(this.state.lines, this.state.timestamp);
   }
 
   override render(): React.ReactNode {
@@ -127,7 +137,10 @@ const _Row = ({
 }) => {
   const timestamp =
     (data.timestamp &&
-      `${dateFormat(data.lines[index].timestamp, 'HH:MM:ss.l')} -> `) ||
+      `${dateFormat(
+        data.lines[index].timestamp,
+        LINE_TIMESTAMP_FORMAT
+      )} -> `) ||
     '';
   return (
     (data.lines[index].lineLen && (

--- a/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
+++ b/arduino-ide-extension/src/browser/serial/monitor/serial-monitor-send-output.tsx
@@ -3,7 +3,11 @@ import { Event } from '@theia/core/lib/common/event';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { areEqual, FixedSizeList as List } from 'react-window';
 import dateFormat from 'dateformat';
-import { messagesToLines, truncateLines, joinLines } from './monitor-utils';
+import {
+  messagesToLines,
+  truncateLines,
+  linesToPlainText,
+} from './monitor-utils';
 import { MonitorManagerProxyClient } from '../../../common/protocol';
 import { MonitorModel } from '../../monitor-model';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
@@ -28,6 +32,14 @@ export class SerialMonitorOutput extends React.Component<
       timestamp: this.props.monitorModel.timestamp,
       charCount: 0,
     };
+  }
+
+  /**
+   * The current output as plain text, in the same form as the
+   * `Copy Output` toolbar action puts it on the clipboard.
+   */
+  getPlainText(): string {
+    return linesToPlainText(this.state.lines);
   }
 
   override render(): React.ReactNode {
@@ -75,12 +87,11 @@ export class SerialMonitorOutput extends React.Component<
       this.props.clearConsoleEvent(() =>
         this.setState({ lines: [], charCount: 0 })
       ),
-      this.props.copyOutputEvent(() => {
-        const text = joinLines(this.state.lines);
-        // Replace null characters with a visible symbol
-        const safe = text.replace(/\u0000/g, '\u25A1');
-        this.props.clipboardService.writeText(safe);
-      }),
+      this.props.copyOutputEvent(() =>
+        this.props.clipboardService.writeText(
+          linesToPlainText(this.state.lines)
+        )
+      ),
       this.props.monitorModel.onChange(({ property }) => {
         if (property === 'timestamp') {
           const { timestamp } = this.props.monitorModel;

--- a/arduino-ide-extension/src/test/browser/monitor-utils.test.ts
+++ b/arduino-ide-extension/src/test/browser/monitor-utils.test.ts
@@ -1,9 +1,11 @@
 import { expect } from 'chai';
+import dateFormat from 'dateformat';
 import {
   messagesToLines,
   truncateLines,
   joinLines,
   linesToPlainText,
+  linesToCsvText,
 } from '../../browser/serial/monitor/monitor-utils';
 import { Line } from '../../browser/serial/monitor/serial-monitor-send-output';
 import { set, reset } from 'mockdate';
@@ -195,6 +197,44 @@ describe('Monitor Utils', () => {
         { message: '\u0000llo!', lineLen: 5 },
       ];
       expect(linesToPlainText(lines)).to.equal('He\u25A1llo!');
+    });
+  });
+
+  context('when converting lines to CSV', () => {
+    it('should write one row per line and keep the raw message', () => {
+      const lines: Line[] = [
+        { message: '1,2,3\n', lineLen: 6 },
+        { message: '4,5,6', lineLen: 5 },
+        { message: '', lineLen: 0 },
+      ];
+      expect(linesToCsvText(lines, false)).to.equal('1,2,3\n4,5,6\n');
+    });
+
+    it('should prepend a timestamp column when timestamps are enabled', () => {
+      const lines: Line[] = [
+        { message: 'a;b\r\n', lineLen: 5, timestamp: date },
+        { message: 'c;\u0000d', lineLen: 4, timestamp: date },
+      ];
+      const timestamp = dateFormat(date, 'HH:MM:ss.l');
+      expect(linesToCsvText(lines, true)).to.equal(
+        `${timestamp},a;b\n${timestamp},c;\u25A1d\n`
+      );
+    });
+
+    it('should keep blank lines and handle lines without a timestamp', () => {
+      const lines: Line[] = [
+        { message: 'a\n', lineLen: 2, timestamp: date },
+        { message: '\n', lineLen: 1, timestamp: date },
+        { message: 'b', lineLen: 1 },
+      ];
+      const timestamp = dateFormat(date, 'HH:MM:ss.l');
+      expect(linesToCsvText(lines, true)).to.equal(
+        `${timestamp},a\n${timestamp},\n,b\n`
+      );
+    });
+
+    it('should return an empty string for empty output', () => {
+      expect(linesToCsvText([], true)).to.equal('');
     });
   });
 });

--- a/arduino-ide-extension/src/test/browser/monitor-utils.test.ts
+++ b/arduino-ide-extension/src/test/browser/monitor-utils.test.ts
@@ -3,6 +3,7 @@ import {
   messagesToLines,
   truncateLines,
   joinLines,
+  linesToPlainText,
 } from '../../browser/serial/monitor/monitor-utils';
 import { Line } from '../../browser/serial/monitor/serial-monitor-send-output';
 import { set, reset } from 'mockdate';
@@ -176,6 +177,24 @@ describe('Monitor Utils', () => {
           expect(joined_str).to.equal(testLine.expectedJoined);
         }
       });
+    });
+  });
+
+  context('when converting lines to plain text', () => {
+    it('should join the lines', () => {
+      const lines: Line[] = [
+        { message: 'Hello\n', lineLen: 6 },
+        { message: 'Dog!', lineLen: 4 },
+      ];
+      expect(linesToPlainText(lines)).to.equal('Hello\nDog!');
+    });
+
+    it('should replace null characters with a visible symbol', () => {
+      const lines: Line[] = [
+        { message: 'He', lineLen: 2 },
+        { message: '\u0000llo!', lineLen: 5 },
+      ];
+      expect(linesToPlainText(lines)).to.equal('He\u25A1llo!');
     });
   });
 });

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -430,6 +430,7 @@
     "replaceMsg": "Replace the existing version of {0}?",
     "selectZip": "Select a zip file containing the library you'd like to add",
     "serial": {
+      "allFiles": "All Files",
       "autoscroll": "Autoscroll",
       "carriageReturn": "Carriage Return",
       "connecting": "Connecting to '{0}' on '{1}'...",
@@ -440,6 +441,10 @@
       "noLineEndings": "No Line Ending",
       "notConnected": "Not connected. Select a board and a port to connect automatically.",
       "openSerialPlotter": "Serial Plotter",
+      "saveOutput": "Save Output",
+      "saveOutputAs": "Save Serial Monitor output as...",
+      "savedOutput": "Saved Serial Monitor output to '{0}'.",
+      "textFiles": "Text Files",
       "timestamp": "Timestamp",
       "toggleTimestamp": "Toggle Timestamp"
     },

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -435,6 +435,7 @@
       "carriageReturn": "Carriage Return",
       "connecting": "Connecting to '{0}' on '{1}'...",
       "copyOutput": "Copy Output",
+      "csvFiles": "CSV Files",
       "message": "Message (Enter to send message to '{0}' on '{1}')",
       "newLine": "New Line",
       "newLineCarriageReturn": "Both NL & CR",


### PR DESCRIPTION
### Motivation

Serial Monitor output is very often delimiter-separated measurement data that users want to
analyze in a spreadsheet (see the discussion in #2093). This is the standard workflow in physics
classes, where Arduinos serve as low-cost measurement instruments: record a series, then analyze
it in a spreadsheet. With the save action in place, a CSV export option supports this workflow
directly. It can also include the timestamps that the monitor already displays, which are
otherwise lost.

### Change description

- The `Save Output` dialog offers a `CSV Files (.csv)` filter next to `Text Files` and
  `All Files`.
- When the chosen file name ends in `.csv`, the output is written as CSV rows instead of the raw
  buffer:
  - one row per buffered line (trailing line breaks stripped, empty placeholder lines skipped,
    same null-character sanitizing as `Copy Output`),
  - when timestamps are enabled in the monitor, each row is prefixed with a `HH:MM:ss.l`
    timestamp column, matching what the monitor displays,
  - the message itself is written as-is, without RFC 4180 quoting: sketch output is typically
    already delimiter-separated data, and quoting would collapse the payload into a single
    spreadsheet column.
- Any other file name keeps the plain-text behavior.

### Other information

- Builds on the save action from #2937, so this PR currently contains both commits. Only the
  last commit is new; the branch will be rebased once #2937 is merged.
- New helper `linesToCsvText` in `monitor-utils.ts` with unit tests (rows, timestamp column, null
  characters, blank lines, empty buffer).
- The CSV mode follows the chosen file extension. On Linux the file dialog does not always append
  the extension of the selected filter, so the file name needs to end in `.csv` there.

Refs #549, #2093
